### PR TITLE
Preserve repo OpenCode MCP config

### DIFF
--- a/.opencode/opencode.json
+++ b/.opencode/opencode.json
@@ -1,0 +1,79 @@
+{
+  "$schema": "https://opencode.ai/config.json",
+  "mcp": {
+    "playwright": {
+      "type": "local",
+      "command": ["npx", "-y", "@playwright/mcp@latest"],
+      "enabled": true
+    },
+    "vercel-vrdex": {
+      "type": "remote",
+      "url": "https://mcp.vercel.com",
+      "oauth": {},
+      "enabled": true
+    },
+    "convex": {
+      "type": "local",
+      "command": ["npx", "convex", "mcp", "start", "--project-dir", "."],
+      "enabled": true
+    },
+    "aws-docs": {
+      "type": "local",
+      "command": ["C:/Users/steve/.local/bin/uvx.exe", "awslabs.aws-documentation-mcp-server@latest"],
+      "environment": {
+        "FASTMCP_LOG_LEVEL": "ERROR",
+        "AWS_DOCUMENTATION_PARTITION": "aws"
+      },
+      "enabled": true
+    },
+    "aws-iac": {
+      "type": "local",
+      "command": ["C:/Users/steve/.local/bin/uvx.exe", "awslabs.aws-iac-mcp-server@latest"],
+      "environment": {
+        "FASTMCP_LOG_LEVEL": "ERROR"
+      },
+      "enabled": true
+    },
+    "aws_terraform": {
+      "type": "local",
+      "command": ["uvx", "awslabs.terraform-mcp-server@latest"],
+      "environment": {
+        "FASTMCP_LOG_LEVEL": "ERROR",
+        "AWS_PROFILE": "default",
+        "AWS_REGION": "us-east-1"
+      },
+      "enabled": true
+    },
+    "aws_mcp": {
+      "type": "local",
+      "command": [
+        "uvx",
+        "--from",
+        "mcp-proxy-for-aws@latest",
+        "mcp-proxy-for-aws.exe",
+        "https://aws-mcp.us-east-1.api.aws/mcp",
+        "--service",
+        "aws-mcp",
+        "--profile",
+        "default",
+        "--region",
+        "us-east-1"
+      ],
+      "enabled": true
+    },
+    "daytona": {
+      "type": "local",
+      "command": ["C:/Users/steve/AppData/Roaming/bin/daytona/daytona.exe", "mcp", "start"],
+      "environment": {
+        "APPDATA": "C:\\Users\\steve\\AppData\\Roaming",
+        "HOME": "C:\\Users\\steve"
+      },
+      "enabled": true
+    }
+  },
+  "permission": {
+    "vercel-vrdex_*": "ask",
+    "aws_mcp_*": "ask",
+    "daytona_*": "ask"
+  }
+}


### PR DESCRIPTION
## What changed
- Preserves the untracked `.opencode/opencode.json` MCP configuration that was left in the merged issue #56 worktree.
- Enables repo-local MCP entries for Playwright, Vercel, Convex, AWS docs/IaC/Terraform/AWS MCP, and Daytona.
- Keeps explicit `ask` permissions for the Vercel, AWS MCP, and Daytona tool patterns present in the preserved config.

## Review notes
- This is intentionally a small draft PR so the repo-level OpenCode config can be reviewed before it affects future sessions.
- Global OpenCode config was not changed.
- The config may broaden this repo's MCP/tool surface; review whether AWS and Daytona should stay enabled before marking ready.

## Validation
- Parsed `.opencode/opencode.json` as JSON with Node.
- Checked the OpenCode schema for the MCP, `environment`, and `permission` shapes.
- `opencode` CLI is not available on PATH in this shell, so runtime config-load validation was not run.
- GitHub Advanced Security secret scanning is not enabled for this repo, so the targeted secret-scan tool could not run.