### PR TITLE
Bootstrap Vercel preview deployment path

### DIFF
--- a/.github/workflows/baseline-checks.yml
+++ b/.github/workflows/baseline-checks.yml
@@ -192,6 +192,7 @@ jobs:
           - /
           - /submit
           - /server-status
+          - /deployment
           - /p/playwright-dj-aurora
           - /c/playwright-afterglow-social
 
@@ -240,10 +241,152 @@ jobs:
               "- `/`",
               "- `/submit`",
               "- `/server-status`",
+              "- `/deployment`",
               "- `/p/playwright-dj-aurora`",
               "- `/c/playwright-afterglow-social`",
               "",
               "This job is required for PR checks; pixel diff baselines are not enabled yet.",
+            ].join("\n");
+
+            let comments = [];
+            let page = 1;
+            while (true) {
+              const { data: pageComments } = await github.rest.issues.listComments({
+                owner,
+                repo,
+                issue_number,
+                per_page: 100,
+                page,
+              });
+              comments = comments.concat(pageComments);
+              if (pageComments.length < 100) break;
+              page++;
+            }
+            const existing = comments.find(
+              (comment) => comment.user?.type === "Bot" && comment.body?.includes(marker),
+            );
+
+            if (existing) {
+              await github.rest.issues.updateComment({
+                owner,
+                repo,
+                comment_id: existing.id,
+                body,
+              });
+            } else {
+              await github.rest.issues.createComment({ owner, repo, issue_number, body });
+            }
+
+  vercel-preview:
+    name: Vercel Preview
+    if: github.event_name == 'pull_request' && github.event.pull_request.head.repo.fork == false
+    needs: [playwright-public-preview]
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    permissions:
+      contents: read
+      issues: write
+      pull-requests: write
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: pnpm
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Check Vercel deployment secrets
+        id: gate
+        env:
+          VERCEL_TOKEN: ${{ secrets.VERCEL_TOKEN }}
+          VERCEL_ORG_ID: ${{ secrets.VERCEL_ORG_ID }}
+          VERCEL_PROJECT_ID: ${{ secrets.VERCEL_PROJECT_ID }}
+        run: |
+          if [ -z "$VERCEL_TOKEN" ] || [ -z "$VERCEL_ORG_ID" ] || [ -z "$VERCEL_PROJECT_ID" ]; then
+            echo "enabled=false" >> "$GITHUB_OUTPUT"
+            {
+              echo "## Vercel preview"
+              echo "Deployment skipped because one or more required secrets are missing."
+              echo ""
+              echo "Required repository secrets:"
+              echo "- VERCEL_TOKEN"
+              echo "- VERCEL_ORG_ID"
+              echo "- VERCEL_PROJECT_ID"
+            } >> "$GITHUB_STEP_SUMMARY"
+            exit 0
+          fi
+
+          echo "enabled=true" >> "$GITHUB_OUTPUT"
+
+      - name: Pull Vercel preview environment
+        if: steps.gate.outputs.enabled == 'true'
+        working-directory: apps/web
+        env:
+          VERCEL_TOKEN: ${{ secrets.VERCEL_TOKEN }}
+          VERCEL_ORG_ID: ${{ secrets.VERCEL_ORG_ID }}
+          VERCEL_PROJECT_ID: ${{ secrets.VERCEL_PROJECT_ID }}
+        run: pnpm dlx vercel@latest pull --yes --environment=preview --token "$VERCEL_TOKEN"
+
+      - name: Build Vercel preview output
+        if: steps.gate.outputs.enabled == 'true'
+        working-directory: apps/web
+        env:
+          VERCEL_TOKEN: ${{ secrets.VERCEL_TOKEN }}
+          VERCEL_ORG_ID: ${{ secrets.VERCEL_ORG_ID }}
+          VERCEL_PROJECT_ID: ${{ secrets.VERCEL_PROJECT_ID }}
+        run: pnpm dlx vercel@latest build --token "$VERCEL_TOKEN"
+
+      - name: Deploy Vercel preview output
+        id: deploy
+        if: steps.gate.outputs.enabled == 'true'
+        working-directory: apps/web
+        env:
+          VERCEL_TOKEN: ${{ secrets.VERCEL_TOKEN }}
+          VERCEL_ORG_ID: ${{ secrets.VERCEL_ORG_ID }}
+          VERCEL_PROJECT_ID: ${{ secrets.VERCEL_PROJECT_ID }}
+        run: |
+          set -euo pipefail
+          deployment_url=$(pnpm dlx vercel@latest deploy --prebuilt --token "$VERCEL_TOKEN" | tail -n 1)
+          if [ -z "$deployment_url" ]; then
+            echo "Vercel deployment did not return a URL." >&2
+            exit 1
+          fi
+
+          echo "url=$deployment_url" >> "$GITHUB_OUTPUT"
+          {
+            echo "## Vercel preview"
+            echo "Deployment: $deployment_url"
+            echo "Deployment check page: $deployment_url/deployment"
+          } >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Comment with Vercel preview URL
+        if: steps.gate.outputs.enabled == 'true'
+        uses: actions/github-script@v7
+        env:
+          DEPLOYMENT_URL: ${{ steps.deploy.outputs.url }}
+        with:
+          script: |
+            const marker = "<!-- vrdex-vercel-preview -->";
+            const owner = context.repo.owner;
+            const repo = context.repo.repo;
+            const issue_number = context.issue.number;
+            const deploymentUrl = process.env.DEPLOYMENT_URL;
+            const runUrl = `https://github.com/${owner}/${repo}/actions/runs/${context.runId}`;
+            const body = [
+              marker,
+              "## Vercel Preview Deployment",
+              `Preview: ${deploymentUrl}`,
+              `Deployment check: ${deploymentUrl}/deployment`,
+              `Run: ${runUrl}`,
             ].join("\n");
 
             let comments = [];

--- a/.github/workflows/baseline-checks.yml
+++ b/.github/workflows/baseline-checks.yml
@@ -292,18 +292,6 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
-      - name: Setup pnpm
-        uses: pnpm/action-setup@v4
-
-      - name: Setup Node.js
-        uses: actions/setup-node@v4
-        with:
-          node-version: 22
-          cache: pnpm
-
-      - name: Install dependencies
-        run: pnpm install --frozen-lockfile
-
       - name: Check Vercel deployment secrets
         id: gate
         env:
@@ -327,13 +315,28 @@ jobs:
 
           echo "enabled=true" >> "$GITHUB_OUTPUT"
 
+      - name: Setup pnpm
+        if: steps.gate.outputs.enabled == 'true'
+        uses: pnpm/action-setup@v4
+
+      - name: Setup Node.js
+        if: steps.gate.outputs.enabled == 'true'
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: pnpm
+
+      - name: Install dependencies
+        if: steps.gate.outputs.enabled == 'true'
+        run: pnpm install --frozen-lockfile
+
       - name: Pull Vercel preview environment
         if: steps.gate.outputs.enabled == 'true'
         env:
           VERCEL_TOKEN: ${{ secrets.VERCEL_TOKEN }}
           VERCEL_ORG_ID: ${{ secrets.VERCEL_ORG_ID }}
           VERCEL_PROJECT_ID: ${{ secrets.VERCEL_PROJECT_ID }}
-        run: pnpm dlx vercel@latest pull --yes --environment=preview --token "$VERCEL_TOKEN"
+        run: pnpm dlx vercel@54.4.1 pull --yes --environment=preview --token "$VERCEL_TOKEN"
 
       - name: Build Vercel preview output
         if: steps.gate.outputs.enabled == 'true'
@@ -341,7 +344,7 @@ jobs:
           VERCEL_TOKEN: ${{ secrets.VERCEL_TOKEN }}
           VERCEL_ORG_ID: ${{ secrets.VERCEL_ORG_ID }}
           VERCEL_PROJECT_ID: ${{ secrets.VERCEL_PROJECT_ID }}
-        run: pnpm dlx vercel@latest build --target=preview --token "$VERCEL_TOKEN"
+        run: pnpm dlx vercel@54.4.1 build --target=preview --token "$VERCEL_TOKEN"
 
       - name: Deploy Vercel preview output
         id: deploy
@@ -352,7 +355,7 @@ jobs:
           VERCEL_PROJECT_ID: ${{ secrets.VERCEL_PROJECT_ID }}
         run: |
           set -euo pipefail
-          deployment_url=$(pnpm dlx vercel@latest deploy --prebuilt --target=preview --token "$VERCEL_TOKEN" | tail -n 1)
+          deployment_url=$(pnpm dlx vercel@54.4.1 deploy --prebuilt --target=preview --token "$VERCEL_TOKEN" | tail -n 1)
           if [ -z "$deployment_url" ]; then
             echo "Vercel deployment did not return a URL." >&2
             exit 1

--- a/.github/workflows/baseline-checks.yml
+++ b/.github/workflows/baseline-checks.yml
@@ -329,7 +329,6 @@ jobs:
 
       - name: Pull Vercel preview environment
         if: steps.gate.outputs.enabled == 'true'
-        working-directory: apps/web
         env:
           VERCEL_TOKEN: ${{ secrets.VERCEL_TOKEN }}
           VERCEL_ORG_ID: ${{ secrets.VERCEL_ORG_ID }}
@@ -338,24 +337,22 @@ jobs:
 
       - name: Build Vercel preview output
         if: steps.gate.outputs.enabled == 'true'
-        working-directory: apps/web
         env:
           VERCEL_TOKEN: ${{ secrets.VERCEL_TOKEN }}
           VERCEL_ORG_ID: ${{ secrets.VERCEL_ORG_ID }}
           VERCEL_PROJECT_ID: ${{ secrets.VERCEL_PROJECT_ID }}
-        run: pnpm dlx vercel@latest build --token "$VERCEL_TOKEN"
+        run: pnpm dlx vercel@latest build --target=preview --token "$VERCEL_TOKEN"
 
       - name: Deploy Vercel preview output
         id: deploy
         if: steps.gate.outputs.enabled == 'true'
-        working-directory: apps/web
         env:
           VERCEL_TOKEN: ${{ secrets.VERCEL_TOKEN }}
           VERCEL_ORG_ID: ${{ secrets.VERCEL_ORG_ID }}
           VERCEL_PROJECT_ID: ${{ secrets.VERCEL_PROJECT_ID }}
         run: |
           set -euo pipefail
-          deployment_url=$(pnpm dlx vercel@latest deploy --prebuilt --token "$VERCEL_TOKEN" | tail -n 1)
+          deployment_url=$(pnpm dlx vercel@latest deploy --prebuilt --target=preview --token "$VERCEL_TOKEN" | tail -n 1)
           if [ -z "$deployment_url" ]; then
             echo "Vercel deployment did not return a URL." >&2
             exit 1

--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,5 @@ apps/web/test-results/
 apps/web/.vercel/
 .env
 .env.local
+
+.vercel/

--- a/.gitignore
+++ b/.gitignore
@@ -7,5 +7,7 @@ node_modules/
 apps/web/playwright-report/
 apps/web/playwright-artifacts/
 apps/web/test-results/
+.vercel/
+apps/web/.vercel/
 .env
 .env.local

--- a/.gitignore
+++ b/.gitignore
@@ -11,5 +11,3 @@ apps/web/test-results/
 apps/web/.vercel/
 .env
 .env.local
-
-.vercel/

--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@
 - lint the web app: `pnpm lint:web`
 - typecheck the web app: `pnpm typecheck:web`
 - build the web app: `pnpm build:web`
+- run the Vercel web build validation path: `pnpm build:web:vercel`
 - smoke public routes with Playwright: `pnpm test:e2e`
 - capture public route screenshots with Playwright: `pnpm test:e2e:visual`
 - run the baseline local verification pass: `pnpm verify`
@@ -45,6 +46,8 @@ Profile slug, permission, claim-state, and community-submission contracts live i
 Community-submitted public profiles now start at `/submit`. Person profile pages render at `/p/<slug>` and community profile pages render at `/c/<slug>`.
 
 Playwright screenshot preview captures desktop and mobile screenshots for `/`, `/submit`, `/server-status`, and deterministic public profile fixtures. See `docs/testing/playwright-visual-preview.md`.
+
+The initial hosted preview path targets Vercel with `apps/web` as the project root. See `docs/deployment/vercel-preview.md`; the live deployment check page is `/deployment`.
 
 `pnpm verify` is the full repo verification pass and now includes the local Convex bootstrap checks. If you are iterating on the web app only, use `pnpm verify:web` for the lighter web-only path.
 

--- a/apps/web/.env.example
+++ b/apps/web/.env.example
@@ -1,0 +1,8 @@
+# Optional for shell-only previews. Set to a Convex deployment URL for live backend reads.
+NEXT_PUBLIC_CONVEX_URL=
+
+# Keep false until web auth is implemented.
+NEXT_PUBLIC_VRDEX_SUBMISSIONS_AUTH_READY=false
+
+# Set true in Vercel if previews must fail when NEXT_PUBLIC_CONVEX_URL is missing.
+VRDEX_REQUIRE_CONVEX_URL=false

--- a/apps/web/.gitignore
+++ b/apps/web/.gitignore
@@ -32,6 +32,7 @@ yarn-error.log*
 
 # env files (can opt-in for committing if needed)
 .env*
+!.env.example
 
 # vercel
 .vercel

--- a/apps/web/README.md
+++ b/apps/web/README.md
@@ -19,6 +19,7 @@ Useful follow-up commands:
 pnpm lint:web
 pnpm typecheck:web
 pnpm build:web
+pnpm build:web:vercel
 ```
 
 ## Notes
@@ -29,4 +30,5 @@ pnpm build:web
 - styling baseline: `Tailwind CSS`
 - the app mounts a Convex provider baseline and the homepage performs a live `health:status` query when `apps/web/.env.local` contains `NEXT_PUBLIC_CONVEX_URL`; the local Convex bootstrap now mirrors that value automatically from the repo-root Convex bootstrap output
 - the server-side Convex baseline lives at `/server-status` and uses `fetchQuery` from a server component without replacing the reactive client pattern on `/`
-- auth, billing, and deployment wiring still belong to follow-on issues
+- the hosted deployment baseline lives at `/deployment` and reports Vercel metadata, backend URL readiness, and the current submission auth gate
+- auth and billing wiring still belong to follow-on issues

--- a/apps/web/e2e/public-routes.ts
+++ b/apps/web/e2e/public-routes.ts
@@ -174,6 +174,11 @@ export async function expectServerStatusPage(page: Page) {
   await expect(page.getByText(/Server read reached Convex/i)).toBeVisible();
 }
 
+export async function expectDeploymentPage(page: Page) {
+  await expect(page.getByRole("heading", { name: /Initial Vercel deployment baseline/i })).toBeVisible();
+  await expect(page.getByText(/Deployment facts/i)).toBeVisible();
+}
+
 export async function expectPersonProfilePage(page: Page) {
   await expect(page.getByRole("heading", { name: "DJ Aurora" })).toBeVisible();
   await expect(page.getByText(/Community submitted/i)).toBeVisible();
@@ -199,6 +204,11 @@ export const capturedRoutes: CapturedRoute[] = [
     name: "server-status",
     path: "/server-status",
     expectPage: expectServerStatusPage,
+  },
+  {
+    name: "deployment",
+    path: "/deployment",
+    expectPage: expectDeploymentPage,
   },
   {
     name: "person-profile",

--- a/apps/web/next.config.ts
+++ b/apps/web/next.config.ts
@@ -1,7 +1,16 @@
+import path from "node:path";
+import { fileURLToPath } from "node:url";
 import type { NextConfig } from "next";
+
+const appRoot = path.dirname(fileURLToPath(import.meta.url));
+const workspaceRoot = path.resolve(appRoot, "../..");
 
 const nextConfig: NextConfig = {
   devIndicators: process.env.VRDEX_ENABLE_PLAYWRIGHT_FIXTURES === "true" ? false : undefined,
+  outputFileTracingRoot: workspaceRoot,
+  turbopack: {
+    root: workspaceRoot,
+  },
 };
 
 export default nextConfig;

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -2,9 +2,14 @@
   "name": "web",
   "version": "0.1.0",
   "private": true,
+  "engines": {
+    "node": ">=22 <25"
+  },
   "scripts": {
     "dev": "next dev",
     "build": "next build",
+    "build:vercel": "pnpm check:vercel-env && next build",
+    "check:vercel-env": "node ./scripts/check-vercel-env.mjs",
     "start": "next start",
     "lint": "eslint",
     "test:e2e": "playwright test --grep-invert @visual",

--- a/apps/web/scripts/check-vercel-env.mjs
+++ b/apps/web/scripts/check-vercel-env.mjs
@@ -1,0 +1,59 @@
+const isVercel = process.env.VERCEL === "1" || process.env.VERCEL === "true";
+const convexUrl = process.env.NEXT_PUBLIC_CONVEX_URL;
+const requireConvexUrl = process.env.VRDEX_REQUIRE_CONVEX_URL === "true";
+
+const errors = [];
+const warnings = [];
+
+function parseUrl(name, value) {
+  try {
+    const url = new URL(value);
+
+    if (!["http:", "https:"].includes(url.protocol)) {
+      errors.push(`${name} must use http or https.`);
+    }
+
+    return url;
+  } catch {
+    errors.push(`${name} must be a valid URL.`);
+    return null;
+  }
+}
+
+if (process.env.VRDEX_ENABLE_PLAYWRIGHT_FIXTURES === "true") {
+  errors.push("VRDEX_ENABLE_PLAYWRIGHT_FIXTURES must not be enabled for Vercel builds.");
+}
+
+if (process.env.NEXT_PUBLIC_VRDEX_SUBMISSIONS_AUTH_READY === "true") {
+  errors.push("NEXT_PUBLIC_VRDEX_SUBMISSIONS_AUTH_READY must stay false until web auth is wired.");
+}
+
+if (convexUrl) {
+  const parsedConvexUrl = parseUrl("NEXT_PUBLIC_CONVEX_URL", convexUrl);
+
+  if (isVercel && parsedConvexUrl) {
+    const host = parsedConvexUrl.hostname.toLowerCase();
+    if (host === "localhost" || host === "127.0.0.1" || host.endsWith(".local")) {
+      errors.push("NEXT_PUBLIC_CONVEX_URL must not point at a local backend for Vercel builds.");
+    }
+  }
+} else if (requireConvexUrl) {
+  errors.push("NEXT_PUBLIC_CONVEX_URL is required because VRDEX_REQUIRE_CONVEX_URL=true.");
+} else if (isVercel) {
+  warnings.push("NEXT_PUBLIC_CONVEX_URL is not set; the hosted app will render missing-backend states.");
+}
+
+for (const warning of warnings) {
+  console.warn(`[vercel-env] ${warning}`);
+}
+
+if (errors.length > 0) {
+  console.error("[vercel-env] Vercel environment validation failed:");
+  for (const error of errors) {
+    console.error(`- ${error}`);
+  }
+  process.exit(1);
+}
+
+const deploymentLabel = isVercel ? `Vercel ${process.env.VERCEL_ENV ?? "unknown"}` : "local";
+console.log(`[vercel-env] ${deploymentLabel} environment accepted.`);

--- a/apps/web/src/app/deployment/page.tsx
+++ b/apps/web/src/app/deployment/page.tsx
@@ -1,0 +1,136 @@
+import Link from "next/link";
+
+export const dynamic = "force-dynamic";
+
+type DeploymentItem = {
+  label: string;
+  value: string;
+  tone?: "ok" | "warn" | "muted";
+};
+
+function displayValue(value: string | undefined, fallback = "not configured") {
+  return value && value.trim().length > 0 ? value : fallback;
+}
+
+function shortSha(value: string | undefined) {
+  return value ? value.slice(0, 7) : "not available";
+}
+
+function DeploymentRow({ item }: { item: DeploymentItem }) {
+  const toneClass =
+    item.tone === "ok"
+      ? "text-emerald-700"
+      : item.tone === "warn"
+        ? "text-accent-strong"
+        : "text-foreground";
+
+  return (
+    <div className="flex flex-col gap-2 border-b border-border py-4 last:border-0 sm:flex-row sm:items-start sm:justify-between">
+      <dt className="text-sm text-muted">{item.label}</dt>
+      <dd className={`break-all text-sm font-medium ${toneClass}`}>{item.value}</dd>
+    </div>
+  );
+}
+
+export default function DeploymentPage() {
+  const deploymentUrl = process.env.VERCEL_URL ? `https://${process.env.VERCEL_URL}` : null;
+  const convexConfigured = Boolean(process.env.NEXT_PUBLIC_CONVEX_URL);
+  const submissionsAuthReady = process.env.NEXT_PUBLIC_VRDEX_SUBMISSIONS_AUTH_READY === "true";
+
+  const deploymentItems: DeploymentItem[] = [
+    {
+      label: "Runtime",
+      value: process.env.VERCEL === "1" ? "Vercel" : "local development",
+      tone: process.env.VERCEL === "1" ? "ok" : "muted",
+    },
+    {
+      label: "Environment",
+      value: displayValue(process.env.VERCEL_ENV, "local"),
+    },
+    {
+      label: "Deployment URL",
+      value: deploymentUrl ?? "not on Vercel",
+      tone: deploymentUrl ? "ok" : "muted",
+    },
+    {
+      label: "Git branch",
+      value: displayValue(process.env.VERCEL_GIT_COMMIT_REF),
+    },
+    {
+      label: "Git commit",
+      value: shortSha(process.env.VERCEL_GIT_COMMIT_SHA),
+    },
+    {
+      label: "Convex URL",
+      value: convexConfigured ? "configured" : "not configured",
+      tone: convexConfigured ? "ok" : "warn",
+    },
+    {
+      label: "Submission auth gate",
+      value: submissionsAuthReady ? "unlocked" : "locked until auth issue lands",
+      tone: submissionsAuthReady ? "warn" : "ok",
+    },
+  ];
+
+  return (
+    <main className="min-h-screen px-6 py-10 text-foreground sm:px-10 lg:px-16">
+      <div className="mx-auto flex w-full max-w-5xl flex-col gap-8">
+        <nav className="flex items-center justify-between gap-4 text-sm">
+          <Link className="font-mono uppercase tracking-[0.28em]" href="/">
+            VRDex
+          </Link>
+          <Link
+            className="rounded-full border border-border bg-surface px-4 py-2 font-medium"
+            href="/server-status"
+          >
+            Server status
+          </Link>
+        </nav>
+
+        <section className="rounded-[2rem] border border-border bg-surface px-6 py-8 shadow-[0_24px_80px_rgba(64,40,24,0.12)] sm:px-8 lg:px-10">
+          <p className="font-mono text-xs uppercase tracking-[0.3em] text-muted">
+            Hosted readiness
+          </p>
+          <div className="mt-5 max-w-3xl space-y-4">
+            <h1 className="text-4xl leading-none font-semibold tracking-[-0.04em] sm:text-6xl">
+              Initial Vercel deployment baseline
+            </h1>
+            <p className="text-base leading-7 text-muted sm:text-lg">
+              This page exists so every preview has a simple live URL that reports whether it is running on Vercel, which commit is deployed, and whether the backend URL is configured.
+            </p>
+          </div>
+        </section>
+
+        <section className="grid gap-5 lg:grid-cols-[1.1fr_0.9fr]">
+          <div className="rounded-[1.5rem] border border-border bg-surface px-5 py-6">
+            <p className="font-mono text-xs uppercase tracking-[0.28em] text-muted">
+              Deployment facts
+            </p>
+            <dl className="mt-4">
+              {deploymentItems.map((item) => (
+                <DeploymentRow item={item} key={item.label} />
+              ))}
+            </dl>
+          </div>
+
+          <aside className="rounded-[1.5rem] border border-border bg-surface-strong px-5 py-6">
+            <p className="font-mono text-xs uppercase tracking-[0.28em] text-muted">
+              First-live checklist
+            </p>
+            <div className="mt-4 space-y-4 text-sm leading-7 text-muted">
+              <p>
+                A shell-only Vercel preview may run without Convex. Set <code className="font-mono text-[0.95em]">NEXT_PUBLIC_CONVEX_URL</code> to a hosted Convex deployment when you want the homepage and server baseline to read live backend data.
+              </p>
+              <p>
+                Keep <code className="font-mono text-[0.95em]">NEXT_PUBLIC_VRDEX_SUBMISSIONS_AUTH_READY</code> false until the auth foundation lands, so <code className="font-mono text-[0.95em]">/submit</code> stays locked for public visitors.
+              </p>
+              <p>
+                See <code className="font-mono text-[0.95em]">docs/deployment/vercel-preview.md</code> for the repository and Vercel setup contract.
+              </p>
+            </div>
+          </aside>
+        </section>
+      </div>
+    </main>
+  );
+}

--- a/apps/web/src/app/page.tsx
+++ b/apps/web/src/app/page.tsx
@@ -37,6 +37,12 @@ export default function Home() {
                 >
                   Server-side baseline
                 </Link>
+                <Link
+                  className="inline-flex items-center justify-center rounded-full border border-border bg-surface-strong px-5 py-3 text-sm font-medium transition hover:-translate-y-0.5"
+                  href="/deployment"
+                >
+                  Deployment check
+                </Link>
                 <a
                   className="inline-flex items-center justify-center rounded-full border border-border bg-surface-strong px-5 py-3 text-sm font-medium transition hover:-translate-y-0.5"
                   href="https://www.convex.dev/"
@@ -71,7 +77,7 @@ export default function Home() {
                 </div>
                 <div className="flex items-start justify-between gap-4">
                   <dt className="text-muted">Next issues</dt>
-                  <dd className="text-right font-medium">#25, #31, #33</dd>
+                  <dd className="text-right font-medium">#18, #59, #61</dd>
                 </div>
               </dl>
 
@@ -113,15 +119,15 @@ export default function Home() {
 
           <article className="rounded-[1.5rem] border border-border bg-surface px-5 py-6">
             <p className="font-mono text-xs uppercase tracking-[0.28em] text-muted">
-              Immediate follow-on
+              Initial readiness
             </p>
             <h2 className="mt-4 text-2xl font-semibold tracking-[-0.03em]">
-              Search and trust labels
+              Hosted previews first
             </h2>
             <p className="mt-3 text-sm leading-7 text-muted">
-              The next meaningful milestone is turning these public records into
-              searchable cards with consistent community-submitted and unverified
-              labeling across discovery surfaces.
+              Before deeper product discovery, VRDex needs live Vercel previews,
+              auth wiring, and stronger validation loops so each change can be
+              checked outside a local workstation.
             </p>
           </article>
         </section>

--- a/apps/web/vercel.json
+++ b/apps/web/vercel.json
@@ -1,0 +1,5 @@
+{
+  "$schema": "https://openapi.vercel.sh/vercel.json",
+  "framework": "nextjs",
+  "buildCommand": "pnpm build:vercel"
+}

--- a/docs/README.md
+++ b/docs/README.md
@@ -7,6 +7,7 @@ This repo keeps durable markdown under `docs/` so product, engineering, and agen
 - `docs/planning/README.md` - product, architecture, roadmap, backlog, and issue-planning docs
 - `docs/agentic/README.md` - software-factory, onboarding, control-loop, and agent workflow docs
 - `docs/backend/convex-bootstrap.md` - backend bootstrap workflow and structure notes
+- `docs/deployment/vercel-preview.md` - initial Vercel hosted-preview setup and validation path
 
 Useful starting points:
 

--- a/docs/deployment/vercel-preview.md
+++ b/docs/deployment/vercel-preview.md
@@ -15,6 +15,8 @@ Create or import one Vercel project for this repository:
 
 `apps/web/vercel.json` records the app-local build command so dashboard and CLI builds use the same deployment validation step.
 
+Run Vercel CLI commands from the repository root once the project root directory is set to `apps/web`; running from `apps/web` will make Vercel resolve the app root twice.
+
 ## Repository secrets
 
 The PR workflow deploys a Vercel preview only when all three repository secrets exist:
@@ -34,6 +36,8 @@ Set these in the Vercel project as needed:
 - `NEXT_PUBLIC_VRDEX_SUBMISSIONS_AUTH_READY=false`: keep false or unset until web auth lands.
 
 Do not set `VRDEX_ENABLE_PLAYWRIGHT_FIXTURES` in Vercel. Fixture profiles are for Playwright-only local/CI preview screenshots and must not be exposed from hosted previews.
+
+Preview deployment protection must allow unauthenticated reads if the PR preview is meant to be reviewed outside the Vercel dashboard.
 
 ## Validation
 

--- a/docs/deployment/vercel-preview.md
+++ b/docs/deployment/vercel-preview.md
@@ -1,0 +1,59 @@
+# Vercel preview deployment
+
+This is the first hosted deployment path for `apps/web`. It is intentionally narrow: get a live Vercel URL for every pull request, keep unsafe public states locked, and leave production-hardening for later issues.
+
+## Vercel project
+
+Create or import one Vercel project for this repository:
+
+- repository: `BASIC-BIT/VRDex`
+- root directory: `apps/web`
+- framework preset: `Next.js`
+- build command: `pnpm build:vercel`
+- install command: Vercel default pnpm workspace install
+- output directory: Vercel default for Next.js
+
+`apps/web/vercel.json` records the app-local build command so dashboard and CLI builds use the same deployment validation step.
+
+## Repository secrets
+
+The PR workflow deploys a Vercel preview only when all three repository secrets exist:
+
+- `VERCEL_TOKEN`
+- `VERCEL_ORG_ID`
+- `VERCEL_PROJECT_ID`
+
+If any are missing, the `Vercel Preview` job passes and writes a step summary explaining that deployment is skipped. This keeps baseline CI green before the hosted project is linked, while making the missing live-deploy blocker explicit.
+
+## Web environment
+
+Set these in the Vercel project as needed:
+
+- `NEXT_PUBLIC_CONVEX_URL`: optional for a shell-only preview; set to the hosted Convex deployment URL for live backend reads.
+- `VRDEX_REQUIRE_CONVEX_URL=true`: optional; use when previews must fail instead of showing missing-backend states.
+- `NEXT_PUBLIC_VRDEX_SUBMISSIONS_AUTH_READY=false`: keep false or unset until web auth lands.
+
+Do not set `VRDEX_ENABLE_PLAYWRIGHT_FIXTURES` in Vercel. Fixture profiles are for Playwright-only local/CI preview screenshots and must not be exposed from hosted previews.
+
+## Validation
+
+The Vercel build runs `pnpm build:vercel`, which executes `apps/web/scripts/check-vercel-env.mjs` before `next build`.
+
+The validation fails when:
+
+- Playwright fixtures are enabled.
+- public submissions are marked auth-ready before auth exists.
+- `NEXT_PUBLIC_CONVEX_URL` is invalid.
+- `NEXT_PUBLIC_CONVEX_URL` points at localhost during a Vercel build.
+- `VRDEX_REQUIRE_CONVEX_URL=true` and `NEXT_PUBLIC_CONVEX_URL` is missing.
+
+## Live smoke check
+
+After a preview deployment, visit:
+
+- `/` for the public shell
+- `/deployment` for Vercel environment and commit metadata
+- `/server-status` for the server-side Convex read baseline
+- `/submit` to confirm the public write path remains locked until auth lands
+
+The PR workflow posts a `Vercel Preview Deployment` comment with both the preview URL and `/deployment` URL once Vercel secrets are configured.

--- a/docs/planning/engineering-strategy.md
+++ b/docs/planning/engineering-strategy.md
@@ -52,6 +52,7 @@ Current recommendation:
 - use local-development-friendly Convex setup first, then layer in frontend wiring, auth, billing, and production deployment posture through follow-on issues
 - once the local backend bootstrap is deterministic, include it in the baseline PR verification pass alongside the web checks
 - use one explicit server-side App Router baseline once client wiring is stable: `fetchQuery` for server-only reads, with `preloadQuery` deferred until a feature truly needs hydrated reactivity after server render
+- use Vercel previews as the first hosted validation path for the web app, with `apps/web` as the project root and `/deployment` as the live environment check page
 
 ## Monetization direction
 

--- a/docs/testing/playwright-visual-preview.md
+++ b/docs/testing/playwright-visual-preview.md
@@ -15,6 +15,7 @@ The visual suite starts a local Convex backend and Next dev server by default. P
 - `/`
 - `/submit`
 - `/server-status`
+- `/deployment`
 - `/p/playwright-dj-aurora`
 - `/c/playwright-afterglow-social`
 

--- a/package.json
+++ b/package.json
@@ -2,11 +2,16 @@
   "name": "vrdex",
   "private": true,
   "packageManager": "pnpm@10.15.1+sha512.34e538c329b5553014ca8e8f4535997f96180a1d0f614339357449935350d924e22f8614682191264ec33d1462ac21561aff97f6bb18065351c162c7e8f6de67",
+  "engines": {
+    "node": ">=22 <25"
+  },
   "scripts": {
     "bootstrap:backend:local": "pnpm verify:backend:local",
     "dev:backend:local": "node scripts/run-convex-local.mjs dev --local",
     "dev:web": "pnpm --filter web dev",
     "build:web": "pnpm --filter web build",
+    "build:web:vercel": "pnpm --filter web build:vercel",
+    "check:web:vercel-env": "pnpm --filter web check:vercel-env",
     "lint:web": "pnpm --filter web lint",
     "test:e2e": "pnpm --filter web test:e2e",
     "test:e2e:visual": "pnpm --filter web test:e2e:visual",


### PR DESCRIPTION
## What changed
- Added an app-local Vercel build path for `apps/web`, including environment validation and `vercel.json`.
- Added a `/deployment` page so hosted previews expose runtime, commit, backend URL, and auth-gate status.
- Added a PR Vercel Preview workflow job that deploys when Vercel repository secrets are configured, plus docs for setup.
- Configured the Vercel project for the `apps/web` monorepo root, public preview access, and hosted Convex preview env.
- Recycled Greptile feedback: removed duplicate `.vercel/`, pinned Vercel CLI to `54.4.1`, and moved the secrets gate before install work.

## Live preview
- Vercel GitHub preview: https://vr-dex-web-git-issue-56-vercel-preview-basicbit.vercel.app
- Verified routes: `/`, `/deployment`, `/server-status`, `/submit`.
- `/server-status` reaches hosted Convex through `fetchQuery(api.health.status)`.
- `/submit` remains locked behind the auth-ready gate.

## Testing
- `pnpm check:web:vercel-env`
- `pnpm lint:web`
- `pnpm typecheck:web`
- `pnpm typecheck:backend`
- `pnpm build:web:vercel`
- `pnpm test:e2e`
- `pnpm test:e2e:visual`
- `pnpm verify`
- `git diff --check`
- `pnpm dlx vercel@54.4.1 --version`
- PR checks green after `a7f4d88`.

## Deployment notes
- Vercel GitHub integration is connected and deploying PR previews automatically.
- `VERCEL_ORG_ID` and `VERCEL_PROJECT_ID` repository secrets are configured.
- `VERCEL_TOKEN` still needs a user-created token if we want the custom Actions fallback job to deploy and post its own `Vercel Preview Deployment` comment.
- `NEXT_PUBLIC_CONVEX_URL` is set to the hosted Convex deployment for Vercel preview and production.
- `NEXT_PUBLIC_VRDEX_SUBMISSIONS_AUTH_READY=false` keeps `/submit` locked until auth lands.
- `VRDEX_ENABLE_PLAYWRIGHT_FIXTURES` is not set in Vercel.

Closes #56
