### PR TITLE
Add Playwright public screenshot preview

### DIFF
--- a/.github/workflows/baseline-checks.yml
+++ b/.github/workflows/baseline-checks.yml
@@ -146,7 +146,6 @@ jobs:
     if: github.event_name == 'pull_request'
     runs-on: ubuntu-latest
     timeout-minutes: 20
-    continue-on-error: true
     permissions:
       contents: read
       issues: write
@@ -174,7 +173,6 @@ jobs:
 
       - name: Capture public route screenshots
         id: visual
-        continue-on-error: true
         run: pnpm test:e2e:visual
 
       - name: Write visual summary
@@ -205,7 +203,7 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: playwright-public-preview
-          if-no-files-found: ignore
+          if-no-files-found: error
           retention-days: 7
           path: |
             apps/web/playwright-report
@@ -244,7 +242,7 @@ jobs:
               "- `/p/playwright-dj-aurora`",
               "- `/c/playwright-afterglow-social`",
               "",
-              "This job is advisory while VRDex UI baselines are still settling.",
+              "This job is required for PR checks; pixel diff baselines are not enabled yet.",
             ].join("\n");
 
             const { data: comments } = await github.rest.issues.listComments({

--- a/.github/workflows/baseline-checks.yml
+++ b/.github/workflows/baseline-checks.yml
@@ -140,3 +140,130 @@ jobs:
 
       - name: Run build
         run: pnpm build:web
+
+  playwright-public-preview:
+    name: Playwright Public Preview
+    if: github.event_name == 'pull_request'
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    continue-on-error: true
+    permissions:
+      contents: read
+      issues: write
+      pull-requests: write
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: pnpm
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Install Playwright Chromium
+        working-directory: apps/web
+        run: pnpm exec playwright install --with-deps chromium
+
+      - name: Capture public route screenshots
+        id: visual
+        continue-on-error: true
+        run: pnpm test:e2e:visual
+
+      - name: Write visual summary
+        if: always()
+        env:
+          VISUAL_OUTCOME: ${{ steps.visual.outcome }}
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+        run: |
+          mkdir -p apps/web/playwright-artifacts
+          cat > apps/web/playwright-artifacts/visual-summary.md <<EOF
+          ## Playwright public screenshot preview
+
+          Outcome: ${VISUAL_OUTCOME}
+
+          Captured routes:
+          - /
+          - /submit
+          - /server-status
+          - /p/playwright-dj-aurora
+          - /c/playwright-afterglow-social
+
+          Run: ${RUN_URL}
+          EOF
+
+      - name: Upload Playwright artifacts
+        id: upload
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: playwright-public-preview
+          if-no-files-found: ignore
+          retention-days: 7
+          path: |
+            apps/web/playwright-report
+            apps/web/test-results
+            apps/web/playwright-artifacts
+
+      - name: Comment with screenshot artifact
+        if: always() && github.event.pull_request.head.repo.fork == false
+        uses: actions/github-script@v7
+        env:
+          VISUAL_OUTCOME: ${{ steps.visual.outcome }}
+          ARTIFACT_URL: ${{ steps.upload.outputs.artifact-url }}
+        with:
+          script: |
+            const marker = "<!-- vrdex-playwright-public-preview -->";
+            const owner = context.repo.owner;
+            const repo = context.repo.repo;
+            const issue_number = context.issue.number;
+            const runUrl = `https://github.com/${owner}/${repo}/actions/runs/${context.runId}`;
+            const artifactUrl = process.env.ARTIFACT_URL || "";
+            const outcome = process.env.VISUAL_OUTCOME || "unknown";
+            const artifactLine = artifactUrl
+              ? `Artifact: [playwright-public-preview](${artifactUrl})`
+              : "Artifact: not generated";
+            const body = [
+              marker,
+              "## Playwright Public Screenshot Preview",
+              `Outcome: ${outcome}`,
+              `Run: ${runUrl}`,
+              artifactLine,
+              "",
+              "Captured routes:",
+              "- `/`",
+              "- `/submit`",
+              "- `/server-status`",
+              "- `/p/playwright-dj-aurora`",
+              "- `/c/playwright-afterglow-social`",
+              "",
+              "This job is advisory while VRDex UI baselines are still settling.",
+            ].join("\n");
+
+            const { data: comments } = await github.rest.issues.listComments({
+              owner,
+              repo,
+              issue_number,
+              per_page: 100,
+            });
+            const existing = comments.find(
+              (comment) => comment.user?.type === "Bot" && comment.body?.includes(marker),
+            );
+
+            if (existing) {
+              await github.rest.issues.updateComment({
+                owner,
+                repo,
+                comment_id: existing.id,
+                body,
+              });
+            } else {
+              await github.rest.issues.createComment({ owner, repo, issue_number, body });
+            }

--- a/.github/workflows/baseline-checks.yml
+++ b/.github/workflows/baseline-checks.yml
@@ -144,6 +144,7 @@ jobs:
   playwright-public-preview:
     name: Playwright Public Preview
     if: github.event_name == 'pull_request'
+    needs: [build-web]
     runs-on: ubuntu-latest
     timeout-minutes: 20
     permissions:
@@ -245,12 +246,20 @@ jobs:
               "This job is required for PR checks; pixel diff baselines are not enabled yet.",
             ].join("\n");
 
-            const { data: comments } = await github.rest.issues.listComments({
-              owner,
-              repo,
-              issue_number,
-              per_page: 100,
-            });
+            let comments = [];
+            let page = 1;
+            while (true) {
+              const { data: pageComments } = await github.rest.issues.listComments({
+                owner,
+                repo,
+                issue_number,
+                per_page: 100,
+                page,
+              });
+              comments = comments.concat(pageComments);
+              if (pageComments.length < 100) break;
+              page++;
+            }
             const existing = comments.find(
               (comment) => comment.user?.type === "Bot" && comment.body?.includes(marker),
             );

--- a/.gitignore
+++ b/.gitignore
@@ -4,5 +4,8 @@ node_modules/
 .husky/_/
 .convex-home/
 .convex-tmp/
+apps/web/playwright-report/
+apps/web/playwright-artifacts/
+apps/web/test-results/
 .env
 .env.local

--- a/README.md
+++ b/README.md
@@ -28,6 +28,8 @@
 - lint the web app: `pnpm lint:web`
 - typecheck the web app: `pnpm typecheck:web`
 - build the web app: `pnpm build:web`
+- smoke public routes with Playwright: `pnpm test:e2e`
+- capture public route screenshots with Playwright: `pnpm test:e2e:visual`
 - run the baseline local verification pass: `pnpm verify`
 
 Convex writes repo-root deployment configuration to `.env.local` during local setup and keeps anonymous local state under `.convex-home/` plus `.convex-tmp/`. Keep all of those uncommitted. The committed `convex/_generated/` files are expected to stay clean after `pnpm check:backend:generated`.
@@ -41,6 +43,8 @@ The first product schema table is `profiles`, covering the shared durable record
 Profile slug, permission, claim-state, and community-submission contracts live in `docs/backend/profile-slugs.md`, `docs/backend/profile-access-and-claims.md`, and `docs/backend/community-submissions.md`.
 
 Community-submitted public profiles now start at `/submit`. Person profile pages render at `/p/<slug>` and community profile pages render at `/c/<slug>`.
+
+Playwright screenshot preview captures desktop and mobile screenshots for `/`, `/submit`, `/server-status`, and deterministic public profile fixtures. See `docs/testing/playwright-visual-preview.md`.
 
 `pnpm verify` is the full repo verification pass and now includes the local Convex bootstrap checks. If you are iterating on the web app only, use `pnpm verify:web` for the lighter web-only path.
 

--- a/apps/web/e2e/public-routes.smoke.spec.ts
+++ b/apps/web/e2e/public-routes.smoke.spec.ts
@@ -1,0 +1,10 @@
+import { test } from "@playwright/test";
+
+import { capturedRoutes } from "./public-routes";
+
+for (const route of capturedRoutes) {
+  test(`${route.name} renders`, async ({ page }) => {
+    await page.goto(route.path);
+    await route.expectPage(page);
+  });
+}

--- a/apps/web/e2e/public-routes.ts
+++ b/apps/web/e2e/public-routes.ts
@@ -103,6 +103,10 @@ export async function prepareVisualPage(page: Page) {
         }
       }
 
+      if (!document.body) {
+        return;
+      }
+
       for (const element of Array.from(document.body.children)) {
         const box = element.getBoundingClientRect();
         const style = window.getComputedStyle(element);

--- a/apps/web/e2e/public-routes.ts
+++ b/apps/web/e2e/public-routes.ts
@@ -1,0 +1,209 @@
+import { expect, type Page, type TestInfo } from "@playwright/test";
+import { mkdirSync } from "node:fs";
+import path from "node:path";
+
+const screenshotDir = path.join(process.cwd(), "playwright-artifacts", "screenshots");
+
+export const visualProfilePaths = {
+  personPath: "/p/playwright-dj-aurora",
+  communityPath: "/c/playwright-afterglow-social",
+} as const;
+
+export type CapturedRoute = {
+  name: string;
+  path: string;
+  expectPage: (page: Page) => Promise<void>;
+};
+
+export async function prepareVisualPage(page: Page) {
+  await page.addInitScript(() => {
+    const fixedNow = Date.UTC(2025, 0, 1, 12, 0, 0);
+    const NativeDate = Date;
+
+    class FixedDate extends NativeDate {
+      constructor();
+      constructor(value: string | number | Date);
+      constructor(
+        year: number,
+        monthIndex: number,
+        date?: number,
+        hours?: number,
+        minutes?: number,
+        seconds?: number,
+        ms?: number,
+      );
+      constructor(
+        ...args:
+          | []
+          | [string | number | Date]
+          | [number, number, number?, number?, number?, number?, number?]
+      ) {
+        if (args.length === 0) {
+          super(fixedNow);
+          return;
+        }
+
+        super(...(args as [number, number, number?, number?, number?, number?, number?]));
+      }
+
+      static now() {
+        return fixedNow;
+      }
+    }
+
+    FixedDate.UTC = NativeDate.UTC;
+    FixedDate.parse = NativeDate.parse;
+    globalThis.Date = FixedDate as DateConstructor;
+
+    const style = document.createElement("style");
+    style.setAttribute("data-visual-test", "true");
+    style.textContent = `
+      *, *::before, *::after {
+        animation-duration: 0s !important;
+        animation-delay: 0s !important;
+        transition-duration: 0s !important;
+        transition-delay: 0s !important;
+        transition-property: none !important;
+      }
+      html {
+        scroll-behavior: auto !important;
+      }
+      body {
+        caret-color: transparent !important;
+      }
+      nextjs-portal,
+      [data-next-badge-root],
+      [data-nextjs-toast],
+      [data-nextjs-dialog-root],
+      [data-nextjs-dev-tools-button],
+      [aria-label*="Next.js"],
+      body > *:has([aria-label*="Next.js"]),
+      body > *:has([data-next-badge-root]),
+      body > *:has([data-nextjs-dev-tools-button]),
+      body > *:has(button[aria-label="Open issues overlay"]),
+      body > *:has(button[aria-label="Collapse issues badge"]) {
+        display: none !important;
+      }
+    `;
+    document.head.appendChild(style);
+
+    const removeDevIndicators = () => {
+      const directSelectors = [
+        "nextjs-portal",
+        "[data-next-badge-root]",
+        "[data-nextjs-dev-tools-button]",
+        'iframe[title*="Next"]',
+        'iframe[src*="next"]',
+        '[aria-label*="Next.js"]',
+      ];
+
+      for (const selector of directSelectors) {
+        for (const element of document.querySelectorAll(selector)) {
+          element.remove();
+        }
+      }
+
+      for (const element of Array.from(document.body.children)) {
+        const box = element.getBoundingClientRect();
+        const style = window.getComputedStyle(element);
+        const isBottomLeftDevBadge =
+          (style.position === "fixed" || style.position === "sticky" || element.tagName === "IFRAME") &&
+          box.left < 80 &&
+          window.innerHeight - box.bottom < 80 &&
+          box.width <= 96 &&
+          box.height <= 96;
+        const isSmallBottomLeftOverlay =
+          box.left < 96 &&
+          box.top > window.innerHeight - 140 &&
+          box.width <= 160 &&
+          box.height <= 160;
+
+        if (isBottomLeftDevBadge || isSmallBottomLeftOverlay) {
+          element.remove();
+        }
+      }
+    };
+
+    removeDevIndicators();
+    new MutationObserver(removeDevIndicators).observe(document.documentElement, {
+      childList: true,
+      subtree: true,
+    });
+    window.setInterval(removeDevIndicators, 250);
+  });
+
+  await page.emulateMedia({ reducedMotion: "reduce" });
+}
+
+export async function waitForVisualReady(page: Page) {
+  await page.waitForLoadState("domcontentloaded");
+  await page.evaluate(async () => {
+    if (document.fonts?.ready) {
+      await document.fonts.ready;
+    }
+  });
+}
+
+export async function captureRouteScreenshot(page: Page, testInfo: TestInfo, name: string) {
+  await waitForVisualReady(page);
+
+  const projectPrefix = testInfo.project.name.replace(/[^a-z0-9]+/gi, "-").toLowerCase();
+  const fileName = `${projectPrefix}-${name}.png`;
+  const screenshotPath = path.join(screenshotDir, fileName);
+
+  mkdirSync(screenshotDir, { recursive: true });
+  await page.screenshot({ path: screenshotPath, fullPage: true });
+  await testInfo.attach(fileName, { path: screenshotPath, contentType: "image/png" });
+}
+
+export async function expectHomePage(page: Page) {
+  await expect(page.getByRole("heading", { name: /Profiles, communities/i })).toBeVisible();
+}
+
+export async function expectSubmitPage(page: Page) {
+  await expect(page.getByRole("heading", { name: /Add a missing VRChat scene profile/i })).toBeVisible();
+  await expect(page.getByRole("heading", { name: "Sign-in required" })).toBeVisible();
+}
+
+export async function expectServerStatusPage(page: Page) {
+  await expect(page.getByRole("heading", { name: /First server-side App Router read path/i })).toBeVisible();
+  await expect(page.getByText(/Server read reached Convex/i)).toBeVisible();
+}
+
+export async function expectPersonProfilePage(page: Page) {
+  await expect(page.getByRole("heading", { name: "DJ Aurora" })).toBeVisible();
+  await expect(page.getByText(/Community submitted/i)).toBeVisible();
+}
+
+export async function expectCommunityProfilePage(page: Page) {
+  await expect(page.getByRole("heading", { name: "Afterglow Social" })).toBeVisible();
+  await expect(page.getByText("Club night", { exact: true }).first()).toBeVisible();
+}
+
+export const capturedRoutes: CapturedRoute[] = [
+  {
+    name: "home",
+    path: "/",
+    expectPage: expectHomePage,
+  },
+  {
+    name: "submit",
+    path: "/submit",
+    expectPage: expectSubmitPage,
+  },
+  {
+    name: "server-status",
+    path: "/server-status",
+    expectPage: expectServerStatusPage,
+  },
+  {
+    name: "person-profile",
+    path: visualProfilePaths.personPath,
+    expectPage: expectPersonProfilePage,
+  },
+  {
+    name: "community-profile",
+    path: visualProfilePaths.communityPath,
+    expectPage: expectCommunityProfilePage,
+  },
+];

--- a/apps/web/e2e/public-routes.visual.spec.ts
+++ b/apps/web/e2e/public-routes.visual.spec.ts
@@ -1,0 +1,19 @@
+import { test } from "@playwright/test";
+
+import {
+  capturedRoutes,
+  captureRouteScreenshot,
+  prepareVisualPage,
+} from "./public-routes";
+
+test.beforeEach(async ({ page }) => {
+  await prepareVisualPage(page);
+});
+
+for (const route of capturedRoutes) {
+  test(`${route.name} @visual`, async ({ page }, testInfo) => {
+    await page.goto(route.path);
+    await route.expectPage(page);
+    await captureRouteScreenshot(page, testInfo, route.name);
+  });
+}

--- a/apps/web/next.config.ts
+++ b/apps/web/next.config.ts
@@ -1,7 +1,7 @@
 import type { NextConfig } from "next";
 
 const nextConfig: NextConfig = {
-  /* config options here */
+  devIndicators: process.env.VRDEX_ENABLE_PLAYWRIGHT_FIXTURES === "true" ? false : undefined,
 };
 
 export default nextConfig;

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -7,6 +7,8 @@
     "build": "next build",
     "start": "next start",
     "lint": "eslint",
+    "test:e2e": "playwright test --grep-invert @visual",
+    "test:e2e:visual": "playwright test --grep @visual",
     "typecheck": "next typegen && node ./scripts/ensure-next-type-stubs.mjs && tsc --noEmit --incremental false"
   },
   "dependencies": {
@@ -16,6 +18,7 @@
     "react-dom": "19.2.3"
   },
   "devDependencies": {
+    "@playwright/test": "^1.60.0",
     "@tailwindcss/postcss": "^4",
     "@types/node": "^22",
     "@types/react": "^19",

--- a/apps/web/playwright.config.mjs
+++ b/apps/web/playwright.config.mjs
@@ -15,7 +15,6 @@ const skipConvexServer = process.env.PLAYWRIGHT_SKIP_CONVEX_DEV === "true";
 
 process.env.CONVEX_URL = convexUrl;
 process.env.NEXT_PUBLIC_CONVEX_URL = convexUrl;
-process.env.VRDEX_ENABLE_PLAYWRIGHT_FIXTURES = "true";
 
 const sharedEnv = {
   ...process.env,
@@ -27,6 +26,7 @@ const sharedEnv = {
 export default defineConfig({
   testDir: "./e2e",
   timeout: 30_000,
+  retries: process.env.CI ? 1 : 0,
   fullyParallel: true,
   reporter: [["list"], ["html", { open: "never", outputFolder: "playwright-report" }]],
   use: {

--- a/apps/web/playwright.config.mjs
+++ b/apps/web/playwright.config.mjs
@@ -1,0 +1,78 @@
+import { defineConfig, devices } from "@playwright/test";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const configDir = path.dirname(fileURLToPath(import.meta.url));
+const repoRoot = path.resolve(configDir, "..", "..");
+const parsedPort = Number(process.env.PLAYWRIGHT_TEST_PORT);
+const port = Number.isFinite(parsedPort) ? parsedPort : 3002;
+const baseURL = `http://127.0.0.1:${port}`;
+const convexUrl = process.env.PLAYWRIGHT_CONVEX_URL ?? "http://127.0.0.1:3210";
+const convexPort = Number(new URL(convexUrl).port) || 3210;
+const reuseNextServer = process.env.PLAYWRIGHT_REUSE_SERVER === "true";
+const reuseConvexServer = process.env.PLAYWRIGHT_REUSE_CONVEX === "true";
+const skipConvexServer = process.env.PLAYWRIGHT_SKIP_CONVEX_DEV === "true";
+
+process.env.CONVEX_URL = convexUrl;
+process.env.NEXT_PUBLIC_CONVEX_URL = convexUrl;
+process.env.VRDEX_ENABLE_PLAYWRIGHT_FIXTURES = "true";
+
+const sharedEnv = {
+  ...process.env,
+  CONVEX_URL: convexUrl,
+  NEXT_PUBLIC_CONVEX_URL: convexUrl,
+  VRDEX_ENABLE_PLAYWRIGHT_FIXTURES: "true",
+};
+
+export default defineConfig({
+  testDir: "./e2e",
+  timeout: 30_000,
+  fullyParallel: true,
+  reporter: [["list"], ["html", { open: "never", outputFolder: "playwright-report" }]],
+  use: {
+    baseURL,
+    trace: "on-first-retry",
+    screenshot: "only-on-failure",
+    video: "retain-on-failure",
+    locale: "en-US",
+    timezoneId: "UTC",
+  },
+  webServer: [
+    ...(skipConvexServer
+      ? []
+      : [
+          {
+            command: "node scripts/run-convex-local.mjs dev --local",
+            cwd: repoRoot,
+            port: convexPort,
+            reuseExistingServer: reuseConvexServer,
+            timeout: 300_000,
+            env: sharedEnv,
+          },
+        ]),
+    {
+      command: `node node_modules/next/dist/bin/next dev --hostname 127.0.0.1 --port ${port}`,
+      cwd: configDir,
+      url: baseURL,
+      reuseExistingServer: reuseNextServer,
+      timeout: 300_000,
+      env: sharedEnv,
+    },
+  ],
+  projects: [
+    {
+      name: "desktop-chromium",
+      use: {
+        ...devices["Desktop Chrome"],
+        viewport: { width: 1280, height: 900 },
+        deviceScaleFactor: 1,
+      },
+    },
+    {
+      name: "mobile-chromium",
+      use: {
+        ...devices["Pixel 7"],
+      },
+    },
+  ],
+});

--- a/apps/web/src/convex/playwright-fixtures.ts
+++ b/apps/web/src/convex/playwright-fixtures.ts
@@ -1,0 +1,67 @@
+import type { PublicProfile } from "@/app/_components/profile-public-page";
+
+const personSlug = "playwright-dj-aurora";
+const communitySlug = "playwright-afterglow-social";
+
+const personProfile: PublicProfile = {
+  profileType: "person",
+  slug: personSlug,
+  displayName: "DJ Aurora",
+  aliases: ["Aurora", "Auralight"],
+  tags: ["DJ", "Melodic House", "EU"],
+  headline: "Melodic house sets for late-night VRChat floors.",
+  bio: "DJ Aurora is a fixture profile for VRDex visual review. It gives the public person page stable content, trust-state copy, tags, aliases, and owner-authored text to render.",
+  about: "This profile is returned only when Playwright fixture mode is explicitly enabled for the Next.js server.",
+  region: "EU",
+  timezone: "UTC+1",
+  trustLabel: "community_submitted",
+  person: {
+    pronouns: "she/they",
+    roleTags: ["DJ", "Producer", "Host"],
+  },
+};
+
+const communityProfile: PublicProfile = {
+  profileType: "community",
+  slug: communitySlug,
+  displayName: "Afterglow Social",
+  aliases: ["Afterglow", "AGS"],
+  tags: ["Club", "Weekend", "Friends"],
+  headline: "A warm VRChat club night for music-first communities.",
+  bio: "Afterglow Social is a deterministic fixture community used by Playwright to keep the public community profile route visible in PR screenshot artifacts.",
+  about: "The seeded page exercises community subtype, category tags, aliases, and the community-submitted trust label without depending on production data.",
+  region: "Global",
+  timezone: "UTC",
+  trustLabel: "community_submitted",
+  community: {
+    subtype: "Club night",
+    categoryTags: ["Music", "Dancing", "Social"],
+  },
+};
+
+export function getPlaywrightPublicProfileFixture(
+  slug: string,
+  profileType: "person" | "community",
+): PublicProfile | null {
+  if (
+    process.env.NODE_ENV === "production" ||
+    process.env.VRDEX_ENABLE_PLAYWRIGHT_FIXTURES !== "true"
+  ) {
+    return null;
+  }
+
+  if (profileType === "person" && slug === personSlug) {
+    return personProfile;
+  }
+
+  if (profileType === "community" && slug === communitySlug) {
+    return communityProfile;
+  }
+
+  return null;
+}
+
+export const playwrightPublicProfilePaths = {
+  personPath: `/p/${personSlug}`,
+  communityPath: `/c/${communitySlug}`,
+};

--- a/apps/web/src/convex/server.ts
+++ b/apps/web/src/convex/server.ts
@@ -1,5 +1,6 @@
 import { fetchQuery } from "convex/nextjs";
 import { api } from "@convex-generated-api";
+import { getPlaywrightPublicProfileFixture } from "./playwright-fixtures";
 
 type PublicProfileType = "person" | "community";
 
@@ -27,6 +28,15 @@ export async function fetchBackendStatus() {
 }
 
 export async function fetchPublicProfileBySlug(slug: string, profileType: PublicProfileType) {
+  const fixtureProfile = getPlaywrightPublicProfileFixture(slug, profileType);
+
+  if (fixtureProfile !== null) {
+    return {
+      kind: "live" as const,
+      profile: fixtureProfile,
+    };
+  }
+
   if (!process.env.NEXT_PUBLIC_CONVEX_URL) {
     return { kind: "missing-url" as const };
   }

--- a/docs/testing/playwright-visual-preview.md
+++ b/docs/testing/playwright-visual-preview.md
@@ -22,10 +22,10 @@ Screenshots are written to `apps/web/playwright-artifacts/screenshots` and attac
 
 ## CI behavior
 
-The `Playwright Public Preview` job is advisory for now. On pull requests it:
+The `Playwright Public Preview` job is required on pull requests. It:
 
 - runs `pnpm test:e2e:visual`
-- uploads `apps/web/playwright-report`, `apps/web/test-results`, and `apps/web/playwright-artifacts`
+- uploads `apps/web/playwright-report`, `apps/web/test-results`, and `apps/web/playwright-artifacts`, failing if no artifact files are found
 - posts or updates a PR comment with the run outcome and artifact link
 
-This intentionally captures review evidence without blocking early UI iteration on pixel diffs. Once the public UI stabilizes, the next step is to add committed baseline snapshots and a separate diff gate.
+This blocks PRs when public route rendering or screenshot capture fails. Pixel review is still artifact-based until committed baseline snapshots and a separate diff gate are added.

--- a/docs/testing/playwright-visual-preview.md
+++ b/docs/testing/playwright-visual-preview.md
@@ -1,0 +1,31 @@
+# Playwright visual preview
+
+Playwright gives VRDex a lightweight screenshot loop before full visual regression gates exist.
+
+## Local commands
+
+- Smoke public routes: `pnpm test:e2e`
+- Capture public route screenshots: `pnpm test:e2e:visual`
+- Reuse already-running local services: set `PLAYWRIGHT_REUSE_SERVER=true` and `PLAYWRIGHT_REUSE_CONVEX=true`
+
+The visual suite starts a local Convex backend and Next dev server by default. Profile screenshots use deterministic Next-server fixtures when `VRDEX_ENABLE_PLAYWRIGHT_FIXTURES=true`, while `/server-status` still exercises the real local Convex health query. Fixture profiles are disabled when `NODE_ENV=production`.
+
+## Captured routes
+
+- `/`
+- `/submit`
+- `/server-status`
+- `/p/playwright-dj-aurora`
+- `/c/playwright-afterglow-social`
+
+Screenshots are written to `apps/web/playwright-artifacts/screenshots` and attached to the Playwright report.
+
+## CI behavior
+
+The `Playwright Public Preview` job is advisory for now. On pull requests it:
+
+- runs `pnpm test:e2e:visual`
+- uploads `apps/web/playwright-report`, `apps/web/test-results`, and `apps/web/playwright-artifacts`
+- posts or updates a PR comment with the run outcome and artifact link
+
+This intentionally captures review evidence without blocking early UI iteration on pixel diffs. Once the public UI stabilizes, the next step is to add committed baseline snapshots and a separate diff gate.

--- a/package.json
+++ b/package.json
@@ -8,6 +8,8 @@
     "dev:web": "pnpm --filter web dev",
     "build:web": "pnpm --filter web build",
     "lint:web": "pnpm --filter web lint",
+    "test:e2e": "pnpm --filter web test:e2e",
+    "test:e2e:visual": "pnpm --filter web test:e2e:visual",
     "test:backend": "node --import tsx --test tests/backend/**/*.test.ts",
     "typecheck:backend": "tsc --noEmit --project convex/tsconfig.json",
     "run:backend:health:local": "pnpm verify:backend:local",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -34,7 +34,7 @@ importers:
         version: 1.32.0(react@19.2.3)
       next:
         specifier: 16.1.6
-        version: 16.1.6(@babel/core@7.29.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
+        version: 16.1.6(@babel/core@7.29.0)(@playwright/test@1.60.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
       react:
         specifier: 19.2.3
         version: 19.2.3
@@ -42,6 +42,9 @@ importers:
         specifier: 19.2.3
         version: 19.2.3(react@19.2.3)
     devDependencies:
+      '@playwright/test':
+        specifier: ^1.60.0
+        version: 1.60.0
       '@tailwindcss/postcss':
         specifier: ^4
         version: 4.2.1
@@ -740,6 +743,11 @@ packages:
   '@nolyfill/is-core-module@1.0.39':
     resolution: {integrity: sha512-nn5ozdjYQpUCZlWGuxcJY/KpxkWQs4DcbMCmKojjyrYDEAGy4Ce19NN4v5MduafTwJlbKc99UA8YhSVqq9yPZA==}
     engines: {node: '>=12.4.0'}
+
+  '@playwright/test@1.60.0':
+    resolution: {integrity: sha512-O71yZIbAh/PxDMNGns37GHBIfrVkEVyn+AXyIa5dOTfb4/xNvRWV+Vv/NMbNCtODB/pO7vLlF2OTmMVLhmr7Ag==}
+    engines: {node: '>=18'}
+    hasBin: true
 
   '@rtsao/scc@1.1.0':
     resolution: {integrity: sha512-zt6OdqaDoOnJ1ZYsCYGt9YmWzDXl4vQdKTyJev62gFhRGKdx7mcT54V9KIjg+d2wi9EXsPvAPKe7i7WjfVWB8g==}
@@ -1497,6 +1505,11 @@ packages:
     resolution: {integrity: sha512-dKx12eRCVIzqCxFGplyFKJMPvLEWgmNtUrpTiJIR5u97zEhRG8ySrtboPHZXx7daLxQVrl643cTzbab2tkQjxg==}
     engines: {node: '>= 0.4'}
 
+  fsevents@2.3.2:
+    resolution: {integrity: sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==}
+    engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
+    os: [darwin]
+
   fsevents@2.3.3:
     resolution: {integrity: sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==}
     engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
@@ -2040,6 +2053,16 @@ packages:
   picomatch@4.0.3:
     resolution: {integrity: sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==}
     engines: {node: '>=12'}
+
+  playwright-core@1.60.0:
+    resolution: {integrity: sha512-9bW6zvX/m0lEbgTKJ6YppOKx8H3VOPBMOCFh2irXFOT4BbHgrx5hPjwJYLT40Lu+4qtD36qKc/Hn56StUW57IA==}
+    engines: {node: '>=18'}
+    hasBin: true
+
+  playwright@1.60.0:
+    resolution: {integrity: sha512-hheHdokM8cdqCb0lcE3s+zT4t4W+vvjpGxsZlDnikarzx8tSzMebh3UiFtgqwFwnTnjYQcsyMF8ei2mCO/tpeA==}
+    engines: {node: '>=18'}
+    hasBin: true
 
   possible-typed-array-names@1.1.0:
     resolution: {integrity: sha512-/+5VFTchJDoVj3bhoqi6UeymcD00DAwb1nJwamzPvHEszJ4FpF6SNNbUbOS8yI56qHzdV8eK0qEfOSiodkTdxg==}
@@ -2926,6 +2949,10 @@ snapshots:
       fastq: 1.20.1
 
   '@nolyfill/is-core-module@1.0.39': {}
+
+  '@playwright/test@1.60.0':
+    dependencies:
+      playwright: 1.60.0
 
   '@rtsao/scc@1.1.0': {}
 
@@ -3863,6 +3890,9 @@ snapshots:
     dependencies:
       is-callable: 1.2.7
 
+  fsevents@2.3.2:
+    optional: true
+
   fsevents@2.3.3:
     optional: true
 
@@ -4276,7 +4306,7 @@ snapshots:
 
   natural-compare@1.4.0: {}
 
-  next@16.1.6(@babel/core@7.29.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3):
+  next@16.1.6(@babel/core@7.29.0)(@playwright/test@1.60.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3):
     dependencies:
       '@next/env': 16.1.6
       '@swc/helpers': 0.5.15
@@ -4295,6 +4325,7 @@ snapshots:
       '@next/swc-linux-x64-musl': 16.1.6
       '@next/swc-win32-arm64-msvc': 16.1.6
       '@next/swc-win32-x64-msvc': 16.1.6
+      '@playwright/test': 1.60.0
       sharp: 0.34.5
     transitivePeerDependencies:
       - '@babel/core'
@@ -4393,6 +4424,14 @@ snapshots:
   picomatch@2.3.1: {}
 
   picomatch@4.0.3: {}
+
+  playwright-core@1.60.0: {}
+
+  playwright@1.60.0:
+    dependencies:
+      playwright-core: 1.60.0
+    optionalDependencies:
+      fsevents: 2.3.2
 
   possible-typed-array-names@1.1.0: {}
 


### PR DESCRIPTION
## What changed
- Added Playwright smoke and visual screenshot suites for public VRDex routes.
- Added deterministic non-production profile fixtures for screenshot-only public pages.
- Added a required PR screenshot artifact workflow and testing docs.

## Why
Issue #71 needs a first loop for seeing public UI changes in PRs before committed visual baselines exist.

## Testing
- pnpm lint:web
- pnpm typecheck:web
- pnpm typecheck:backend
- pnpm test:e2e
- pnpm test:e2e:visual
- pnpm verify

## Risk notes
- The Playwright preview workflow is PR-only and now blocks PRs if public route rendering, screenshot capture, or artifact upload fails.
- Pixel diff baselines are not enabled yet; screenshot review is artifact-based for this slice.
- Fixture profiles require VRDEX_ENABLE_PLAYWRIGHT_FIXTURES=true and are disabled when NODE_ENV=production.

Closes #71