### PR TITLE
feat: bootstrap initial Convex backend

### DIFF
--- a/.github/workflows/baseline-checks.yml
+++ b/.github/workflows/baseline-checks.yml
@@ -63,6 +63,7 @@ jobs:
   typecheck-backend:
     name: Typecheck Backend
     runs-on: ubuntu-latest
+    timeout-minutes: 10
 
     steps:
       - name: Checkout

--- a/.github/workflows/baseline-checks.yml
+++ b/.github/workflows/baseline-checks.yml
@@ -60,6 +60,29 @@ jobs:
       - name: Run typecheck
         run: pnpm typecheck:web
 
+  typecheck-backend:
+    name: Typecheck Backend
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: pnpm
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Run backend typecheck
+        run: pnpm typecheck:backend
+
   verify-backend-local:
     name: Verify Backend Local
     runs-on: ubuntu-latest
@@ -84,9 +107,12 @@ jobs:
       - name: Verify backend bootstrap
         run: pnpm verify:backend:local
 
+      - name: Check generated backend files
+        run: git diff --exit-code -- convex/_generated
+
   build-web:
     name: Build Web
-    needs: [lint-web, typecheck-web]
+    needs: [lint-web, typecheck-web, typecheck-backend, verify-backend-local]
     runs-on: ubuntu-latest
 
     steps:

--- a/.github/workflows/baseline-checks.yml
+++ b/.github/workflows/baseline-checks.yml
@@ -17,6 +17,7 @@ jobs:
   lint-web:
     name: Lint Web
     runs-on: ubuntu-latest
+    timeout-minutes: 10
 
     steps:
       - name: Checkout
@@ -40,6 +41,7 @@ jobs:
   typecheck-web:
     name: Typecheck Web
     runs-on: ubuntu-latest
+    timeout-minutes: 10
 
     steps:
       - name: Checkout

--- a/.github/workflows/baseline-checks.yml
+++ b/.github/workflows/baseline-checks.yml
@@ -63,6 +63,7 @@ jobs:
   verify-backend-local:
     name: Verify Backend Local
     runs-on: ubuntu-latest
+    timeout-minutes: 10
 
     steps:
       - name: Checkout

--- a/.github/workflows/baseline-checks.yml
+++ b/.github/workflows/baseline-checks.yml
@@ -60,6 +60,29 @@ jobs:
       - name: Run typecheck
         run: pnpm typecheck:web
 
+  verify-backend-local:
+    name: Verify Backend Local
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: pnpm
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Verify backend bootstrap
+        run: pnpm verify:backend:local
+
   build-web:
     name: Build Web
     needs: [lint-web, typecheck-web]

--- a/.github/workflows/baseline-checks.yml
+++ b/.github/workflows/baseline-checks.yml
@@ -115,6 +115,7 @@ jobs:
     name: Build Web
     needs: [lint-web, typecheck-web, typecheck-backend, verify-backend-local]
     runs-on: ubuntu-latest
+    timeout-minutes: 15
 
     steps:
       - name: Checkout

--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,7 @@ AGENTS.local.md
 .opencode/state/
 node_modules/
 .husky/_/
+.convex-home/
+.convex-tmp/
+.env
+.env.local

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@
 - install git hooks after dependency changes if needed: `pnpm prepare`
 - bootstrap an anonymous local Convex deployment and run the backend health query: `pnpm bootstrap:backend:local`
 - keep the local Convex backend watcher running: `pnpm dev:backend:local`
-- run the Convex health query against the local backend: `pnpm run:backend:health:local`
+- run the one-shot local Convex health check alias: `pnpm run:backend:health:local`
 - typecheck Convex backend files: `pnpm typecheck:backend`
 - re-run the local backend verification pass: `pnpm verify:backend:local`
 - confirm committed Convex codegen is current: `pnpm check:backend:generated`

--- a/README.md
+++ b/README.md
@@ -7,20 +7,28 @@
 - `AGENTS.md` - repo-wide agent rules and durable workflow defaults
 - `AGENTS.local.md.example` - local operator preference template for `AGENTS.local.md`
 - `apps/web` - initial `Next.js` web application scaffold
+- `convex` - initial Convex backend functions, schema, and generated API types
 - `docs/README.md` - docs entry point
 - `docs/planning/` - product, architecture, roadmap, backlog, and issue-planning docs
 - `docs/agentic/` - software-factory, onboarding, and agent workflow docs
+- `docs/backend/` - backend setup notes and implementation-facing docs
 - `.opencode/skills/` - repo-local skills, including onboarding
 
-## Local app bootstrap
+## Local bootstrap
 
 - install workspace dependencies: `pnpm install`
 - install git hooks after dependency changes if needed: `pnpm prepare`
+- bootstrap an anonymous local Convex deployment and run the backend health query: `pnpm bootstrap:backend:local`
+- keep the local Convex backend watcher running: `pnpm dev:backend:local`
+- run the Convex health query against the local backend: `pnpm run:backend:health:local`
+- re-run the local backend verification pass: `pnpm verify:backend:local`
 - run the web app: `pnpm dev:web`
 - lint the web app: `pnpm lint:web`
 - typecheck the web app: `pnpm typecheck:web`
 - build the web app: `pnpm build:web`
-- run the baseline local verification pass: `pnpm verify:web`
+- run the baseline local verification pass: `pnpm verify`
+
+Convex writes repo-root deployment configuration to `.env.local` during local setup and keeps anonymous local state under `.convex-home/` plus `.convex-tmp/`. Keep all of those uncommitted.
 
 ## Start here
 
@@ -39,6 +47,7 @@ Important planning note:
 Currently locked stack direction:
 
 - `Next.js`
+- `TypeScript`
 - `Convex`
 - `AWS`
 - `Stripe`

--- a/README.md
+++ b/README.md
@@ -21,14 +21,16 @@
 - bootstrap an anonymous local Convex deployment and run the backend health query: `pnpm bootstrap:backend:local`
 - keep the local Convex backend watcher running: `pnpm dev:backend:local`
 - run the Convex health query against the local backend: `pnpm run:backend:health:local`
+- typecheck Convex backend files: `pnpm typecheck:backend`
 - re-run the local backend verification pass: `pnpm verify:backend:local`
+- confirm committed Convex codegen is current: `pnpm check:backend:generated`
 - run the web app: `pnpm dev:web`
 - lint the web app: `pnpm lint:web`
 - typecheck the web app: `pnpm typecheck:web`
 - build the web app: `pnpm build:web`
 - run the baseline local verification pass: `pnpm verify`
 
-Convex writes repo-root deployment configuration to `.env.local` during local setup and keeps anonymous local state under `.convex-home/` plus `.convex-tmp/`. Keep all of those uncommitted.
+Convex writes repo-root deployment configuration to `.env.local` during local setup and keeps anonymous local state under `.convex-home/` plus `.convex-tmp/`. Keep all of those uncommitted. The committed `convex/_generated/` files are expected to stay clean after `pnpm check:backend:generated`.
 
 ## Start here
 

--- a/README.md
+++ b/README.md
@@ -32,6 +32,8 @@
 
 Convex writes repo-root deployment configuration to `.env.local` during local setup and keeps anonymous local state under `.convex-home/` plus `.convex-tmp/`. Keep all of those uncommitted. The committed `convex/_generated/` files are expected to stay clean after `pnpm check:backend:generated`.
 
+`pnpm verify` is the full repo verification pass and now includes the local Convex bootstrap checks. If you are iterating on the web app only, use `pnpm verify:web` for the lighter web-only path.
+
 ## Start here
 
 - product/planning context: `docs/planning/README.md`

--- a/apps/web/src/app/page.tsx
+++ b/apps/web/src/app/page.tsx
@@ -7,7 +7,7 @@ export default function Home() {
             <div className="flex flex-col gap-8">
               <div className="flex items-center gap-3 text-sm uppercase tracking-[0.28em] text-muted">
                 <span className="rounded-full border border-border px-3 py-1">VRDex</span>
-                <span>Initial web scaffold</span>
+                <span>Web + backend bootstrap</span>
               </div>
 
               <div className="max-w-3xl space-y-5">
@@ -65,7 +65,7 @@ export default function Home() {
                 </div>
                 <div className="flex items-start justify-between gap-4">
                   <dt className="text-muted">Next issues</dt>
-                  <dd className="text-right font-medium">#54, #55, #56, #59</dd>
+                  <dd className="text-right font-medium">#55, #56, #59</dd>
                 </div>
               </dl>
             </aside>
@@ -92,11 +92,13 @@ export default function Home() {
               Deliberately deferred
             </p>
             <h2 className="mt-4 text-2xl font-semibold tracking-[-0.03em]">
-              Backend and auth wiring
+              App integration and auth wiring
             </h2>
             <p className="mt-3 text-sm leading-7 text-muted">
-              Convex, identity providers, billing, and deployment posture stay in
-              their own issues so this bootstrap remains easy to reason about.
+              Convex now has a real backend foothold under{" "}
+              <code className="font-mono text-[0.95em]">convex/</code>, while app
+              integration, identity providers, billing, and deployment posture
+              stay in their own follow-on issues.
             </p>
           </article>
 

--- a/convex.json
+++ b/convex.json
@@ -1,0 +1,6 @@
+{
+  "$schema": "./node_modules/convex/schemas/convex.schema.json",
+  "node": {
+    "nodeVersion": "22"
+  }
+}

--- a/convex/README.md
+++ b/convex/README.md
@@ -12,5 +12,7 @@ Use the repo-root scripts for local work:
 - `pnpm bootstrap:backend:local`
 - `pnpm dev:backend:local`
 - `pnpm run:backend:health:local`
+- `pnpm typecheck:backend`
+- `pnpm check:backend:generated`
 
 The canonical workflow notes live in `docs/backend/convex-bootstrap.md`.

--- a/convex/README.md
+++ b/convex/README.md
@@ -1,0 +1,16 @@
+# Convex Backend
+
+This directory holds the initial Convex backend slice for `VRDex`.
+
+- `health.ts` exposes the placeholder public query `health:status`
+- `schema.ts` keeps the starting schema explicit and intentionally empty
+- `_generated/` contains committed Convex codegen output and should not be edited by hand
+- `tsconfig.json` is the Convex-managed TypeScript config for backend functions
+
+Use the repo-root scripts for local work:
+
+- `pnpm bootstrap:backend:local`
+- `pnpm dev:backend:local`
+- `pnpm run:backend:health:local`
+
+The canonical workflow notes live in `docs/backend/convex-bootstrap.md`.

--- a/convex/_generated/api.d.ts
+++ b/convex/_generated/api.d.ts
@@ -1,0 +1,49 @@
+/* eslint-disable */
+/**
+ * Generated `api` utility.
+ *
+ * THIS CODE IS AUTOMATICALLY GENERATED.
+ *
+ * To regenerate, run `npx convex dev`.
+ * @module
+ */
+
+import type * as health from "../health.js";
+
+import type {
+  ApiFromModules,
+  FilterApi,
+  FunctionReference,
+} from "convex/server";
+
+declare const fullApi: ApiFromModules<{
+  health: typeof health;
+}>;
+
+/**
+ * A utility for referencing Convex functions in your app's public API.
+ *
+ * Usage:
+ * ```js
+ * const myFunctionReference = api.myModule.myFunction;
+ * ```
+ */
+export declare const api: FilterApi<
+  typeof fullApi,
+  FunctionReference<any, "public">
+>;
+
+/**
+ * A utility for referencing Convex functions in your app's internal API.
+ *
+ * Usage:
+ * ```js
+ * const myFunctionReference = internal.myModule.myFunction;
+ * ```
+ */
+export declare const internal: FilterApi<
+  typeof fullApi,
+  FunctionReference<any, "internal">
+>;
+
+export declare const components: {};

--- a/convex/_generated/api.js
+++ b/convex/_generated/api.js
@@ -1,0 +1,23 @@
+/* eslint-disable */
+/**
+ * Generated `api` utility.
+ *
+ * THIS CODE IS AUTOMATICALLY GENERATED.
+ *
+ * To regenerate, run `npx convex dev`.
+ * @module
+ */
+
+import { anyApi, componentsGeneric } from "convex/server";
+
+/**
+ * A utility for referencing Convex functions in your app's API.
+ *
+ * Usage:
+ * ```js
+ * const myFunctionReference = api.myModule.myFunction;
+ * ```
+ */
+export const api = anyApi;
+export const internal = anyApi;
+export const components = componentsGeneric();

--- a/convex/_generated/dataModel.d.ts
+++ b/convex/_generated/dataModel.d.ts
@@ -1,0 +1,60 @@
+/* eslint-disable */
+/**
+ * Generated data model types.
+ *
+ * THIS CODE IS AUTOMATICALLY GENERATED.
+ *
+ * To regenerate, run `npx convex dev`.
+ * @module
+ */
+
+import type {
+  DataModelFromSchemaDefinition,
+  DocumentByName,
+  TableNamesInDataModel,
+  SystemTableNames,
+} from "convex/server";
+import type { GenericId } from "convex/values";
+import schema from "../schema.js";
+
+/**
+ * The names of all of your Convex tables.
+ */
+export type TableNames = TableNamesInDataModel<DataModel>;
+
+/**
+ * The type of a document stored in Convex.
+ *
+ * @typeParam TableName - A string literal type of the table name (like "users").
+ */
+export type Doc<TableName extends TableNames> = DocumentByName<
+  DataModel,
+  TableName
+>;
+
+/**
+ * An identifier for a document in Convex.
+ *
+ * Convex documents are uniquely identified by their `Id`, which is accessible
+ * on the `_id` field. To learn more, see [Document IDs](https://docs.convex.dev/using/document-ids).
+ *
+ * Documents can be loaded using `db.get(tableName, id)` in query and mutation functions.
+ *
+ * IDs are just strings at runtime, but this type can be used to distinguish them from other
+ * strings when type checking.
+ *
+ * @typeParam TableName - A string literal type of the table name (like "users").
+ */
+export type Id<TableName extends TableNames | SystemTableNames> =
+  GenericId<TableName>;
+
+/**
+ * A type describing your Convex data model.
+ *
+ * This type includes information about what tables you have, the type of
+ * documents stored in those tables, and the indexes defined on them.
+ *
+ * This type is used to parameterize methods like `queryGeneric` and
+ * `mutationGeneric` to make them type-safe.
+ */
+export type DataModel = DataModelFromSchemaDefinition<typeof schema>;

--- a/convex/_generated/server.d.ts
+++ b/convex/_generated/server.d.ts
@@ -1,0 +1,143 @@
+/* eslint-disable */
+/**
+ * Generated utilities for implementing server-side Convex query and mutation functions.
+ *
+ * THIS CODE IS AUTOMATICALLY GENERATED.
+ *
+ * To regenerate, run `npx convex dev`.
+ * @module
+ */
+
+import {
+  ActionBuilder,
+  HttpActionBuilder,
+  MutationBuilder,
+  QueryBuilder,
+  GenericActionCtx,
+  GenericMutationCtx,
+  GenericQueryCtx,
+  GenericDatabaseReader,
+  GenericDatabaseWriter,
+} from "convex/server";
+import type { DataModel } from "./dataModel.js";
+
+/**
+ * Define a query in this Convex app's public API.
+ *
+ * This function will be allowed to read your Convex database and will be accessible from the client.
+ *
+ * @param func - The query function. It receives a {@link QueryCtx} as its first argument.
+ * @returns The wrapped query. Include this as an `export` to name it and make it accessible.
+ */
+export declare const query: QueryBuilder<DataModel, "public">;
+
+/**
+ * Define a query that is only accessible from other Convex functions (but not from the client).
+ *
+ * This function will be allowed to read from your Convex database. It will not be accessible from the client.
+ *
+ * @param func - The query function. It receives a {@link QueryCtx} as its first argument.
+ * @returns The wrapped query. Include this as an `export` to name it and make it accessible.
+ */
+export declare const internalQuery: QueryBuilder<DataModel, "internal">;
+
+/**
+ * Define a mutation in this Convex app's public API.
+ *
+ * This function will be allowed to modify your Convex database and will be accessible from the client.
+ *
+ * @param func - The mutation function. It receives a {@link MutationCtx} as its first argument.
+ * @returns The wrapped mutation. Include this as an `export` to name it and make it accessible.
+ */
+export declare const mutation: MutationBuilder<DataModel, "public">;
+
+/**
+ * Define a mutation that is only accessible from other Convex functions (but not from the client).
+ *
+ * This function will be allowed to modify your Convex database. It will not be accessible from the client.
+ *
+ * @param func - The mutation function. It receives a {@link MutationCtx} as its first argument.
+ * @returns The wrapped mutation. Include this as an `export` to name it and make it accessible.
+ */
+export declare const internalMutation: MutationBuilder<DataModel, "internal">;
+
+/**
+ * Define an action in this Convex app's public API.
+ *
+ * An action is a function which can execute any JavaScript code, including non-deterministic
+ * code and code with side-effects, like calling third-party services.
+ * They can be run in Convex's JavaScript environment or in Node.js using the "use node" directive.
+ * They can interact with the database indirectly by calling queries and mutations using the {@link ActionCtx}.
+ *
+ * @param func - The action. It receives an {@link ActionCtx} as its first argument.
+ * @returns The wrapped action. Include this as an `export` to name it and make it accessible.
+ */
+export declare const action: ActionBuilder<DataModel, "public">;
+
+/**
+ * Define an action that is only accessible from other Convex functions (but not from the client).
+ *
+ * @param func - The function. It receives an {@link ActionCtx} as its first argument.
+ * @returns The wrapped function. Include this as an `export` to name it and make it accessible.
+ */
+export declare const internalAction: ActionBuilder<DataModel, "internal">;
+
+/**
+ * Define an HTTP action.
+ *
+ * The wrapped function will be used to respond to HTTP requests received
+ * by a Convex deployment if the requests matches the path and method where
+ * this action is routed. Be sure to route your httpAction in `convex/http.js`.
+ *
+ * @param func - The function. It receives an {@link ActionCtx} as its first argument
+ * and a Fetch API `Request` object as its second.
+ * @returns The wrapped function. Import this function from `convex/http.js` and route it to hook it up.
+ */
+export declare const httpAction: HttpActionBuilder;
+
+/**
+ * A set of services for use within Convex query functions.
+ *
+ * The query context is passed as the first argument to any Convex query
+ * function run on the server.
+ *
+ * This differs from the {@link MutationCtx} because all of the services are
+ * read-only.
+ */
+export type QueryCtx = GenericQueryCtx<DataModel>;
+
+/**
+ * A set of services for use within Convex mutation functions.
+ *
+ * The mutation context is passed as the first argument to any Convex mutation
+ * function run on the server.
+ */
+export type MutationCtx = GenericMutationCtx<DataModel>;
+
+/**
+ * A set of services for use within Convex action functions.
+ *
+ * The action context is passed as the first argument to any Convex action
+ * function run on the server.
+ */
+export type ActionCtx = GenericActionCtx<DataModel>;
+
+/**
+ * An interface to read from the database within Convex query functions.
+ *
+ * The two entry points are {@link DatabaseReader.get}, which fetches a single
+ * document by its {@link Id}, or {@link DatabaseReader.query}, which starts
+ * building a query.
+ */
+export type DatabaseReader = GenericDatabaseReader<DataModel>;
+
+/**
+ * An interface to read from and write to the database within Convex mutation
+ * functions.
+ *
+ * Convex guarantees that all writes within a single mutation are
+ * executed atomically, so you never have to worry about partial writes leaving
+ * your data in an inconsistent state. See [the Convex Guide](https://docs.convex.dev/understanding/convex-fundamentals/functions#atomicity-and-optimistic-concurrency-control)
+ * for the guarantees Convex provides your functions.
+ */
+export type DatabaseWriter = GenericDatabaseWriter<DataModel>;

--- a/convex/_generated/server.js
+++ b/convex/_generated/server.js
@@ -1,0 +1,93 @@
+/* eslint-disable */
+/**
+ * Generated utilities for implementing server-side Convex query and mutation functions.
+ *
+ * THIS CODE IS AUTOMATICALLY GENERATED.
+ *
+ * To regenerate, run `npx convex dev`.
+ * @module
+ */
+
+import {
+  actionGeneric,
+  httpActionGeneric,
+  queryGeneric,
+  mutationGeneric,
+  internalActionGeneric,
+  internalMutationGeneric,
+  internalQueryGeneric,
+} from "convex/server";
+
+/**
+ * Define a query in this Convex app's public API.
+ *
+ * This function will be allowed to read your Convex database and will be accessible from the client.
+ *
+ * @param func - The query function. It receives a {@link QueryCtx} as its first argument.
+ * @returns The wrapped query. Include this as an `export` to name it and make it accessible.
+ */
+export const query = queryGeneric;
+
+/**
+ * Define a query that is only accessible from other Convex functions (but not from the client).
+ *
+ * This function will be allowed to read from your Convex database. It will not be accessible from the client.
+ *
+ * @param func - The query function. It receives a {@link QueryCtx} as its first argument.
+ * @returns The wrapped query. Include this as an `export` to name it and make it accessible.
+ */
+export const internalQuery = internalQueryGeneric;
+
+/**
+ * Define a mutation in this Convex app's public API.
+ *
+ * This function will be allowed to modify your Convex database and will be accessible from the client.
+ *
+ * @param func - The mutation function. It receives a {@link MutationCtx} as its first argument.
+ * @returns The wrapped mutation. Include this as an `export` to name it and make it accessible.
+ */
+export const mutation = mutationGeneric;
+
+/**
+ * Define a mutation that is only accessible from other Convex functions (but not from the client).
+ *
+ * This function will be allowed to modify your Convex database. It will not be accessible from the client.
+ *
+ * @param func - The mutation function. It receives a {@link MutationCtx} as its first argument.
+ * @returns The wrapped mutation. Include this as an `export` to name it and make it accessible.
+ */
+export const internalMutation = internalMutationGeneric;
+
+/**
+ * Define an action in this Convex app's public API.
+ *
+ * An action is a function which can execute any JavaScript code, including non-deterministic
+ * code and code with side-effects, like calling third-party services.
+ * They can be run in Convex's JavaScript environment or in Node.js using the "use node" directive.
+ * They can interact with the database indirectly by calling queries and mutations using the {@link ActionCtx}.
+ *
+ * @param func - The action. It receives an {@link ActionCtx} as its first argument.
+ * @returns The wrapped action. Include this as an `export` to name it and make it accessible.
+ */
+export const action = actionGeneric;
+
+/**
+ * Define an action that is only accessible from other Convex functions (but not from the client).
+ *
+ * @param func - The function. It receives an {@link ActionCtx} as its first argument.
+ * @returns The wrapped function. Include this as an `export` to name it and make it accessible.
+ */
+export const internalAction = internalActionGeneric;
+
+/**
+ * Define an HTTP action.
+ *
+ * The wrapped function will be used to respond to HTTP requests received
+ * by a Convex deployment if the requests matches the path and method where
+ * this action is routed. Be sure to route your httpAction in `convex/http.js`.
+ *
+ * @param func - The function. It receives an {@link ActionCtx} as its first argument
+ * and a Fetch API `Request` object as its second.
+ * @returns The wrapped function. Import this function from `convex/http.js` and route it to hook it up.
+ */
+export const httpAction = httpActionGeneric;

--- a/convex/health.ts
+++ b/convex/health.ts
@@ -1,0 +1,14 @@
+import { query } from "./_generated/server";
+
+export const status = query({
+  args: {},
+  handler: async () => {
+    return {
+      backend: "convex",
+      note: "Initial Convex backend bootstrap is active.",
+      project: "vrdex",
+      scope: "bootstrap",
+      status: "ok",
+    };
+  },
+});

--- a/convex/health.ts
+++ b/convex/health.ts
@@ -2,7 +2,7 @@ import { query } from "./_generated/server";
 
 export const status = query({
   args: {},
-  handler: async () => {
+  handler: () => {
     return {
       backend: "convex",
       note: "Initial Convex backend bootstrap is active.",

--- a/convex/schema.ts
+++ b/convex/schema.ts
@@ -1,0 +1,3 @@
+import { defineSchema } from "convex/server";
+
+export default defineSchema({});

--- a/convex/tsconfig.json
+++ b/convex/tsconfig.json
@@ -1,0 +1,25 @@
+{
+  /* This TypeScript project config describes the environment that
+   * Convex functions run in and is used to typecheck them.
+   * You can modify it, but some settings are required to use Convex.
+   */
+  "compilerOptions": {
+    /* These settings are not required by Convex and can be modified. */
+    "allowJs": true,
+    "strict": true,
+    "moduleResolution": "Bundler",
+    "jsx": "react-jsx",
+    "skipLibCheck": true,
+    "allowSyntheticDefaultImports": true,
+
+    /* These compiler options are required by Convex */
+    "target": "ESNext",
+    "lib": ["ES2021", "dom"],
+    "forceConsistentCasingInFileNames": true,
+    "module": "ESNext",
+    "isolatedModules": true,
+    "noEmit": true
+  },
+  "include": ["./**/*"],
+  "exclude": ["./_generated"]
+}

--- a/convex/tsconfig.json
+++ b/convex/tsconfig.json
@@ -8,7 +8,6 @@
     "allowJs": true,
     "strict": true,
     "moduleResolution": "Bundler",
-    "jsx": "react-jsx",
     "skipLibCheck": true,
     "allowSyntheticDefaultImports": true,
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -6,6 +6,7 @@ This repo keeps durable markdown under `docs/` so product, engineering, and agen
 
 - `docs/planning/README.md` - product, architecture, roadmap, backlog, and issue-planning docs
 - `docs/agentic/README.md` - software-factory, onboarding, control-loop, and agent workflow docs
+- `docs/backend/convex-bootstrap.md` - backend bootstrap workflow and structure notes
 
 Useful starting points:
 

--- a/docs/backend/convex-bootstrap.md
+++ b/docs/backend/convex-bootstrap.md
@@ -28,6 +28,8 @@ It is intentionally narrow: enough structure to run Convex locally, generate typ
 5. Run `pnpm typecheck:backend` before shipping backend edits.
 6. Run `pnpm check:backend:generated` before pushing schema or function changes that may affect `convex/_generated/`.
 
+If you want the full repo gate, use `pnpm verify`. If you only need the web app checks, keep using `pnpm verify:web`.
+
 Notes:
 
 - Convex writes deployment configuration to the repo-root `.env.local` file.

--- a/docs/backend/convex-bootstrap.md
+++ b/docs/backend/convex-bootstrap.md
@@ -24,7 +24,7 @@ It is intentionally narrow: enough structure to run Convex locally, generate typ
 1. Install dependencies with `pnpm install`.
 2. Bootstrap an anonymous local deployment and verify the health query with `pnpm bootstrap:backend:local`.
 3. Keep `pnpm dev:backend:local` running while editing backend files.
-4. Run `pnpm run:backend:health:local` from a second terminal when you want to manually confirm the placeholder query result.
+4. Run `pnpm run:backend:health:local` from a second terminal when you want the same one-shot placeholder health check without using the verify script name directly.
 5. Run `pnpm typecheck:backend` before shipping backend edits.
 6. Run `pnpm check:backend:generated` before pushing schema or function changes that may affect `convex/_generated/`.
 

--- a/docs/backend/convex-bootstrap.md
+++ b/docs/backend/convex-bootstrap.md
@@ -25,12 +25,15 @@ It is intentionally narrow: enough structure to run Convex locally, generate typ
 2. Bootstrap an anonymous local deployment and verify the health query with `pnpm bootstrap:backend:local`.
 3. Keep `pnpm dev:backend:local` running while editing backend files.
 4. Run `pnpm run:backend:health:local` from a second terminal when you want to manually confirm the placeholder query result.
+5. Run `pnpm typecheck:backend` before shipping backend edits.
+6. Run `pnpm check:backend:generated` before pushing schema or function changes that may affect `convex/_generated/`.
 
 Notes:
 
 - Convex writes deployment configuration to the repo-root `.env.local` file.
 - Anonymous local backend state for this repo is kept under `.convex-home/` and `.convex-tmp/` so the bootstrap does not collide with other Convex projects on the same machine.
 - The current bootstrap is local-development focused. Production deploy keys, preview deployments, and frontend environment wiring belong to follow-on issues.
+- Committed files in `convex/_generated/` are treated as checked-in build artifacts and should remain diff-free after `pnpm check:backend:generated`.
 
 ## Structure rule
 

--- a/docs/backend/convex-bootstrap.md
+++ b/docs/backend/convex-bootstrap.md
@@ -1,0 +1,46 @@
+# Convex Backend Bootstrap
+
+## Status note
+
+This doc captures the initial Convex backend slice landed for `#54`.
+
+It is intentionally narrow: enough structure to run Convex locally, generate typed backend helpers, and prove the backend is wired, without prematurely locking product tables or auth decisions.
+
+## Locked decision
+
+- the first backend surface lives in the repo-root `convex/` directory
+- the initial bootstrap should stay schema-light and friendly to anonymous local development
+- generated Convex types under `convex/_generated/` should be committed
+
+## Current implementation
+
+- `convex/schema.ts` defines an explicit empty schema so later table work starts from a typed baseline instead of ad hoc implicit tables
+- `convex/health.ts` exposes a minimal public query, `health:status`, that confirms the backend is reachable without hard-coding early product domain records
+- `convex.json` pins Convex to Node `22` so local backend runtime expectations stay aligned with the repo's current Node baseline
+- `convex/tsconfig.json` provides the TypeScript settings Convex uses to typecheck backend source files
+
+## Local workflow
+
+1. Install dependencies with `pnpm install`.
+2. Bootstrap an anonymous local deployment and verify the health query with `pnpm bootstrap:backend:local`.
+3. Keep `pnpm dev:backend:local` running while editing backend files.
+4. Run `pnpm run:backend:health:local` from a second terminal when you want to manually confirm the placeholder query result.
+
+Notes:
+
+- Convex writes deployment configuration to the repo-root `.env.local` file.
+- Anonymous local backend state for this repo is kept under `.convex-home/` and `.convex-tmp/` so the bootstrap does not collide with other Convex projects on the same machine.
+- The current bootstrap is local-development focused. Production deploy keys, preview deployments, and frontend environment wiring belong to follow-on issues.
+
+## Structure rule
+
+Keep the initial backend slice simple:
+
+- add new schema and functions under `convex/`
+- avoid introducing product tables until the relevant issue defines the domain slice
+- prefer small, typed functions over placeholder complexity
+
+## Follow-on issues
+
+- `#55` should wire the web app to the Convex client/runtime path
+- schema, auth, billing, and production deployment posture should land in their own issues instead of bloating the bootstrap

--- a/docs/planning/architecture.md
+++ b/docs/planning/architecture.md
@@ -56,12 +56,24 @@ Email infrastructure direction:
 
 ## Monorepo suggestion
 
+Current bootstrap shape:
+
 ```text
 vrdex/
   apps/
     web/
-    api/
+  convex/
+  docs/
+```
+
+Candidate expansion later:
+
+```text
+vrdex/
+  apps/
+    web/
     bot/
+  convex/
   packages/
     shared/
     config/

--- a/docs/planning/engineering-strategy.md
+++ b/docs/planning/engineering-strategy.md
@@ -45,6 +45,13 @@ Why this fits:
 - `meeting-notes-discord-bot` already shows strong Stripe, AWS, Playwright, and visual testing patterns
 - unified typing stays strong across app and backend logic
 
+Current recommendation:
+
+- bootstrap Convex in the repo-root `convex/` directory so backend functions stay easy to discover in a small monorepo
+- keep the first backend slice schema-light with an explicit health query instead of guessing at product tables too early
+- use local-development-friendly Convex setup first, then layer in frontend wiring, auth, billing, and production deployment posture through follow-on issues
+- once the local backend bootstrap is deterministic, include it in the baseline PR verification pass alongside the web checks
+
 ## Monetization direction
 
 VRDex should plan for billing early even if the first paid features are modest.

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "build:web": "pnpm --filter web build",
     "lint:web": "pnpm --filter web lint",
     "typecheck:backend": "tsc --noEmit --project convex/tsconfig.json",
-    "run:backend:health:local": "pnpm verify:backend:local",
+    "run:backend:health:local": "node scripts/run-convex-local.mjs dev --local --once --run health:status",
     "typecheck:web": "pnpm --filter web typecheck",
     "verify:backend:local": "node scripts/run-convex-local.mjs dev --local --once --run health:status --tail-logs disable",
     "check:backend:generated": "pnpm verify:backend:local && git diff --exit-code -- convex/_generated",

--- a/package.json
+++ b/package.json
@@ -8,11 +8,13 @@
     "dev:web": "pnpm --filter web dev",
     "build:web": "pnpm --filter web build",
     "lint:web": "pnpm --filter web lint",
+    "typecheck:backend": "tsc --noEmit --project convex/tsconfig.json",
     "run:backend:health:local": "node scripts/run-convex-local.mjs run health:status",
     "typecheck:web": "pnpm --filter web typecheck",
     "verify:backend:local": "node scripts/run-convex-local.mjs dev --once --run health:status --tail-logs disable",
+    "check:backend:generated": "pnpm verify:backend:local && git diff --exit-code -- convex/_generated",
     "verify:web": "pnpm lint:web && pnpm typecheck:web && pnpm build:web",
-    "verify": "pnpm verify:web && pnpm verify:backend:local",
+    "verify": "pnpm verify:web && pnpm typecheck:backend && pnpm check:backend:generated",
     "prepare": "husky"
   },
   "lint-staged": {

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "build:web": "pnpm --filter web build",
     "lint:web": "pnpm --filter web lint",
     "typecheck:backend": "tsc --noEmit --project convex/tsconfig.json",
-    "run:backend:health:local": "node scripts/run-convex-local.mjs dev --local --once --run health:status --tail-logs disable",
+    "run:backend:health:local": "pnpm verify:backend:local",
     "typecheck:web": "pnpm --filter web typecheck",
     "verify:backend:local": "node scripts/run-convex-local.mjs dev --local --once --run health:status --tail-logs disable",
     "check:backend:generated": "pnpm verify:backend:local && git diff --exit-code -- convex/_generated",

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "build:web": "pnpm --filter web build",
     "lint:web": "pnpm --filter web lint",
     "typecheck:backend": "tsc --noEmit --project convex/tsconfig.json",
-    "run:backend:health:local": "node scripts/run-convex-local.mjs dev --local --once --run health:status",
+    "run:backend:health:local": "node scripts/run-convex-local.mjs dev --local --once --run health:status --tail-logs disable",
     "typecheck:web": "pnpm --filter web typecheck",
     "verify:backend:local": "node scripts/run-convex-local.mjs dev --local --once --run health:status --tail-logs disable",
     "check:backend:generated": "pnpm verify:backend:local && git diff --exit-code -- convex/_generated",

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "private": true,
   "packageManager": "pnpm@10.15.1+sha512.34e538c329b5553014ca8e8f4535997f96180a1d0f614339357449935350d924e22f8614682191264ec33d1462ac21561aff97f6bb18065351c162c7e8f6de67",
   "scripts": {
-    "bootstrap:backend:local": "node scripts/run-convex-local.mjs dev --once --run health:status --tail-logs disable",
+    "bootstrap:backend:local": "pnpm verify:backend:local",
     "dev:backend:local": "node scripts/run-convex-local.mjs dev --local",
     "dev:web": "pnpm --filter web dev",
     "build:web": "pnpm --filter web build",

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "typecheck:backend": "tsc --noEmit --project convex/tsconfig.json",
     "run:backend:health:local": "node scripts/run-convex-local.mjs run health:status",
     "typecheck:web": "pnpm --filter web typecheck",
-    "verify:backend:local": "node scripts/run-convex-local.mjs dev --once --run health:status --tail-logs disable",
+    "verify:backend:local": "node scripts/run-convex-local.mjs dev --local --once --run health:status --tail-logs disable",
     "check:backend:generated": "pnpm verify:backend:local && git diff --exit-code -- convex/_generated",
     "verify:web": "pnpm lint:web && pnpm typecheck:web && pnpm build:web",
     "verify": "pnpm verify:web && pnpm typecheck:backend && pnpm check:backend:generated",

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "verify:backend:local": "node scripts/run-convex-local.mjs dev --local --once --run health:status --tail-logs disable",
     "check:backend:generated": "pnpm verify:backend:local && git diff --exit-code -- convex/_generated",
     "verify:web": "pnpm lint:web && pnpm typecheck:web && pnpm build:web",
-    "verify": "pnpm verify:web && pnpm typecheck:backend && pnpm check:backend:generated",
+    "verify": "pnpm verify:web && pnpm check:backend:generated && pnpm typecheck:backend",
     "prepare": "husky"
   },
   "lint-staged": {

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "build:web": "pnpm --filter web build",
     "lint:web": "pnpm --filter web lint",
     "typecheck:backend": "tsc --noEmit --project convex/tsconfig.json",
-    "run:backend:health:local": "node scripts/run-convex-local.mjs run health:status",
+    "run:backend:health:local": "pnpm verify:backend:local",
     "typecheck:web": "pnpm --filter web typecheck",
     "verify:backend:local": "node scripts/run-convex-local.mjs dev --local --once --run health:status --tail-logs disable",
     "check:backend:generated": "pnpm verify:backend:local && git diff --exit-code -- convex/_generated",

--- a/package.json
+++ b/package.json
@@ -3,19 +3,26 @@
   "private": true,
   "packageManager": "pnpm@10.15.1+sha512.34e538c329b5553014ca8e8f4535997f96180a1d0f614339357449935350d924e22f8614682191264ec33d1462ac21561aff97f6bb18065351c162c7e8f6de67",
   "scripts": {
+    "bootstrap:backend:local": "node scripts/run-convex-local.mjs dev --once --run health:status --tail-logs disable",
+    "dev:backend:local": "node scripts/run-convex-local.mjs dev --local",
     "dev:web": "pnpm --filter web dev",
     "build:web": "pnpm --filter web build",
     "lint:web": "pnpm --filter web lint",
+    "run:backend:health:local": "node scripts/run-convex-local.mjs run health:status",
     "typecheck:web": "pnpm --filter web typecheck",
+    "verify:backend:local": "node scripts/run-convex-local.mjs dev --once --run health:status --tail-logs disable",
     "verify:web": "pnpm lint:web && pnpm typecheck:web && pnpm build:web",
-    "verify": "pnpm verify:web",
+    "verify": "pnpm verify:web && pnpm verify:backend:local",
     "prepare": "husky"
   },
   "lint-staged": {
     "apps/web/**/*.{js,jsx,ts,tsx,mjs,cjs}": "pnpm --filter web exec eslint --fix --max-warnings=0"
   },
   "devDependencies": {
+    "@types/node": "^22.19.15",
+    "convex": "^1.32.0",
     "husky": "^9.1.7",
-    "lint-staged": "^16.3.3"
+    "lint-staged": "^16.3.3",
+    "typescript": "^5.9.3"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -8,12 +8,21 @@ importers:
 
   .:
     devDependencies:
+      '@types/node':
+        specifier: ^22.19.15
+        version: 22.19.15
+      convex:
+        specifier: ^1.32.0
+        version: 1.32.0(react@19.2.3)
       husky:
         specifier: ^9.1.7
         version: 9.1.7
       lint-staged:
         specifier: ^16.3.3
         version: 16.3.3
+      typescript:
+        specifier: ^5.9.3
+        version: 5.9.3
 
   apps/web:
     dependencies:
@@ -133,6 +142,162 @@ packages:
 
   '@emnapi/wasi-threads@1.1.0':
     resolution: {integrity: sha512-WI0DdZ8xFSbgMjR1sFsKABJ/C5OnRrjT06JXbZKexJGrDuPTzZdDYfFlsgcCXCyf+suG5QU2e/y1Wo2V/OapLQ==}
+
+  '@esbuild/aix-ppc64@0.27.0':
+    resolution: {integrity: sha512-KuZrd2hRjz01y5JK9mEBSD3Vj3mbCvemhT466rSuJYeE/hjuBrHfjjcjMdTm/sz7au+++sdbJZJmuBwQLuw68A==}
+    engines: {node: '>=18'}
+    cpu: [ppc64]
+    os: [aix]
+
+  '@esbuild/android-arm64@0.27.0':
+    resolution: {integrity: sha512-CC3vt4+1xZrs97/PKDkl0yN7w8edvU2vZvAFGD16n9F0Cvniy5qvzRXjfO1l94efczkkQE6g1x0i73Qf5uthOQ==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [android]
+
+  '@esbuild/android-arm@0.27.0':
+    resolution: {integrity: sha512-j67aezrPNYWJEOHUNLPj9maeJte7uSMM6gMoxfPC9hOg8N02JuQi/T7ewumf4tNvJadFkvLZMlAq73b9uwdMyQ==}
+    engines: {node: '>=18'}
+    cpu: [arm]
+    os: [android]
+
+  '@esbuild/android-x64@0.27.0':
+    resolution: {integrity: sha512-wurMkF1nmQajBO1+0CJmcN17U4BP6GqNSROP8t0X/Jiw2ltYGLHpEksp9MpoBqkrFR3kv2/te6Sha26k3+yZ9Q==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [android]
+
+  '@esbuild/darwin-arm64@0.27.0':
+    resolution: {integrity: sha512-uJOQKYCcHhg07DL7i8MzjvS2LaP7W7Pn/7uA0B5S1EnqAirJtbyw4yC5jQ5qcFjHK9l6o/MX9QisBg12kNkdHg==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@esbuild/darwin-x64@0.27.0':
+    resolution: {integrity: sha512-8mG6arH3yB/4ZXiEnXof5MK72dE6zM9cDvUcPtxhUZsDjESl9JipZYW60C3JGreKCEP+p8P/72r69m4AZGJd5g==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [darwin]
+
+  '@esbuild/freebsd-arm64@0.27.0':
+    resolution: {integrity: sha512-9FHtyO988CwNMMOE3YIeci+UV+x5Zy8fI2qHNpsEtSF83YPBmE8UWmfYAQg6Ux7Gsmd4FejZqnEUZCMGaNQHQw==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [freebsd]
+
+  '@esbuild/freebsd-x64@0.27.0':
+    resolution: {integrity: sha512-zCMeMXI4HS/tXvJz8vWGexpZj2YVtRAihHLk1imZj4efx1BQzN76YFeKqlDr3bUWI26wHwLWPd3rwh6pe4EV7g==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [freebsd]
+
+  '@esbuild/linux-arm64@0.27.0':
+    resolution: {integrity: sha512-AS18v0V+vZiLJyi/4LphvBE+OIX682Pu7ZYNsdUHyUKSoRwdnOsMf6FDekwoAFKej14WAkOef3zAORJgAtXnlQ==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [linux]
+
+  '@esbuild/linux-arm@0.27.0':
+    resolution: {integrity: sha512-t76XLQDpxgmq2cNXKTVEB7O7YMb42atj2Re2Haf45HkaUpjM2J0UuJZDuaGbPbamzZ7bawyGFUkodL+zcE+jvQ==}
+    engines: {node: '>=18'}
+    cpu: [arm]
+    os: [linux]
+
+  '@esbuild/linux-ia32@0.27.0':
+    resolution: {integrity: sha512-Mz1jxqm/kfgKkc/KLHC5qIujMvnnarD9ra1cEcrs7qshTUSksPihGrWHVG5+osAIQ68577Zpww7SGapmzSt4Nw==}
+    engines: {node: '>=18'}
+    cpu: [ia32]
+    os: [linux]
+
+  '@esbuild/linux-loong64@0.27.0':
+    resolution: {integrity: sha512-QbEREjdJeIreIAbdG2hLU1yXm1uu+LTdzoq1KCo4G4pFOLlvIspBm36QrQOar9LFduavoWX2msNFAAAY9j4BDg==}
+    engines: {node: '>=18'}
+    cpu: [loong64]
+    os: [linux]
+
+  '@esbuild/linux-mips64el@0.27.0':
+    resolution: {integrity: sha512-sJz3zRNe4tO2wxvDpH/HYJilb6+2YJxo/ZNbVdtFiKDufzWq4JmKAiHy9iGoLjAV7r/W32VgaHGkk35cUXlNOg==}
+    engines: {node: '>=18'}
+    cpu: [mips64el]
+    os: [linux]
+
+  '@esbuild/linux-ppc64@0.27.0':
+    resolution: {integrity: sha512-z9N10FBD0DCS2dmSABDBb5TLAyF1/ydVb+N4pi88T45efQ/w4ohr/F/QYCkxDPnkhkp6AIpIcQKQ8F0ANoA2JA==}
+    engines: {node: '>=18'}
+    cpu: [ppc64]
+    os: [linux]
+
+  '@esbuild/linux-riscv64@0.27.0':
+    resolution: {integrity: sha512-pQdyAIZ0BWIC5GyvVFn5awDiO14TkT/19FTmFcPdDec94KJ1uZcmFs21Fo8auMXzD4Tt+diXu1LW1gHus9fhFQ==}
+    engines: {node: '>=18'}
+    cpu: [riscv64]
+    os: [linux]
+
+  '@esbuild/linux-s390x@0.27.0':
+    resolution: {integrity: sha512-hPlRWR4eIDDEci953RI1BLZitgi5uqcsjKMxwYfmi4LcwyWo2IcRP+lThVnKjNtk90pLS8nKdroXYOqW+QQH+w==}
+    engines: {node: '>=18'}
+    cpu: [s390x]
+    os: [linux]
+
+  '@esbuild/linux-x64@0.27.0':
+    resolution: {integrity: sha512-1hBWx4OUJE2cab++aVZ7pObD6s+DK4mPGpemtnAORBvb5l/g5xFGk0vc0PjSkrDs0XaXj9yyob3d14XqvnQ4gw==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [linux]
+
+  '@esbuild/netbsd-arm64@0.27.0':
+    resolution: {integrity: sha512-6m0sfQfxfQfy1qRuecMkJlf1cIzTOgyaeXaiVaaki8/v+WB+U4hc6ik15ZW6TAllRlg/WuQXxWj1jx6C+dfy3w==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [netbsd]
+
+  '@esbuild/netbsd-x64@0.27.0':
+    resolution: {integrity: sha512-xbbOdfn06FtcJ9d0ShxxvSn2iUsGd/lgPIO2V3VZIPDbEaIj1/3nBBe1AwuEZKXVXkMmpr6LUAgMkLD/4D2PPA==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [netbsd]
+
+  '@esbuild/openbsd-arm64@0.27.0':
+    resolution: {integrity: sha512-fWgqR8uNbCQ/GGv0yhzttj6sU/9Z5/Sv/VGU3F5OuXK6J6SlriONKrQ7tNlwBrJZXRYk5jUhuWvF7GYzGguBZQ==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [openbsd]
+
+  '@esbuild/openbsd-x64@0.27.0':
+    resolution: {integrity: sha512-aCwlRdSNMNxkGGqQajMUza6uXzR/U0dIl1QmLjPtRbLOx3Gy3otfFu/VjATy4yQzo9yFDGTxYDo1FfAD9oRD2A==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [openbsd]
+
+  '@esbuild/openharmony-arm64@0.27.0':
+    resolution: {integrity: sha512-nyvsBccxNAsNYz2jVFYwEGuRRomqZ149A39SHWk4hV0jWxKM0hjBPm3AmdxcbHiFLbBSwG6SbpIcUbXjgyECfA==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [openharmony]
+
+  '@esbuild/sunos-x64@0.27.0':
+    resolution: {integrity: sha512-Q1KY1iJafM+UX6CFEL+F4HRTgygmEW568YMqDA5UV97AuZSm21b7SXIrRJDwXWPzr8MGr75fUZPV67FdtMHlHA==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [sunos]
+
+  '@esbuild/win32-arm64@0.27.0':
+    resolution: {integrity: sha512-W1eyGNi6d+8kOmZIwi/EDjrL9nxQIQ0MiGqe/AWc6+IaHloxHSGoeRgDRKHFISThLmsewZ5nHFvGFWdBYlgKPg==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [win32]
+
+  '@esbuild/win32-ia32@0.27.0':
+    resolution: {integrity: sha512-30z1aKL9h22kQhilnYkORFYt+3wp7yZsHWus+wSKAJR8JtdfI76LJ4SBdMsCopTR3z/ORqVu5L1vtnHZWVj4cQ==}
+    engines: {node: '>=18'}
+    cpu: [ia32]
+    os: [win32]
+
+  '@esbuild/win32-x64@0.27.0':
+    resolution: {integrity: sha512-aIitBcjQeyOhMTImhLZmtxfdOcuNRpwlPNmlFKPcHQYPhEssw75Cl1TSXJXpMkzaua9FUetx/4OQKq7eJul5Cg==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [win32]
 
   '@eslint-community/eslint-utils@4.9.1':
     resolution: {integrity: sha512-phrYmNiYppR7znFEdqgfWHXR6NCkZEK7hwWDHZUjit/2/U0r6XvkDl0SYnoM51Hq7FhCGdLDT6zxCCOY1hexsQ==}
@@ -854,6 +1019,22 @@ packages:
   convert-source-map@2.0.0:
     resolution: {integrity: sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==}
 
+  convex@1.32.0:
+    resolution: {integrity: sha512-5FlajdLpW75pdLS+/CgGH5H6yeRuA+ru50AKJEYbJpmyILUS+7fdTvsdTaQ7ZFXMv0gE8mX4S+S3AtJ94k0mfw==}
+    engines: {node: '>=18.0.0', npm: '>=7.0.0'}
+    hasBin: true
+    peerDependencies:
+      '@auth0/auth0-react': ^2.0.1
+      '@clerk/clerk-react': ^4.12.8 || ^5.0.0
+      react: ^18.0.0 || ^19.0.0-0 || ^19.0.0
+    peerDependenciesMeta:
+      '@auth0/auth0-react':
+        optional: true
+      '@clerk/clerk-react':
+        optional: true
+      react:
+        optional: true
+
   cross-spawn@7.0.6:
     resolution: {integrity: sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==}
     engines: {node: '>= 8'}
@@ -964,6 +1145,11 @@ packages:
   es-to-primitive@1.3.0:
     resolution: {integrity: sha512-w+5mJ3GuFL+NjVtJlvydShqE1eN3h3PbI7/5LAsYJP/2qtuMXjfL2LpHSRqo4b4eSF5K/DH1JXKUAHSB2UW50g==}
     engines: {node: '>= 0.4'}
+
+  esbuild@0.27.0:
+    resolution: {integrity: sha512-jd0f4NHbD6cALCyGElNpGAOtWxSq46l9X/sWB0Nzd5er4Kz2YTm+Vl0qKFT9KUJvD8+fiO8AvoHhFvEatfVixA==}
+    engines: {node: '>=18'}
+    hasBin: true
 
   escalade@3.2.0:
     resolution: {integrity: sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==}
@@ -1699,6 +1885,11 @@ packages:
     resolution: {integrity: sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g==}
     engines: {node: '>= 0.8.0'}
 
+  prettier@3.8.1:
+    resolution: {integrity: sha512-UOnG6LftzbdaHZcKoPFtOcCKztrQ57WkHDeRD9t/PTQtmT0NHSeWWepj6pS0z/N7+08BHFDQVUrfmfMRcZwbMg==}
+    engines: {node: '>=14'}
+    hasBin: true
+
   prop-types@15.8.1:
     resolution: {integrity: sha512-oj87CgZICdulUohogVAR7AjlC0327U4el4L6eAvOqCeudMDVU0NThNaV+b9Df4dXgSP1gXMTnPdhfe/2qDH5cg==}
 
@@ -2026,6 +2217,18 @@ packages:
     resolution: {integrity: sha512-42AtmgqjV+X1VpdOfyTGOYRi0/zsoLqtXQckTmqTeybT+BDIbM/Guxo7x3pE2vtpr1ok6xRqM9OpBe+Jyoqyww==}
     engines: {node: '>=18'}
 
+  ws@8.18.0:
+    resolution: {integrity: sha512-8VbfWfHLbbwu3+N6OKsOMpBdT4kXPDDB9cJk2bJ6mh9ucxdlnNvH1e+roYkKmN9Nxw2yjz7VzeO9oOz2zJ04Pw==}
+    engines: {node: '>=10.0.0'}
+    peerDependencies:
+      bufferutil: ^4.0.1
+      utf-8-validate: '>=5.0.2'
+    peerDependenciesMeta:
+      bufferutil:
+        optional: true
+      utf-8-validate:
+        optional: true
+
   yallist@3.1.1:
     resolution: {integrity: sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==}
 
@@ -2165,6 +2368,84 @@ snapshots:
   '@emnapi/wasi-threads@1.1.0':
     dependencies:
       tslib: 2.8.1
+    optional: true
+
+  '@esbuild/aix-ppc64@0.27.0':
+    optional: true
+
+  '@esbuild/android-arm64@0.27.0':
+    optional: true
+
+  '@esbuild/android-arm@0.27.0':
+    optional: true
+
+  '@esbuild/android-x64@0.27.0':
+    optional: true
+
+  '@esbuild/darwin-arm64@0.27.0':
+    optional: true
+
+  '@esbuild/darwin-x64@0.27.0':
+    optional: true
+
+  '@esbuild/freebsd-arm64@0.27.0':
+    optional: true
+
+  '@esbuild/freebsd-x64@0.27.0':
+    optional: true
+
+  '@esbuild/linux-arm64@0.27.0':
+    optional: true
+
+  '@esbuild/linux-arm@0.27.0':
+    optional: true
+
+  '@esbuild/linux-ia32@0.27.0':
+    optional: true
+
+  '@esbuild/linux-loong64@0.27.0':
+    optional: true
+
+  '@esbuild/linux-mips64el@0.27.0':
+    optional: true
+
+  '@esbuild/linux-ppc64@0.27.0':
+    optional: true
+
+  '@esbuild/linux-riscv64@0.27.0':
+    optional: true
+
+  '@esbuild/linux-s390x@0.27.0':
+    optional: true
+
+  '@esbuild/linux-x64@0.27.0':
+    optional: true
+
+  '@esbuild/netbsd-arm64@0.27.0':
+    optional: true
+
+  '@esbuild/netbsd-x64@0.27.0':
+    optional: true
+
+  '@esbuild/openbsd-arm64@0.27.0':
+    optional: true
+
+  '@esbuild/openbsd-x64@0.27.0':
+    optional: true
+
+  '@esbuild/openharmony-arm64@0.27.0':
+    optional: true
+
+  '@esbuild/sunos-x64@0.27.0':
+    optional: true
+
+  '@esbuild/win32-arm64@0.27.0':
+    optional: true
+
+  '@esbuild/win32-ia32@0.27.0':
+    optional: true
+
+  '@esbuild/win32-x64@0.27.0':
     optional: true
 
   '@eslint-community/eslint-utils@4.9.1(eslint@9.39.4(jiti@2.6.1))':
@@ -2825,6 +3106,17 @@ snapshots:
 
   convert-source-map@2.0.0: {}
 
+  convex@1.32.0(react@19.2.3):
+    dependencies:
+      esbuild: 0.27.0
+      prettier: 3.8.1
+      ws: 8.18.0
+    optionalDependencies:
+      react: 19.2.3
+    transitivePeerDependencies:
+      - bufferutil
+      - utf-8-validate
+
   cross-spawn@7.0.6:
     dependencies:
       path-key: 3.1.1
@@ -3000,6 +3292,35 @@ snapshots:
       is-callable: 1.2.7
       is-date-object: 1.1.0
       is-symbol: 1.1.1
+
+  esbuild@0.27.0:
+    optionalDependencies:
+      '@esbuild/aix-ppc64': 0.27.0
+      '@esbuild/android-arm': 0.27.0
+      '@esbuild/android-arm64': 0.27.0
+      '@esbuild/android-x64': 0.27.0
+      '@esbuild/darwin-arm64': 0.27.0
+      '@esbuild/darwin-x64': 0.27.0
+      '@esbuild/freebsd-arm64': 0.27.0
+      '@esbuild/freebsd-x64': 0.27.0
+      '@esbuild/linux-arm': 0.27.0
+      '@esbuild/linux-arm64': 0.27.0
+      '@esbuild/linux-ia32': 0.27.0
+      '@esbuild/linux-loong64': 0.27.0
+      '@esbuild/linux-mips64el': 0.27.0
+      '@esbuild/linux-ppc64': 0.27.0
+      '@esbuild/linux-riscv64': 0.27.0
+      '@esbuild/linux-s390x': 0.27.0
+      '@esbuild/linux-x64': 0.27.0
+      '@esbuild/netbsd-arm64': 0.27.0
+      '@esbuild/netbsd-x64': 0.27.0
+      '@esbuild/openbsd-arm64': 0.27.0
+      '@esbuild/openbsd-x64': 0.27.0
+      '@esbuild/openharmony-arm64': 0.27.0
+      '@esbuild/sunos-x64': 0.27.0
+      '@esbuild/win32-arm64': 0.27.0
+      '@esbuild/win32-ia32': 0.27.0
+      '@esbuild/win32-x64': 0.27.0
 
   escalade@3.2.0: {}
 
@@ -3802,6 +4123,8 @@ snapshots:
 
   prelude-ls@1.2.1: {}
 
+  prettier@3.8.1: {}
+
   prop-types@15.8.1:
     dependencies:
       loose-envify: 1.4.0
@@ -4264,6 +4587,8 @@ snapshots:
       ansi-styles: 6.2.3
       string-width: 7.2.0
       strip-ansi: 7.2.0
+
+  ws@8.18.0: {}
 
   yallist@3.1.1: {}
 

--- a/scripts/run-convex-local.mjs
+++ b/scripts/run-convex-local.mjs
@@ -21,7 +21,7 @@ const convexBin = path.join(
   repoRoot,
   "node_modules",
   ".bin",
-  process.platform === "win32" ? "convex.CMD" : "convex",
+  process.platform === "win32" ? "convex.cmd" : "convex",
 );
 
 const child = spawn(convexBin, args, {

--- a/scripts/run-convex-local.mjs
+++ b/scripts/run-convex-local.mjs
@@ -55,6 +55,20 @@ const child = spawn(convexBin, args, {
   },
 });
 
+const forwardSignal = (signal) => {
+  if (!child.killed) {
+    child.kill(signal);
+  }
+};
+
+process.on("SIGINT", () => {
+  forwardSignal("SIGINT");
+});
+
+process.on("SIGTERM", () => {
+  forwardSignal("SIGTERM");
+});
+
 child.on("error", (error) => {
   const code = error.code ? ` [${error.code}]` : "";
   console.error(`Failed to spawn Convex CLI (${convexBin})${code}: ${error.message}`);

--- a/scripts/run-convex-local.mjs
+++ b/scripts/run-convex-local.mjs
@@ -32,6 +32,8 @@ const child = spawn(convexBin, args, {
     ...process.env,
     CONVEX_AGENT_MODE: "anonymous",
     CONVEX_TMPDIR: convexTmp,
+    // Isolate anonymous Convex state from the user's real home directory.
+    // This also affects subprocesses spawned by the Convex CLI.
     HOME: convexHome,
     USERPROFILE: convexHome,
   },

--- a/scripts/run-convex-local.mjs
+++ b/scripts/run-convex-local.mjs
@@ -42,6 +42,9 @@ const child = spawn(convexBin, args, {
     // `--local` and would otherwise try to prompt for cloud auth.
     CONVEX_AGENT_MODE: "anonymous",
     CONVEX_TMPDIR: convexTmp,
+    TMPDIR: convexTmp,
+    TEMP: convexTmp,
+    TMP: convexTmp,
     // Isolate anonymous Convex state from the user's real home directory.
     // This also affects subprocesses spawned by the Convex CLI.
     HOME: convexHome,

--- a/scripts/run-convex-local.mjs
+++ b/scripts/run-convex-local.mjs
@@ -14,8 +14,16 @@ if (args.length === 0) {
   process.exit(1);
 }
 
-mkdirSync(convexHome, { recursive: true });
-mkdirSync(convexTmp, { recursive: true });
+try {
+  mkdirSync(convexHome, { recursive: true });
+  mkdirSync(convexTmp, { recursive: true });
+} catch (error) {
+  const message = error instanceof Error ? error.message : String(error);
+  console.error(
+    `Failed to create Convex isolation directories (${convexHome}, ${convexTmp}): ${message}`,
+  );
+  process.exit(1);
+}
 
 const convexBin = path.join(
   repoRoot,

--- a/scripts/run-convex-local.mjs
+++ b/scripts/run-convex-local.mjs
@@ -49,6 +49,9 @@ const child = spawn(convexBin, args, {
     // This also affects subprocesses spawned by the Convex CLI.
     HOME: convexHome,
     USERPROFILE: convexHome,
+    XDG_CONFIG_HOME: path.join(convexHome, ".config"),
+    XDG_DATA_HOME: path.join(convexHome, ".local", "share"),
+    XDG_CACHE_HOME: path.join(convexHome, ".cache"),
   },
 });
 
@@ -60,7 +63,12 @@ child.on("error", (error) => {
 
 child.on("exit", (code, signal) => {
   if (signal) {
-    process.kill(process.pid, signal);
+    if (process.platform !== "win32") {
+      process.kill(process.pid, signal);
+      return;
+    }
+
+    process.exit(1);
     return;
   }
 

--- a/scripts/run-convex-local.mjs
+++ b/scripts/run-convex-local.mjs
@@ -52,6 +52,7 @@ const child = spawn(convexBin, args, {
     XDG_CONFIG_HOME: path.join(convexHome, ".config"),
     XDG_DATA_HOME: path.join(convexHome, ".local", "share"),
     XDG_CACHE_HOME: path.join(convexHome, ".cache"),
+    XDG_STATE_HOME: path.join(convexHome, ".local", "state"),
   },
 });
 

--- a/scripts/run-convex-local.mjs
+++ b/scripts/run-convex-local.mjs
@@ -30,6 +30,8 @@ const child = spawn(convexBin, args, {
   shell: process.platform === "win32",
   env: {
     ...process.env,
+    // Belt-and-suspenders fallback in case a future script invocation omits
+    // `--local` and would otherwise try to prompt for cloud auth.
     CONVEX_AGENT_MODE: "anonymous",
     CONVEX_TMPDIR: convexTmp,
     // Isolate anonymous Convex state from the user's real home directory.

--- a/scripts/run-convex-local.mjs
+++ b/scripts/run-convex-local.mjs
@@ -1,0 +1,52 @@
+import { spawn } from "node:child_process";
+import { mkdirSync } from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const scriptDir = path.dirname(fileURLToPath(import.meta.url));
+const repoRoot = path.resolve(scriptDir, "..");
+const convexHome = path.join(repoRoot, ".convex-home");
+const convexTmp = path.join(repoRoot, ".convex-tmp");
+const args = process.argv.slice(2);
+
+if (args.length === 0) {
+  console.error("Usage: node scripts/run-convex-local.mjs <convex args>");
+  process.exit(1);
+}
+
+mkdirSync(convexHome, { recursive: true });
+mkdirSync(convexTmp, { recursive: true });
+
+const convexBin = path.join(
+  repoRoot,
+  "node_modules",
+  ".bin",
+  process.platform === "win32" ? "convex.CMD" : "convex",
+);
+
+const child = spawn(convexBin, args, {
+  cwd: repoRoot,
+  stdio: "inherit",
+  shell: process.platform === "win32",
+  env: {
+    ...process.env,
+    CONVEX_AGENT_MODE: "anonymous",
+    CONVEX_TMPDIR: convexTmp,
+    HOME: convexHome,
+    USERPROFILE: convexHome,
+  },
+});
+
+child.on("error", (error) => {
+  console.error(error.message);
+  process.exit(1);
+});
+
+child.on("exit", (code, signal) => {
+  if (signal) {
+    process.kill(process.pid, signal);
+    return;
+  }
+
+  process.exit(code ?? 1);
+});

--- a/scripts/run-convex-local.mjs
+++ b/scripts/run-convex-local.mjs
@@ -40,7 +40,8 @@ const child = spawn(convexBin, args, {
 });
 
 child.on("error", (error) => {
-  console.error(error.message);
+  const code = error.code ? ` [${error.code}]` : "";
+  console.error(`Failed to spawn Convex CLI (${convexBin})${code}: ${error.message}`);
   process.exit(1);
 });
 


### PR DESCRIPTION
## Summary
- initialize a repo-root Convex backend with an explicit empty schema and a minimal `health:status` query
- add isolated local bootstrap scripts plus committed Convex codegen so backend setup works without colliding with other local Convex projects
- extend docs and baseline checks to cover the backend bootstrap and update the web placeholder copy to reflect the new stack state

Closes #54