### PR TITLE
Add profile identity foundation

### DIFF
--- a/.github/workflows/baseline-checks.yml
+++ b/.github/workflows/baseline-checks.yml
@@ -86,6 +86,9 @@ jobs:
       - name: Run backend typecheck
         run: pnpm typecheck:backend
 
+      - name: Run backend unit tests
+        run: pnpm test:backend
+
   verify-backend-local:
     name: Verify Backend Local
     runs-on: ubuntu-latest

--- a/README.md
+++ b/README.md
@@ -38,6 +38,8 @@ The first server-side `Next.js -> Convex` baseline now lives at `/server-status`
 
 The first product schema table is `profiles`, covering the shared durable record for both people and communities. See `docs/backend/profile-schema.md` for the current field and state contract.
 
+Profile slug, permission, and claim-state contracts live in `docs/backend/profile-slugs.md` and `docs/backend/profile-access-and-claims.md`.
+
 `pnpm verify` is the full repo verification pass and now includes the local Convex bootstrap checks. If you are iterating on the web app only, use `pnpm verify:web` for the lighter web-only path.
 
 ## Start here

--- a/convex/README.md
+++ b/convex/README.md
@@ -4,6 +4,9 @@ This directory holds the initial Convex backend slice for `VRDex`.
 
 - `health.ts` exposes the placeholder public query `health:status`
 - `schema.ts` defines the base `profiles` table for people and communities
+- `_profileSlugs.ts` contains pure slug validation, generation, and lookup helpers
+- `_profileStates.ts` contains pure claim-state and trust-label helpers
+- `_profilePermissions.ts` contains pure read/write permission baseline helpers
 - `_generated/` contains committed Convex codegen output and should not be edited by hand
 - `tsconfig.json` is the Convex-managed TypeScript config for backend functions
 
@@ -18,3 +21,5 @@ Use the repo-root scripts for local work:
 The canonical workflow notes live in `docs/backend/convex-bootstrap.md`.
 
 The profile schema contract lives in `docs/backend/profile-schema.md`.
+
+The slug, permission, and claim-state contracts live in `docs/backend/profile-slugs.md` and `docs/backend/profile-access-and-claims.md`.

--- a/convex/_generated/api.d.ts
+++ b/convex/_generated/api.d.ts
@@ -8,6 +8,9 @@
  * @module
  */
 
+import type * as _profilePermissions from "../_profilePermissions.js";
+import type * as _profileSlugs from "../_profileSlugs.js";
+import type * as _profileStates from "../_profileStates.js";
 import type * as health from "../health.js";
 
 import type {
@@ -17,6 +20,9 @@ import type {
 } from "convex/server";
 
 declare const fullApi: ApiFromModules<{
+  _profilePermissions: typeof _profilePermissions;
+  _profileSlugs: typeof _profileSlugs;
+  _profileStates: typeof _profileStates;
   health: typeof health;
 }>;
 

--- a/convex/_profilePermissions.ts
+++ b/convex/_profilePermissions.ts
@@ -54,10 +54,14 @@ export function canReadProfile(
 
 export function canEditProfileField(
   subject: ProfilePermissionSubject,
-  profile: Pick<Doc<"profiles">, "claimState" | "profileType">,
+  profile: Pick<Doc<"profiles">, "claimState" | "profileType" | "publicationState">,
   field: ProfileEditableField,
 ): boolean {
   if (!isFieldCompatibleWithProfileType(profile.profileType, field)) {
+    return false;
+  }
+
+  if (!canReadProfile(subject, profile)) {
     return false;
   }
 

--- a/convex/_profilePermissions.ts
+++ b/convex/_profilePermissions.ts
@@ -1,0 +1,80 @@
+import type { Doc } from "./_generated/dataModel";
+
+export type ProfilePermissionSubject =
+  | "public"
+  | "community_submitter"
+  | "claimed_owner"
+  | "moderator";
+
+export type ProfileEditableField =
+  | "displayName"
+  | "aliases"
+  | "tags"
+  | "headline"
+  | "bio"
+  | "region"
+  | "timezone"
+  | "slug"
+  | "person"
+  | "community";
+
+export const COMMUNITY_SUBMISSION_EDITABLE_FIELDS = [
+  "displayName",
+  "aliases",
+  "tags",
+  "person",
+  "community",
+] as const satisfies readonly ProfileEditableField[];
+
+function isFieldCompatibleWithProfileType(
+  profileType: Doc<"profiles">["profileType"],
+  field: ProfileEditableField,
+): boolean {
+  if (field === "person") {
+    return profileType === "person";
+  }
+
+  if (field === "community") {
+    return profileType === "community";
+  }
+
+  return true;
+}
+
+export function canReadProfile(
+  subject: ProfilePermissionSubject,
+  profile: Pick<Doc<"profiles">, "publicationState">,
+): boolean {
+  if (subject === "claimed_owner" || subject === "moderator") {
+    return true;
+  }
+
+  return profile.publicationState === "published";
+}
+
+export function canEditProfileField(
+  subject: ProfilePermissionSubject,
+  profile: Pick<Doc<"profiles">, "claimState" | "profileType">,
+  field: ProfileEditableField,
+): boolean {
+  if (!isFieldCompatibleWithProfileType(profile.profileType, field)) {
+    return false;
+  }
+
+  if (subject === "moderator") {
+    return true;
+  }
+
+  if (subject === "claimed_owner") {
+    return profile.claimState !== "unclaimed";
+  }
+
+  if (subject === "community_submitter") {
+    return (
+      profile.claimState === "unclaimed" &&
+      (COMMUNITY_SUBMISSION_EDITABLE_FIELDS as readonly ProfileEditableField[]).includes(field)
+    );
+  }
+
+  return false;
+}

--- a/convex/_profileSlugs.ts
+++ b/convex/_profileSlugs.ts
@@ -4,6 +4,7 @@ import type { DatabaseReader } from "./_generated/server";
 export const PROFILE_SLUG_MIN_LENGTH = 3;
 export const PROFILE_SLUG_MAX_LENGTH = 64;
 export const PROFILE_SLUG_PATTERN = /^[a-z0-9]+(?:-[a-z0-9]+)*$/;
+export const PROFILE_SLUG_FALLBACK_BASE = "profile-page";
 
 export const RESERVED_PROFILE_SLUGS = [
   "about",
@@ -100,22 +101,24 @@ export function toProfileSlug(input: string): ProfileSlugValidationResult {
 }
 
 export function createProfileSlugBase(input: string): string {
-  let slug = normalizeProfileSlugInput(input) || "profile-page";
+  let slug = normalizeProfileSlugInput(input) || PROFILE_SLUG_FALLBACK_BASE;
 
-  if (slug.length < PROFILE_SLUG_MIN_LENGTH) {
-    slug = `${slug}-profile`;
+  for (let attempt = 0; attempt < 5; attempt += 1) {
+    if (slug.length < PROFILE_SLUG_MIN_LENGTH || RESERVED_PROFILE_SLUG_SET.has(slug)) {
+      slug = `${slug}-profile`;
+    }
+
+    if (slug.length > PROFILE_SLUG_MAX_LENGTH) {
+      slug = slug.slice(0, PROFILE_SLUG_MAX_LENGTH).replace(/-+$/g, "");
+    }
+
+    const validated = validateProfileSlug(slug);
+    if (validated.ok) {
+      return validated.slug;
+    }
   }
 
-  if (RESERVED_PROFILE_SLUG_SET.has(slug)) {
-    slug = `${slug}-profile`;
-  }
-
-  if (slug.length > PROFILE_SLUG_MAX_LENGTH) {
-    slug = slug.slice(0, PROFILE_SLUG_MAX_LENGTH).replace(/-+$/g, "");
-  }
-
-  const validated = validateProfileSlug(slug);
-  return validated.ok ? validated.slug : "profile-page";
+  return PROFILE_SLUG_FALLBACK_BASE;
 }
 
 export function createProfileSlugCandidate(base: string, attempt: number): string {

--- a/convex/_profileSlugs.ts
+++ b/convex/_profileSlugs.ts
@@ -1,0 +1,184 @@
+import type { Id } from "./_generated/dataModel";
+import type { DatabaseReader } from "./_generated/server";
+
+export const PROFILE_SLUG_MIN_LENGTH = 3;
+export const PROFILE_SLUG_MAX_LENGTH = 64;
+export const PROFILE_SLUG_PATTERN = /^[a-z0-9]+(?:-[a-z0-9]+)*$/;
+
+export const RESERVED_PROFILE_SLUGS = [
+  "about",
+  "account",
+  "admin",
+  "api",
+  "auth",
+  "billing",
+  "blog",
+  "c",
+  "cards",
+  "communities",
+  "community",
+  "contact",
+  "dashboard",
+  "docs",
+  "e",
+  "events",
+  "help",
+  "login",
+  "logout",
+  "me",
+  "moderation",
+  "p",
+  "people",
+  "person",
+  "pricing",
+  "privacy",
+  "profile",
+  "profiles",
+  "search",
+  "settings",
+  "signup",
+  "support",
+  "terms",
+  "vrdex",
+] as const;
+
+export type ProfileSlugValidationReason =
+  | "empty"
+  | "too_short"
+  | "too_long"
+  | "invalid_format"
+  | "reserved";
+
+export type ProfileSlugValidationResult =
+  | { ok: true; slug: string }
+  | { ok: false; reason: ProfileSlugValidationReason };
+
+export type ProfileSlugAvailabilityResult =
+  | { available: true; slug: string }
+  | { available: false; slug: string; reason: "invalid" | "reserved" | "taken" };
+
+const RESERVED_PROFILE_SLUG_SET = new Set<string>(RESERVED_PROFILE_SLUGS);
+
+export function normalizeProfileSlugInput(input: string): string {
+  return input
+    .normalize("NFKD")
+    .replace(/[\u0300-\u036f]/g, "")
+    .trim()
+    .toLowerCase()
+    .replace(/&/g, " and ")
+    .replace(/[^a-z0-9]+/g, "-")
+    .replace(/^-+|-+$/g, "")
+    .replace(/-{2,}/g, "-");
+}
+
+export function validateProfileSlug(slug: string): ProfileSlugValidationResult {
+  if (slug.length === 0) {
+    return { ok: false, reason: "empty" };
+  }
+
+  if (slug.length < PROFILE_SLUG_MIN_LENGTH) {
+    return { ok: false, reason: "too_short" };
+  }
+
+  if (slug.length > PROFILE_SLUG_MAX_LENGTH) {
+    return { ok: false, reason: "too_long" };
+  }
+
+  if (!PROFILE_SLUG_PATTERN.test(slug)) {
+    return { ok: false, reason: "invalid_format" };
+  }
+
+  if (RESERVED_PROFILE_SLUG_SET.has(slug)) {
+    return { ok: false, reason: "reserved" };
+  }
+
+  return { ok: true, slug };
+}
+
+export function toProfileSlug(input: string): ProfileSlugValidationResult {
+  return validateProfileSlug(normalizeProfileSlugInput(input));
+}
+
+export function createProfileSlugBase(input: string): string {
+  let slug = normalizeProfileSlugInput(input) || "profile-page";
+
+  if (slug.length < PROFILE_SLUG_MIN_LENGTH) {
+    slug = `${slug}-profile`;
+  }
+
+  if (RESERVED_PROFILE_SLUG_SET.has(slug)) {
+    slug = `${slug}-profile`;
+  }
+
+  if (slug.length > PROFILE_SLUG_MAX_LENGTH) {
+    slug = slug.slice(0, PROFILE_SLUG_MAX_LENGTH).replace(/-+$/g, "");
+  }
+
+  const validated = validateProfileSlug(slug);
+  return validated.ok ? validated.slug : "profile-page";
+}
+
+export function createProfileSlugCandidate(base: string, attempt: number): string {
+  if (attempt <= 1) {
+    return base;
+  }
+
+  const suffix = `-${attempt}`;
+  const maxBaseLength = PROFILE_SLUG_MAX_LENGTH - suffix.length;
+  return `${base.slice(0, maxBaseLength).replace(/-+$/g, "")}${suffix}`;
+}
+
+export async function getProfileBySlug(db: DatabaseReader, slug: string) {
+  return await db
+    .query("profiles")
+    .withIndex("by_slug", (q) => q.eq("slug", slug))
+    .unique();
+}
+
+export async function checkProfileSlugAvailability(
+  db: DatabaseReader,
+  slug: string,
+  excludingProfileId?: Id<"profiles">,
+): Promise<ProfileSlugAvailabilityResult> {
+  const validation = validateProfileSlug(slug);
+
+  if (!validation.ok) {
+    return {
+      available: false,
+      slug,
+      reason: validation.reason === "reserved" ? "reserved" : "invalid",
+    };
+  }
+
+  const existingProfile = await getProfileBySlug(db, validation.slug);
+
+  if (existingProfile !== null && existingProfile._id !== excludingProfileId) {
+    return { available: false, slug: validation.slug, reason: "taken" };
+  }
+
+  return { available: true, slug: validation.slug };
+}
+
+export async function findAvailableProfileSlug(
+  db: DatabaseReader,
+  input: string,
+  options: { excludingProfileId?: Id<"profiles">; maxAttempts?: number } = {},
+): Promise<string> {
+  const base = createProfileSlugBase(input);
+  const maxAttempts = options.maxAttempts ?? 50;
+
+  for (let attempt = 1; attempt <= maxAttempts; attempt += 1) {
+    const candidate = createProfileSlugCandidate(base, attempt);
+    const availability = await checkProfileSlugAvailability(
+      db,
+      candidate,
+      options.excludingProfileId,
+    );
+
+    if (availability.available) {
+      return availability.slug;
+    }
+  }
+
+  throw new Error(`Unable to find an available profile slug for "${base}".`);
+}

--- a/convex/_profileStates.ts
+++ b/convex/_profileStates.ts
@@ -1,0 +1,51 @@
+import type { Doc } from "./_generated/dataModel";
+
+export type ProfileClaimState = Doc<"profiles">["claimState"];
+export type ProfileCreationSource = Doc<"profiles">["creationSource"];
+
+export type ProfileTrustLabel =
+  | "community_submitted"
+  | "unclaimed"
+  | "claimed_unverified"
+  | "claimed_verified";
+
+const ALLOWED_CLAIM_STATE_TRANSITIONS: Record<ProfileClaimState, ProfileClaimState[]> = {
+  unclaimed: ["claimed_unverified", "claimed_verified"],
+  claimed_unverified: ["claimed_verified"],
+  claimed_verified: [],
+};
+
+export function getProfileTrustLabel(
+  claimState: ProfileClaimState,
+  creationSource: ProfileCreationSource,
+): ProfileTrustLabel {
+  if (claimState === "claimed_verified") {
+    return "claimed_verified";
+  }
+
+  if (claimState === "claimed_unverified") {
+    return "claimed_unverified";
+  }
+
+  if (creationSource === "community") {
+    return "community_submitted";
+  }
+
+  return "unclaimed";
+}
+
+export function canTransitionProfileClaimState(
+  from: ProfileClaimState,
+  to: ProfileClaimState,
+): boolean {
+  return from === to || ALLOWED_CLAIM_STATE_TRANSITIONS[from].includes(to);
+}
+
+export function requireProfileClaimStateTransition(
+  from: ProfileClaimState,
+  to: ProfileClaimState,
+): void {
+  if (!canTransitionProfileClaimState(from, to)) {
+    throw new Error(`Invalid profile claim state transition from "${from}" to "${to}".`);
+  }
+}

--- a/convex/_profileStates.ts
+++ b/convex/_profileStates.ts
@@ -38,7 +38,7 @@ export function canTransitionProfileClaimState(
   from: ProfileClaimState,
   to: ProfileClaimState,
 ): boolean {
-  return from === to || ALLOWED_CLAIM_STATE_TRANSITIONS[from].includes(to);
+  return ALLOWED_CLAIM_STATE_TRANSITIONS[from].includes(to);
 }
 
 export function requireProfileClaimStateTransition(

--- a/convex/schema.ts
+++ b/convex/schema.ts
@@ -1,8 +1,6 @@
 import { defineSchema, defineTable } from "convex/server";
 import { v } from "convex/values";
 
-const profileType = v.union(v.literal("person"), v.literal("community"));
-
 const claimState = v.union(
   v.literal("unclaimed"),
   v.literal("claimed_unverified"),
@@ -22,25 +20,48 @@ const creationSource = v.union(
   v.literal("moderator"),
 );
 
+const sharedProfileFields = {
+  slug: v.string(),
+  displayName: v.string(),
+  sortName: v.string(),
+  aliases: v.array(v.string()),
+  tags: v.array(v.string()),
+  headline: v.optional(v.string()),
+  bio: v.optional(v.string()),
+  region: v.optional(v.string()),
+  timezone: v.optional(v.string()),
+  claimState,
+  publicationState,
+  creationSource,
+  // Mutations must set claimedAt/publishedAt with state transitions
+  // and patch updatedAt on every profile write.
+  claimedAt: v.optional(v.number()),
+  publishedAt: v.optional(v.number()),
+  updatedAt: v.number(),
+};
+
 export default defineSchema({
-  profiles: defineTable({
-    profileType,
-    displayName: v.string(),
-    sortName: v.string(),
-    aliases: v.array(v.string()),
-    headline: v.optional(v.string()),
-    bio: v.optional(v.string()),
-    region: v.optional(v.string()),
-    timezone: v.optional(v.string()),
-    claimState,
-    publicationState,
-    creationSource,
-    // Mutations must set claimedAt/publishedAt with state transitions
-    // and patch updatedAt on every profile write.
-    claimedAt: v.optional(v.number()),
-    publishedAt: v.optional(v.number()),
-    updatedAt: v.number(),
-  })
+  profiles: defineTable(
+    v.union(
+      v.object({
+        ...sharedProfileFields,
+        profileType: v.literal("person"),
+        person: v.object({
+          pronouns: v.optional(v.string()),
+          roleTags: v.array(v.string()),
+        }),
+      }),
+      v.object({
+        ...sharedProfileFields,
+        profileType: v.literal("community"),
+        community: v.object({
+          subtype: v.optional(v.string()),
+          categoryTags: v.array(v.string()),
+        }),
+      }),
+    ),
+  )
+    .index("by_slug", ["slug"])
     .index("by_profileType_publicationState", ["profileType", "publicationState"])
     .index("by_publicationState_claimState", ["publicationState", "claimState"])
     .index("by_claimState_profileType", ["claimState", "profileType"])

--- a/docs/backend/convex-bootstrap.md
+++ b/docs/backend/convex-bootstrap.md
@@ -2,9 +2,9 @@
 
 ## Status note
 
-This doc captures the initial Convex backend slice landed for `#54`, plus the first product schema slice from `#9`.
+This doc captures the initial Convex backend slice landed for `#54`, plus the first profile foundation slices from `#9` through `#13`.
 
-It is intentionally narrow: enough structure to run Convex locally, generate typed backend helpers, prove the backend is wired, and define the first profile table without prematurely locking auth, permissions, slugs, or rich product flows.
+It is intentionally narrow: enough structure to run Convex locally, generate typed backend helpers, prove the backend is wired, and define profile identity/authority contracts without prematurely locking auth providers, account links, public write flows, billing, or rich presentation features.
 
 ## Locked decision
 
@@ -55,7 +55,8 @@ Keep the initial backend slice simple:
 - `#55` wires the web app to the first Convex client/runtime path using `health:status`
 - `#64` adds the first server-side `Next.js -> Convex` data path with `fetchQuery` on `/server-status`
 - profile schema, auth, billing, and production deployment posture should land in their own issues instead of bloating the bootstrap
-- `#9` adds the first product table, `profiles`, while keeping slugs, auth/account links, permissions, and type-specific fields deferred
+- `#9` adds the first product table, `profiles`
+- `#10` through `#13` add profile slugs, type-aware fields, permission contracts, and claim-state helpers while keeping auth/account links deferred
 
 ## App Router baseline
 

--- a/docs/backend/profile-access-and-claims.md
+++ b/docs/backend/profile-access-and-claims.md
@@ -1,0 +1,70 @@
+# Profile Access And Claims
+
+## Status Note
+
+This doc captures the permission and claim-state baseline for `#12` and `#13`.
+
+It intentionally does not add auth, account records, public write mutations, OAuth claim flows, VRChat proof-code verification, moderation UI, role delegation, or ownership transfer.
+
+## Read Baseline
+
+- public users can read `published` profiles
+- `draft_private` profiles are not public
+- claimed owners can read their own profiles regardless of publication state once ownership is modeled
+- moderators can read profiles regardless of publication state once moderator authority exists
+
+## Edit Baseline
+
+Ordinary public users cannot edit profiles.
+
+Community submitters may populate only a narrow safe field set for unclaimed profiles once submission flows exist:
+
+- `displayName`
+- `aliases`
+- `tags`
+- `person` type-specific fields
+- `community` type-specific fields
+
+Community submitters must not set fields that imply verified authority, private contact details, billing state, ownership, custom slugs, or sensitive visibility choices. Profile creation can still generate an initial slug from submitted display text.
+
+Claimed owners may edit normal profile fields after a claim attaches authority to the existing profile record. This baseline assumes claimed owners can edit identity, presentation, slug, tags, and type-specific profile fields, subject to future field-level visibility and abuse controls.
+
+Moderators may override profile fields later for safety, corrections, and abuse handling. The moderation UI and detailed audit model are deferred.
+
+## Claim States
+
+`claimState` describes owner authority:
+
+- `unclaimed`: no owner authority is attached yet
+- `claimed_unverified`: a claimant controls the profile, but stronger verification is not complete
+- `claimed_verified`: owner control and stronger verification are both established
+
+Claim transitions preserve the same profile record and slug. Claiming a profile should not create a duplicate identity record.
+
+Allowed ordinary transitions:
+
+- `unclaimed` -> `claimed_unverified`
+- `unclaimed` -> `claimed_verified`
+- `claimed_unverified` -> `claimed_verified`
+
+Downgrades, contested claims, transfer flows, and suppression flows require explicit moderation or ownership workflows later.
+
+## Trust Labels
+
+Initial trust labels map from `claimState` plus `creationSource`:
+
+- `community_submitted`: `claimState: "unclaimed"` and `creationSource: "community"`
+- `unclaimed`: no owner authority has been attached
+- `claimed_unverified`: owner control exists, stronger verification is pending
+- `claimed_verified`: owner control and verification are established
+
+These labels are business-logic helpers only. Final UI copy and visual treatment belong to public profile and trust-label issues.
+
+## Mutation Contracts
+
+Future claim mutations must:
+
+- validate allowed claim-state transitions
+- set `claimedAt` when `claimState` leaves `"unclaimed"`
+- preserve the profile `_id` and slug when authority changes
+- patch `updatedAt` on every profile write

--- a/docs/backend/profile-access-and-claims.md
+++ b/docs/backend/profile-access-and-claims.md
@@ -41,7 +41,7 @@ Moderators may override profile fields later for safety, corrections, and abuse 
 
 Claim transitions preserve the same profile record and slug. Claiming a profile should not create a duplicate identity record.
 
-Allowed ordinary transitions:
+Allowed ordinary transitions are real state changes only:
 
 - `unclaimed` -> `claimed_unverified`
 - `unclaimed` -> `claimed_verified`
@@ -65,6 +65,7 @@ These labels are business-logic helpers only. Final UI copy and visual treatment
 Future claim mutations must:
 
 - validate allowed claim-state transitions
+- handle no-op writes outside the claim transition helper
 - set `claimedAt` when `claimState` leaves `"unclaimed"`
 - preserve the profile `_id` and slug when authority changes
 - patch `updatedAt` on every profile write

--- a/docs/backend/profile-schema.md
+++ b/docs/backend/profile-schema.md
@@ -2,19 +2,19 @@
 
 ## Status Note
 
-This doc captures the first durable profile schema slice for `#9`.
+This doc captures the durable profile schema foundation started in `#9` and extended through `#10`, `#11`, `#12`, and `#13`.
 
-The schema is intentionally narrow. It establishes one shared `profiles` table for people and communities without introducing slug generation, auth/account links, claim flows, permissions, normalized link tables, asset tables, search-specific indexing, or type-specific profile fields.
+The schema is intentionally narrow. It establishes one shared `profiles` table for people and communities without introducing auth/account links, public write mutations, full claim flows, normalized link tables, asset tables, or public profile pages.
 
 ## Locked Decisions
 
 - profiles are first-class records independent from the user account that may later claim them
-- `profileType` is explicit and currently supports `person` and `community`
+- `profileType` is explicit and currently supports `person` and `community` through a discriminated schema union
+- every profile has a canonical `slug` that is globally unique across people and communities
 - claim state, publication state, and creation provenance are separate fields
 - community-submitted unclaimed records are represented by `creationSource: "community"` plus `claimState: "unclaimed"`
 - account/user references are deferred until auth and claim issues define the account model
-- slugs are deferred to `#10`
-- type-aware person/community detail fields are deferred to `#11`
+- public write mutations are deferred until auth and permissions are wired
 - normalized alias, link, asset, and rich authored block tables are deferred to later profile presentation issues
 
 ## `profiles` Table
@@ -22,9 +22,11 @@ The schema is intentionally narrow. It establishes one shared `profiles` table f
 Core identity fields:
 
 - `profileType`: `"person" | "community"`
+- `slug`: globally unique canonical URL handle
 - `displayName`: public display name
 - `sortName`: normalized display-sort key for deterministic listing
 - `aliases`: alternate names or searchable display variants kept inline for the first schema slice
+- `tags`: flexible shared discovery tags or genres, without imposing a rigid taxonomy
 
 Core presentation fields:
 
@@ -42,6 +44,13 @@ State fields:
 - `publishedAt`: optional publication timestamp, present once a profile has been published
 - `updatedAt`: application-maintained update timestamp that every profile mutation must refresh
 
+Type-specific fields:
+
+- `person.pronouns`: optional short pronoun text
+- `person.roleTags`: flexible role/type tags such as DJ, VJ, host, photographer, or performer
+- `community.subtype`: optional short subtype text such as venue, collective, brand, or agency
+- `community.categoryTags`: flexible category tags for community discovery and presentation
+
 Convex automatically provides `_id` and `_creationTime`; those are not duplicated in the schema.
 
 ## State Semantics
@@ -55,7 +64,7 @@ Convex automatically provides `_id` and `_creationTime`; those are not duplicate
 `publicationState` describes public surfacing:
 
 - `draft_private`: not public and not searchable
-- `published`: eligible for public profile pages and later discovery flows, subject to future permission, trust, and opt-out rules
+- `published`: eligible for public profile pages and later discovery flows, subject to permission, trust, and opt-out rules
 
 `creationSource` describes how the record entered the system. It is not an authority marker by itself; authority comes from `claimState` and later claim records.
 
@@ -69,6 +78,7 @@ Convex schema validation cannot enforce conditional timestamp invariants, so pro
 
 ## Initial Indexes
 
+- `by_slug`: canonical profile lookup and mutation-enforced slug uniqueness
 - `by_profileType_publicationState`: public page/discovery entry points split by person vs community
 - `by_publicationState_claimState`: public/trust filtering for later profile lists
 - `by_claimState_profileType`: moderation and claim-review flows by claim state, with optional type splitting
@@ -80,7 +90,7 @@ Convex schema validation cannot enforce conditional timestamp invariants, so pro
 - `#10` adds canonical slugs, validation, and uniqueness rules
 - `#11` adds type-aware person/community fields and documents shared vs type-specific data
 - `#12` defines read/write permission behavior
-- `#13` implements claim-state transitions and trust labeling behavior
+- `#13` defines claim-state transitions and trust labeling behavior
 - `#22` adds presentation assets and owner-authored content sections
 - `#23` adds community submission flows and source attribution details
 - `#27` adds field-level visibility controls

--- a/docs/backend/profile-slugs.md
+++ b/docs/backend/profile-slugs.md
@@ -1,0 +1,52 @@
+# Profile Slugs
+
+## Status Note
+
+This doc captures the slug contract for `#10`.
+
+Profiles use one global slug namespace across both people and communities, even though public pages are planned as `/p/<slug>` and `/c/<slug>`. This avoids ambiguous API, card, and search lookups.
+
+## Rules
+
+- slugs are lowercase ASCII only
+- allowed characters are `a-z`, `0-9`, and `-`
+- length must be 3 to 64 characters
+- leading hyphens are invalid
+- trailing hyphens are invalid
+- consecutive hyphens are invalid
+- reserved slugs are invalid
+- canonical slugs are independent from Discord, VRChat, Google, email, or any other login identifier
+
+## Reserved Slugs
+
+The reserved list lives in `convex/_profileSlugs.ts` and protects current plus likely future public routes, including app routes, auth routes, profile collection routes, API surfaces, account/settings routes, and support/legal pages.
+
+## Generation
+
+Initial slug generation starts from a display name or owner-provided text:
+
+1. normalize to lowercase ASCII
+2. strip combining marks
+3. convert non-alphanumeric runs to hyphens
+4. trim leading/trailing hyphens
+5. collapse repeated hyphens
+6. append a safe suffix when the base would be too short or reserved
+7. append numeric suffixes such as `-2`, `-3`, and later attempts when a slug is already taken
+
+## Uniqueness
+
+Convex does not enforce unique indexes at the schema layer. Profile slug uniqueness is enforced by mutations using the `by_slug` index before insert or update.
+
+No public profile write mutations exist yet. Future mutations that create or update profiles must:
+
+- normalize and validate the candidate slug
+- reject invalid or reserved slugs
+- query `by_slug` to reject collisions outside the current profile
+- patch `updatedAt` with the slug write
+
+## Follow-On Boundaries
+
+- slug history and redirects are deferred
+- custom domains are deferred
+- SEO metadata is deferred
+- public pages and API routes that consume slugs are deferred

--- a/docs/backend/profile-slugs.md
+++ b/docs/backend/profile-slugs.md
@@ -30,8 +30,9 @@ Initial slug generation starts from a display name or owner-provided text:
 3. convert non-alphanumeric runs to hyphens
 4. trim leading/trailing hyphens
 5. collapse repeated hyphens
-6. append a safe suffix when the base would be too short or reserved
-7. append numeric suffixes such as `-2`, `-3`, and later attempts when a slug is already taken
+6. append and revalidate a safe suffix when the base would be too short or reserved
+7. trim and revalidate overlong bases
+8. append numeric suffixes such as `-2`, `-3`, and later attempts when a slug is already taken
 
 ## Uniqueness
 

--- a/docs/planning/architecture.md
+++ b/docs/planning/architecture.md
@@ -90,8 +90,11 @@ One row per person or community.
 Implementation status:
 
 - `#9` establishes one shared Convex `profiles` table
-- claim state, publication state, and creation source are split into separate fields
-- account/user links, slug generation, type-specific fields, assets, and search-specific indexes are deferred to follow-on issues
+- `#10` adds globally unique canonical profile slugs and validation helpers
+- `#11` adds discriminated person/community type-specific fields
+- `#12` documents the profile read/write permission baseline
+- `#13` documents claim-state transitions and trust-label helpers
+- account/user links, assets, public profile pages, and search-specific indexes are deferred to follow-on issues
 
 Suggested fields:
 

--- a/package.json
+++ b/package.json
@@ -8,13 +8,14 @@
     "dev:web": "pnpm --filter web dev",
     "build:web": "pnpm --filter web build",
     "lint:web": "pnpm --filter web lint",
+    "test:backend": "node --import tsx --test tests/backend/**/*.test.ts",
     "typecheck:backend": "tsc --noEmit --project convex/tsconfig.json",
     "run:backend:health:local": "pnpm verify:backend:local",
     "typecheck:web": "pnpm --filter web typecheck",
     "verify:backend:local": "node scripts/run-convex-local.mjs dev --local --once --run health:status --tail-logs disable",
     "check:backend:generated": "pnpm verify:backend:local && git diff --exit-code -- convex/_generated",
     "verify:web": "pnpm lint:web && pnpm typecheck:web && pnpm build:web",
-    "verify": "pnpm verify:web && pnpm check:backend:generated && pnpm typecheck:backend",
+    "verify": "pnpm verify:web && pnpm check:backend:generated && pnpm typecheck:backend && pnpm test:backend",
     "prepare": "husky"
   },
   "lint-staged": {
@@ -25,6 +26,7 @@
     "convex": "^1.32.0",
     "husky": "^9.1.7",
     "lint-staged": "^16.3.3",
+    "tsx": "^4.22.1",
     "typescript": "^5.9.3"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -20,6 +20,9 @@ importers:
       lint-staged:
         specifier: ^16.3.3
         version: 16.3.3
+      tsx:
+        specifier: ^4.22.1
+        version: 4.22.1
       typescript:
         specifier: ^5.9.3
         version: 5.9.3
@@ -152,8 +155,20 @@ packages:
     cpu: [ppc64]
     os: [aix]
 
+  '@esbuild/aix-ppc64@0.28.0':
+    resolution: {integrity: sha512-lhRUCeuOyJQURhTxl4WkpFTjIsbDayJHih5kZC1giwE+MhIzAb7mEsQMqMf18rHLsrb5qI1tafG20mLxEWcWlA==}
+    engines: {node: '>=18'}
+    cpu: [ppc64]
+    os: [aix]
+
   '@esbuild/android-arm64@0.27.0':
     resolution: {integrity: sha512-CC3vt4+1xZrs97/PKDkl0yN7w8edvU2vZvAFGD16n9F0Cvniy5qvzRXjfO1l94efczkkQE6g1x0i73Qf5uthOQ==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [android]
+
+  '@esbuild/android-arm64@0.28.0':
+    resolution: {integrity: sha512-+WzIXQOSaGs33tLEgYPYe/yQHf0WTU0X42Jca3y8NWMbUVhp7rUnw+vAsRC/QiDrdD31IszMrZy+qwPOPjd+rw==}
     engines: {node: '>=18'}
     cpu: [arm64]
     os: [android]
@@ -164,8 +179,20 @@ packages:
     cpu: [arm]
     os: [android]
 
+  '@esbuild/android-arm@0.28.0':
+    resolution: {integrity: sha512-wqh0ByljabXLKHeWXYLqoJ5jKC4XBaw6Hk08OfMrCRd2nP2ZQ5eleDZC41XHyCNgktBGYMbqnrJKq/K/lzPMSQ==}
+    engines: {node: '>=18'}
+    cpu: [arm]
+    os: [android]
+
   '@esbuild/android-x64@0.27.0':
     resolution: {integrity: sha512-wurMkF1nmQajBO1+0CJmcN17U4BP6GqNSROP8t0X/Jiw2ltYGLHpEksp9MpoBqkrFR3kv2/te6Sha26k3+yZ9Q==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [android]
+
+  '@esbuild/android-x64@0.28.0':
+    resolution: {integrity: sha512-+VJggoaKhk2VNNqVL7f6S189UzShHC/mR9EE8rDdSkdpN0KflSwWY/gWjDrNxxisg8Fp1ZCD9jLMo4m0OUfeUA==}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [android]
@@ -176,8 +203,20 @@ packages:
     cpu: [arm64]
     os: [darwin]
 
+  '@esbuild/darwin-arm64@0.28.0':
+    resolution: {integrity: sha512-0T+A9WZm+bZ84nZBtk1ckYsOvyA3x7e2Acj1KdVfV4/2tdG4fzUp91YHx+GArWLtwqp77pBXVCPn2We7Letr0Q==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [darwin]
+
   '@esbuild/darwin-x64@0.27.0':
     resolution: {integrity: sha512-8mG6arH3yB/4ZXiEnXof5MK72dE6zM9cDvUcPtxhUZsDjESl9JipZYW60C3JGreKCEP+p8P/72r69m4AZGJd5g==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [darwin]
+
+  '@esbuild/darwin-x64@0.28.0':
+    resolution: {integrity: sha512-fyzLm/DLDl/84OCfp2f/XQ4flmORsjU7VKt8HLjvIXChJoFFOIL6pLJPH4Yhd1n1gGFF9mPwtlN5Wf82DZs+LQ==}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [darwin]
@@ -188,8 +227,20 @@ packages:
     cpu: [arm64]
     os: [freebsd]
 
+  '@esbuild/freebsd-arm64@0.28.0':
+    resolution: {integrity: sha512-l9GeW5UZBT9k9brBYI+0WDffcRxgHQD8ShN2Ur4xWq/NFzUKm3k5lsH4PdaRgb2w7mI9u61nr2gI2mLI27Nh3Q==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [freebsd]
+
   '@esbuild/freebsd-x64@0.27.0':
     resolution: {integrity: sha512-zCMeMXI4HS/tXvJz8vWGexpZj2YVtRAihHLk1imZj4efx1BQzN76YFeKqlDr3bUWI26wHwLWPd3rwh6pe4EV7g==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [freebsd]
+
+  '@esbuild/freebsd-x64@0.28.0':
+    resolution: {integrity: sha512-BXoQai/A0wPO6Es3yFJ7APCiKGc1tdAEOgeTNy3SsB491S3aHn4S4r3e976eUnPdU+NbdtmBuLncYir2tMU9Nw==}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [freebsd]
@@ -200,8 +251,20 @@ packages:
     cpu: [arm64]
     os: [linux]
 
+  '@esbuild/linux-arm64@0.28.0':
+    resolution: {integrity: sha512-RVyzfb3FWsGA55n6WY0MEIEPURL1FcbhFE6BffZEMEekfCzCIMtB5yyDcFnVbTnwk+CLAgTujmV/Lgvih56W+A==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [linux]
+
   '@esbuild/linux-arm@0.27.0':
     resolution: {integrity: sha512-t76XLQDpxgmq2cNXKTVEB7O7YMb42atj2Re2Haf45HkaUpjM2J0UuJZDuaGbPbamzZ7bawyGFUkodL+zcE+jvQ==}
+    engines: {node: '>=18'}
+    cpu: [arm]
+    os: [linux]
+
+  '@esbuild/linux-arm@0.28.0':
+    resolution: {integrity: sha512-CjaaREJagqJp7iTaNQjjidaNbCKYcd4IDkzbwwxtSvjI7NZm79qiHc8HqciMddQ6CKvJT6aBd8lO9kN/ZudLlw==}
     engines: {node: '>=18'}
     cpu: [arm]
     os: [linux]
@@ -212,8 +275,20 @@ packages:
     cpu: [ia32]
     os: [linux]
 
+  '@esbuild/linux-ia32@0.28.0':
+    resolution: {integrity: sha512-KBnSTt1kxl9x70q+ydterVdl+Cn0H18ngRMRCEQfrbqdUuntQQ0LoMZv47uB97NljZFzY6HcfqEZ2SAyIUTQBQ==}
+    engines: {node: '>=18'}
+    cpu: [ia32]
+    os: [linux]
+
   '@esbuild/linux-loong64@0.27.0':
     resolution: {integrity: sha512-QbEREjdJeIreIAbdG2hLU1yXm1uu+LTdzoq1KCo4G4pFOLlvIspBm36QrQOar9LFduavoWX2msNFAAAY9j4BDg==}
+    engines: {node: '>=18'}
+    cpu: [loong64]
+    os: [linux]
+
+  '@esbuild/linux-loong64@0.28.0':
+    resolution: {integrity: sha512-zpSlUce1mnxzgBADvxKXX5sl8aYQHo2ezvMNI8I0lbblJtp8V4odlm3Yzlj7gPyt3T8ReksE6bK+pT3WD+aJRg==}
     engines: {node: '>=18'}
     cpu: [loong64]
     os: [linux]
@@ -224,8 +299,20 @@ packages:
     cpu: [mips64el]
     os: [linux]
 
+  '@esbuild/linux-mips64el@0.28.0':
+    resolution: {integrity: sha512-2jIfP6mmjkdmeTlsX/9vmdmhBmKADrWqN7zcdtHIeNSCH1SqIoNI63cYsjQR8J+wGa4Y5izRcSHSm8K3QWmk3w==}
+    engines: {node: '>=18'}
+    cpu: [mips64el]
+    os: [linux]
+
   '@esbuild/linux-ppc64@0.27.0':
     resolution: {integrity: sha512-z9N10FBD0DCS2dmSABDBb5TLAyF1/ydVb+N4pi88T45efQ/w4ohr/F/QYCkxDPnkhkp6AIpIcQKQ8F0ANoA2JA==}
+    engines: {node: '>=18'}
+    cpu: [ppc64]
+    os: [linux]
+
+  '@esbuild/linux-ppc64@0.28.0':
+    resolution: {integrity: sha512-bc0FE9wWeC0WBm49IQMPSPILRocGTQt3j5KPCA8os6VprfuJ7KD+5PzESSrJ6GmPIPJK965ZJHTUlSA6GNYEhg==}
     engines: {node: '>=18'}
     cpu: [ppc64]
     os: [linux]
@@ -236,8 +323,20 @@ packages:
     cpu: [riscv64]
     os: [linux]
 
+  '@esbuild/linux-riscv64@0.28.0':
+    resolution: {integrity: sha512-SQPZOwoTTT/HXFXQJG/vBX8sOFagGqvZyXcgLA3NhIqcBv1BJU1d46c0rGcrij2B56Z2rNiSLaZOYW5cUk7yLQ==}
+    engines: {node: '>=18'}
+    cpu: [riscv64]
+    os: [linux]
+
   '@esbuild/linux-s390x@0.27.0':
     resolution: {integrity: sha512-hPlRWR4eIDDEci953RI1BLZitgi5uqcsjKMxwYfmi4LcwyWo2IcRP+lThVnKjNtk90pLS8nKdroXYOqW+QQH+w==}
+    engines: {node: '>=18'}
+    cpu: [s390x]
+    os: [linux]
+
+  '@esbuild/linux-s390x@0.28.0':
+    resolution: {integrity: sha512-SCfR0HN8CEEjnYnySJTd2cw0k9OHB/YFzt5zgJEwa+wL/T/raGWYMBqwDNAC6dqFKmJYZoQBRfHjgwLHGSrn3Q==}
     engines: {node: '>=18'}
     cpu: [s390x]
     os: [linux]
@@ -248,8 +347,20 @@ packages:
     cpu: [x64]
     os: [linux]
 
+  '@esbuild/linux-x64@0.28.0':
+    resolution: {integrity: sha512-us0dSb9iFxIi8srnpl931Nvs65it/Jd2a2K3qs7fz2WfGPHqzfzZTfec7oxZJRNPXPnNYZtanmRc4AL/JwVzHQ==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [linux]
+
   '@esbuild/netbsd-arm64@0.27.0':
     resolution: {integrity: sha512-6m0sfQfxfQfy1qRuecMkJlf1cIzTOgyaeXaiVaaki8/v+WB+U4hc6ik15ZW6TAllRlg/WuQXxWj1jx6C+dfy3w==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [netbsd]
+
+  '@esbuild/netbsd-arm64@0.28.0':
+    resolution: {integrity: sha512-CR/RYotgtCKwtftMwJlUU7xCVNg3lMYZ0RzTmAHSfLCXw3NtZtNpswLEj/Kkf6kEL3Gw+BpOekRX0BYCtklhUw==}
     engines: {node: '>=18'}
     cpu: [arm64]
     os: [netbsd]
@@ -260,8 +371,20 @@ packages:
     cpu: [x64]
     os: [netbsd]
 
+  '@esbuild/netbsd-x64@0.28.0':
+    resolution: {integrity: sha512-nU1yhmYutL+fQ71Kxnhg8uEOdC0pwEW9entHykTgEbna2pw2dkbFSMeqjjyHZoCmt8SBkOSvV+yNmm94aUrrqw==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [netbsd]
+
   '@esbuild/openbsd-arm64@0.27.0':
     resolution: {integrity: sha512-fWgqR8uNbCQ/GGv0yhzttj6sU/9Z5/Sv/VGU3F5OuXK6J6SlriONKrQ7tNlwBrJZXRYk5jUhuWvF7GYzGguBZQ==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [openbsd]
+
+  '@esbuild/openbsd-arm64@0.28.0':
+    resolution: {integrity: sha512-cXb5vApOsRsxsEl4mcZ1XY3D4DzcoMxR/nnc4IyqYs0rTI8ZKmW6kyyg+11Z8yvgMfAEldKzP7AdP64HnSC/6g==}
     engines: {node: '>=18'}
     cpu: [arm64]
     os: [openbsd]
@@ -272,8 +395,20 @@ packages:
     cpu: [x64]
     os: [openbsd]
 
+  '@esbuild/openbsd-x64@0.28.0':
+    resolution: {integrity: sha512-8wZM2qqtv9UP3mzy7HiGYNH/zjTA355mpeuA+859TyR+e+Tc08IHYpLJuMsfpDJwoLo1ikIJI8jC3GFjnRClzA==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [openbsd]
+
   '@esbuild/openharmony-arm64@0.27.0':
     resolution: {integrity: sha512-nyvsBccxNAsNYz2jVFYwEGuRRomqZ149A39SHWk4hV0jWxKM0hjBPm3AmdxcbHiFLbBSwG6SbpIcUbXjgyECfA==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [openharmony]
+
+  '@esbuild/openharmony-arm64@0.28.0':
+    resolution: {integrity: sha512-FLGfyizszcef5C3YtoyQDACyg95+dndv79i2EekILBofh5wpCa1KuBqOWKrEHZg3zrL3t5ouE5jgr94vA+Wb2w==}
     engines: {node: '>=18'}
     cpu: [arm64]
     os: [openharmony]
@@ -284,8 +419,20 @@ packages:
     cpu: [x64]
     os: [sunos]
 
+  '@esbuild/sunos-x64@0.28.0':
+    resolution: {integrity: sha512-1ZgjUoEdHZZl/YlV76TSCz9Hqj9h9YmMGAgAPYd+q4SicWNX3G5GCyx9uhQWSLcbvPW8Ni7lj4gDa1T40akdlw==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [sunos]
+
   '@esbuild/win32-arm64@0.27.0':
     resolution: {integrity: sha512-W1eyGNi6d+8kOmZIwi/EDjrL9nxQIQ0MiGqe/AWc6+IaHloxHSGoeRgDRKHFISThLmsewZ5nHFvGFWdBYlgKPg==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [win32]
+
+  '@esbuild/win32-arm64@0.28.0':
+    resolution: {integrity: sha512-Q9StnDmQ/enxnpxCCLSg0oo4+34B9TdXpuyPeTedN/6+iXBJ4J+zwfQI28u/Jl40nOYAxGoNi7mFP40RUtkmUA==}
     engines: {node: '>=18'}
     cpu: [arm64]
     os: [win32]
@@ -296,8 +443,20 @@ packages:
     cpu: [ia32]
     os: [win32]
 
+  '@esbuild/win32-ia32@0.28.0':
+    resolution: {integrity: sha512-zF3ag/gfiCe6U2iczcRzSYJKH1DCI+ByzSENHlM2FcDbEeo5Zd2C86Aq0tKUYAJJ1obRP84ymxIAksZUcdztHA==}
+    engines: {node: '>=18'}
+    cpu: [ia32]
+    os: [win32]
+
   '@esbuild/win32-x64@0.27.0':
     resolution: {integrity: sha512-aIitBcjQeyOhMTImhLZmtxfdOcuNRpwlPNmlFKPcHQYPhEssw75Cl1TSXJXpMkzaua9FUetx/4OQKq7eJul5Cg==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [win32]
+
+  '@esbuild/win32-x64@0.28.0':
+    resolution: {integrity: sha512-pEl1bO9mfAmIC+tW5btTmrKaujg3zGtUmWNdCw/xs70FBjwAL3o9OEKNHvNmnyylD6ubxUERiEhdsL0xBQ9efw==}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [win32]
@@ -1154,6 +1313,11 @@ packages:
     engines: {node: '>=18'}
     hasBin: true
 
+  esbuild@0.28.0:
+    resolution: {integrity: sha512-sNR9MHpXSUV/XB4zmsFKN+QgVG82Cc7+/aaxJ8Adi8hyOac+EXptIp45QBPaVyX3N70664wRbTcLTOemCAnyqw==}
+    engines: {node: '>=18'}
+    hasBin: true
+
   escalade@3.2.0:
     resolution: {integrity: sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==}
     engines: {node: '>=6'}
@@ -1332,6 +1496,11 @@ packages:
   for-each@0.3.5:
     resolution: {integrity: sha512-dKx12eRCVIzqCxFGplyFKJMPvLEWgmNtUrpTiJIR5u97zEhRG8ySrtboPHZXx7daLxQVrl643cTzbab2tkQjxg==}
     engines: {node: '>= 0.4'}
+
+  fsevents@2.3.3:
+    resolution: {integrity: sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==}
+    engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
+    os: [darwin]
 
   function-bind@1.1.2:
     resolution: {integrity: sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==}
@@ -2140,6 +2309,11 @@ packages:
   tslib@2.8.1:
     resolution: {integrity: sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==}
 
+  tsx@4.22.1:
+    resolution: {integrity: sha512-TvncJykhxAzFCk0VQZKBTClall4Pm7qXDSodb6uxi8QFa8X8mT6ABjxxsQ2opDRYxG7AzcRWXaFtruz5HJKuWg==}
+    engines: {node: '>=18.0.0'}
+    hasBin: true
+
   type-check@0.4.0:
     resolution: {integrity: sha512-XleUoc9uwGXqjWwXaUTZAmzMcFZ5858QA2vvx1Ur5xIcixXIP+8LnFDgRplU30us6teqdlskFfu+ae4K79Ooew==}
     engines: {node: '>= 0.8.0'}
@@ -2376,79 +2550,157 @@ snapshots:
   '@esbuild/aix-ppc64@0.27.0':
     optional: true
 
+  '@esbuild/aix-ppc64@0.28.0':
+    optional: true
+
   '@esbuild/android-arm64@0.27.0':
+    optional: true
+
+  '@esbuild/android-arm64@0.28.0':
     optional: true
 
   '@esbuild/android-arm@0.27.0':
     optional: true
 
+  '@esbuild/android-arm@0.28.0':
+    optional: true
+
   '@esbuild/android-x64@0.27.0':
+    optional: true
+
+  '@esbuild/android-x64@0.28.0':
     optional: true
 
   '@esbuild/darwin-arm64@0.27.0':
     optional: true
 
+  '@esbuild/darwin-arm64@0.28.0':
+    optional: true
+
   '@esbuild/darwin-x64@0.27.0':
+    optional: true
+
+  '@esbuild/darwin-x64@0.28.0':
     optional: true
 
   '@esbuild/freebsd-arm64@0.27.0':
     optional: true
 
+  '@esbuild/freebsd-arm64@0.28.0':
+    optional: true
+
   '@esbuild/freebsd-x64@0.27.0':
+    optional: true
+
+  '@esbuild/freebsd-x64@0.28.0':
     optional: true
 
   '@esbuild/linux-arm64@0.27.0':
     optional: true
 
+  '@esbuild/linux-arm64@0.28.0':
+    optional: true
+
   '@esbuild/linux-arm@0.27.0':
+    optional: true
+
+  '@esbuild/linux-arm@0.28.0':
     optional: true
 
   '@esbuild/linux-ia32@0.27.0':
     optional: true
 
+  '@esbuild/linux-ia32@0.28.0':
+    optional: true
+
   '@esbuild/linux-loong64@0.27.0':
+    optional: true
+
+  '@esbuild/linux-loong64@0.28.0':
     optional: true
 
   '@esbuild/linux-mips64el@0.27.0':
     optional: true
 
+  '@esbuild/linux-mips64el@0.28.0':
+    optional: true
+
   '@esbuild/linux-ppc64@0.27.0':
+    optional: true
+
+  '@esbuild/linux-ppc64@0.28.0':
     optional: true
 
   '@esbuild/linux-riscv64@0.27.0':
     optional: true
 
+  '@esbuild/linux-riscv64@0.28.0':
+    optional: true
+
   '@esbuild/linux-s390x@0.27.0':
+    optional: true
+
+  '@esbuild/linux-s390x@0.28.0':
     optional: true
 
   '@esbuild/linux-x64@0.27.0':
     optional: true
 
+  '@esbuild/linux-x64@0.28.0':
+    optional: true
+
   '@esbuild/netbsd-arm64@0.27.0':
+    optional: true
+
+  '@esbuild/netbsd-arm64@0.28.0':
     optional: true
 
   '@esbuild/netbsd-x64@0.27.0':
     optional: true
 
+  '@esbuild/netbsd-x64@0.28.0':
+    optional: true
+
   '@esbuild/openbsd-arm64@0.27.0':
+    optional: true
+
+  '@esbuild/openbsd-arm64@0.28.0':
     optional: true
 
   '@esbuild/openbsd-x64@0.27.0':
     optional: true
 
+  '@esbuild/openbsd-x64@0.28.0':
+    optional: true
+
   '@esbuild/openharmony-arm64@0.27.0':
+    optional: true
+
+  '@esbuild/openharmony-arm64@0.28.0':
     optional: true
 
   '@esbuild/sunos-x64@0.27.0':
     optional: true
 
+  '@esbuild/sunos-x64@0.28.0':
+    optional: true
+
   '@esbuild/win32-arm64@0.27.0':
+    optional: true
+
+  '@esbuild/win32-arm64@0.28.0':
     optional: true
 
   '@esbuild/win32-ia32@0.27.0':
     optional: true
 
+  '@esbuild/win32-ia32@0.28.0':
+    optional: true
+
   '@esbuild/win32-x64@0.27.0':
+    optional: true
+
+  '@esbuild/win32-x64@0.28.0':
     optional: true
 
   '@eslint-community/eslint-utils@4.9.1(eslint@9.39.4(jiti@2.6.1))':
@@ -3325,6 +3577,35 @@ snapshots:
       '@esbuild/win32-ia32': 0.27.0
       '@esbuild/win32-x64': 0.27.0
 
+  esbuild@0.28.0:
+    optionalDependencies:
+      '@esbuild/aix-ppc64': 0.28.0
+      '@esbuild/android-arm': 0.28.0
+      '@esbuild/android-arm64': 0.28.0
+      '@esbuild/android-x64': 0.28.0
+      '@esbuild/darwin-arm64': 0.28.0
+      '@esbuild/darwin-x64': 0.28.0
+      '@esbuild/freebsd-arm64': 0.28.0
+      '@esbuild/freebsd-x64': 0.28.0
+      '@esbuild/linux-arm': 0.28.0
+      '@esbuild/linux-arm64': 0.28.0
+      '@esbuild/linux-ia32': 0.28.0
+      '@esbuild/linux-loong64': 0.28.0
+      '@esbuild/linux-mips64el': 0.28.0
+      '@esbuild/linux-ppc64': 0.28.0
+      '@esbuild/linux-riscv64': 0.28.0
+      '@esbuild/linux-s390x': 0.28.0
+      '@esbuild/linux-x64': 0.28.0
+      '@esbuild/netbsd-arm64': 0.28.0
+      '@esbuild/netbsd-x64': 0.28.0
+      '@esbuild/openbsd-arm64': 0.28.0
+      '@esbuild/openbsd-x64': 0.28.0
+      '@esbuild/openharmony-arm64': 0.28.0
+      '@esbuild/sunos-x64': 0.28.0
+      '@esbuild/win32-arm64': 0.28.0
+      '@esbuild/win32-ia32': 0.28.0
+      '@esbuild/win32-x64': 0.28.0
+
   escalade@3.2.0: {}
 
   escape-string-regexp@4.0.0: {}
@@ -3581,6 +3862,9 @@ snapshots:
   for-each@0.3.5:
     dependencies:
       is-callable: 1.2.7
+
+  fsevents@2.3.3:
+    optional: true
 
   function-bind@1.1.2: {}
 
@@ -4444,6 +4728,12 @@ snapshots:
       strip-bom: 3.0.0
 
   tslib@2.8.1: {}
+
+  tsx@4.22.1:
+    dependencies:
+      esbuild: 0.28.0
+    optionalDependencies:
+      fsevents: 2.3.3
 
   type-check@0.4.0:
     dependencies:

--- a/tests/backend/profile-foundation.test.ts
+++ b/tests/backend/profile-foundation.test.ts
@@ -1,0 +1,136 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+
+import {
+  createProfileSlugBase,
+  createProfileSlugCandidate,
+  normalizeProfileSlugInput,
+  PROFILE_SLUG_MAX_LENGTH,
+  toProfileSlug,
+  validateProfileSlug,
+} from "../../convex/_profileSlugs";
+import { canEditProfileField, canReadProfile } from "../../convex/_profilePermissions";
+import {
+  canTransitionProfileClaimState,
+  getProfileTrustLabel,
+  requireProfileClaimStateTransition,
+} from "../../convex/_profileStates";
+
+describe("profile slug helpers", () => {
+  it("normalizes display text into strict ASCII slug candidates", () => {
+    assert.equal(
+      normalizeProfileSlugInput(" DJ Celine & Friends!! "),
+      "dj-celine-and-friends",
+    );
+  });
+
+  it("validates canonical slug rules", () => {
+    assert.deepEqual(validateProfileSlug("dj-celine"), {
+      ok: true,
+      slug: "dj-celine",
+    });
+    assert.deepEqual(validateProfileSlug("DJ-Celine"), {
+      ok: false,
+      reason: "invalid_format",
+    });
+    assert.deepEqual(validateProfileSlug("dj--celine"), {
+      ok: false,
+      reason: "invalid_format",
+    });
+    assert.deepEqual(validateProfileSlug("admin"), {
+      ok: false,
+      reason: "reserved",
+    });
+  });
+
+  it("turns freeform input into a valid custom slug result", () => {
+    assert.deepEqual(toProfileSlug("DJ Celine"), {
+      ok: true,
+      slug: "dj-celine",
+    });
+  });
+
+  it("generates safe bases for short, reserved, empty, and long inputs", () => {
+    assert.equal(createProfileSlugBase("dj"), "dj-profile");
+    assert.equal(createProfileSlugBase("admin"), "admin-profile");
+    assert.equal(createProfileSlugBase("!!!"), "profile-page");
+
+    const longBase = createProfileSlugBase("a".repeat(PROFILE_SLUG_MAX_LENGTH + 20));
+    assert.equal(longBase.length, PROFILE_SLUG_MAX_LENGTH);
+    assert.equal(validateProfileSlug(longBase).ok, true);
+  });
+
+  it("keeps numeric retry candidates inside the maximum length", () => {
+    const base = "a".repeat(PROFILE_SLUG_MAX_LENGTH);
+    const candidate = createProfileSlugCandidate(base, 12);
+
+    assert.equal(candidate.length, PROFILE_SLUG_MAX_LENGTH);
+    assert.equal(candidate.endsWith("-12"), true);
+  });
+});
+
+describe("profile permission helpers", () => {
+  const publishedUnclaimedPerson = {
+    claimState: "unclaimed",
+    profileType: "person",
+    publicationState: "published",
+  } as const;
+
+  const privateUnclaimedPerson = {
+    ...publishedUnclaimedPerson,
+    publicationState: "draft_private",
+  } as const;
+
+  const privateClaimedPerson = {
+    ...privateUnclaimedPerson,
+    claimState: "claimed_unverified",
+  } as const;
+
+  it("gates public reads by publication state", () => {
+    assert.equal(canReadProfile("public", publishedUnclaimedPerson), true);
+    assert.equal(canReadProfile("public", privateUnclaimedPerson), false);
+    assert.equal(canReadProfile("claimed_owner", privateClaimedPerson), true);
+    assert.equal(canReadProfile("moderator", privateUnclaimedPerson), true);
+  });
+
+  it("requires read access before edit access", () => {
+    assert.equal(
+      canEditProfileField("community_submitter", privateUnclaimedPerson, "displayName"),
+      false,
+    );
+    assert.equal(
+      canEditProfileField("community_submitter", publishedUnclaimedPerson, "displayName"),
+      true,
+    );
+  });
+
+  it("blocks incompatible type-specific fields and custom slug submission", () => {
+    assert.equal(
+      canEditProfileField("community_submitter", publishedUnclaimedPerson, "community"),
+      false,
+    );
+    assert.equal(canEditProfileField("community_submitter", publishedUnclaimedPerson, "slug"), false);
+  });
+});
+
+describe("profile claim-state helpers", () => {
+  it("maps trust labels from claim state and creation source", () => {
+    assert.equal(getProfileTrustLabel("unclaimed", "community"), "community_submitted");
+    assert.equal(getProfileTrustLabel("unclaimed", "self"), "unclaimed");
+    assert.equal(getProfileTrustLabel("claimed_unverified", "community"), "claimed_unverified");
+    assert.equal(getProfileTrustLabel("claimed_verified", "community"), "claimed_verified");
+  });
+
+  it("allows only real forward claim-state transitions", () => {
+    assert.equal(canTransitionProfileClaimState("unclaimed", "claimed_unverified"), true);
+    assert.equal(canTransitionProfileClaimState("unclaimed", "claimed_verified"), true);
+    assert.equal(canTransitionProfileClaimState("claimed_unverified", "claimed_verified"), true);
+    assert.equal(canTransitionProfileClaimState("unclaimed", "unclaimed"), false);
+    assert.equal(canTransitionProfileClaimState("claimed_verified", "claimed_unverified"), false);
+  });
+
+  it("throws for invalid claim-state transitions", () => {
+    assert.throws(() => requireProfileClaimStateTransition("unclaimed", "unclaimed"));
+    assert.throws(() => requireProfileClaimStateTransition("claimed_verified", "unclaimed"));
+  });
+});


### PR DESCRIPTION
## Summary
- add global profile slugs with strict validation/generation helpers and a `by_slug` lookup index
- convert `profiles` to a discriminated person/community schema with flexible type-aware fields
- add permission, claim-state, and trust-label helper contracts without public write mutations
- document slug, type-aware, permission, and claim-state behavior for follow-on work

## Validation
- `pnpm verify`

Closes #10
Closes #11
Closes #12
Closes #13