### PR TITLE
Add event profile foundation

### DIFF
--- a/apps/web/e2e/public-routes.ts
+++ b/apps/web/e2e/public-routes.ts
@@ -8,6 +8,7 @@ export const visualProfilePaths = {
   personPath: "/p/playwright-dj-aurora",
   communityPath: "/c/playwright-afterglow-social",
   worldPath: "/w/playwright-neon-harbor",
+  eventPath: "/e/playwright-afterglow-harbor-sessions",
 } as const;
 
 export type CapturedRoute = {
@@ -186,17 +187,29 @@ export async function expectDeploymentPage(page: Page) {
 export async function expectPersonProfilePage(page: Page) {
   await expect(page.getByRole("heading", { name: "DJ Aurora" })).toBeVisible();
   await expect(page.getByText(/Community submitted/i)).toBeVisible();
+  await expect(page.getByRole("heading", { name: /Where this profile appears next/i })).toBeVisible();
+  await expect(page.getByRole("heading", { name: "Afterglow Harbor Sessions" })).toBeVisible();
   await expect(page.getByText(/Creator links/i)).toBeVisible();
   await expect(page.getByText("DJ Aurora Ko-fi", { exact: true })).toBeVisible();
   await expect(page.getByText(/World credits/i)).toBeVisible();
-  await expect(page.getByText("Neon Harbor", { exact: true })).toBeVisible();
+  await expect(page.getByRole("link", { name: /Neon Harbor Media Credit A/i })).toBeVisible();
 }
 
 export async function expectCommunityProfilePage(page: Page) {
   await expect(page.getByRole("heading", { name: "Afterglow Social" })).toBeVisible();
+  await expect(page.getByRole("heading", { name: /Upcoming community events/i })).toBeVisible();
+  await expect(page.getByRole("heading", { name: "Afterglow Harbor Sessions" })).toBeVisible();
   await expect(page.getByText("Club night", { exact: true }).first()).toBeVisible();
   await expect(page.getByText("Afterglow event archive", { exact: true })).toBeVisible();
   await expect(page.getByText("World Author", { exact: true })).toBeVisible();
+}
+
+export async function expectEventPage(page: Page) {
+  await expect(page.getByRole("heading", { name: "Afterglow Harbor Sessions" })).toBeVisible();
+  await expect(page.getByText(/People associated with this event/i)).toBeVisible();
+  await expect(page.getByText("DJ Aurora", { exact: true })).toBeVisible();
+  await expect(page.getByText("Neon Harbor", { exact: true })).toBeVisible();
+  await expect(page.getByText("Fixture watch link", { exact: true })).toBeVisible();
 }
 
 export async function expectWorldProfilePage(page: Page) {
@@ -243,5 +256,10 @@ export const capturedRoutes: CapturedRoute[] = [
     name: "world-profile",
     path: visualProfilePaths.worldPath,
     expectPage: expectWorldProfilePage,
+  },
+  {
+    name: "event-profile",
+    path: visualProfilePaths.eventPath,
+    expectPage: expectEventPage,
   },
 ];

--- a/apps/web/src/app/_components/event-public-page.tsx
+++ b/apps/web/src/app/_components/event-public-page.tsx
@@ -243,7 +243,7 @@ export function EventBackendNotice({ kind }: { kind: "missing-url" | "error" }) 
   );
 }
 
-export function EventPublicPage({ event }: { event: PublicEvent }) {
+export function EventPublicPage({ event, showEditLink = false }: { event: PublicEvent; showEditLink?: boolean }) {
   const posterStyle = safeImageBackground(event.posterImageUrl, true);
   const sourceUrl = safeHttpsUrl(event.source.url);
 
@@ -258,9 +258,11 @@ export function EventPublicPage({ event }: { event: PublicEvent }) {
             <Link className="rounded-full border border-border bg-white/80 px-4 py-2 font-medium" href="/events/new">
               Add event
             </Link>
-            <Link className="rounded-full border border-border bg-white/80 px-4 py-2 font-medium" href={`/events/${event.slug}/edit`}>
-              Edit event
-            </Link>
+            {showEditLink ? (
+              <Link className="rounded-full border border-border bg-white/80 px-4 py-2 font-medium" href={`/events/${event.slug}/edit`}>
+                Edit event
+              </Link>
+            ) : null}
           </div>
         </nav>
 

--- a/apps/web/src/app/_components/event-public-page.tsx
+++ b/apps/web/src/app/_components/event-public-page.tsx
@@ -1,0 +1,415 @@
+import Link from "next/link";
+
+type EventSourceType = "manual" | "community" | "partner" | "import" | "ai_suggested";
+type EventMediaLinkType =
+  | "event_page"
+  | "watch"
+  | "stream"
+  | "vrcdn"
+  | "discord"
+  | "ticket"
+  | "other";
+type EventMediaLinkPresentation = "open" | "copy";
+type ProfileTrustLabel =
+  | "community_submitted"
+  | "unclaimed"
+  | "claimed_unverified"
+  | "claimed_verified";
+
+export type PublicEventPreview = {
+  slug?: string;
+  title: string;
+  startAt: number;
+  endAt?: number;
+  timezone?: string;
+  communityName?: string;
+  communitySlug?: string;
+  summary?: string;
+  posterImageUrl?: string;
+  source: {
+    sourceType: EventSourceType;
+    label: string;
+    url?: string;
+  };
+  worlds: Array<{
+    slug: string;
+    displayName: string;
+  }>;
+  participantCount: number;
+};
+
+export type PublicEvent = Omit<PublicEventPreview, "worlds"> & {
+  slug: string;
+  notes?: string;
+  mediaLinks: Array<{
+    type: EventMediaLinkType;
+    label: string;
+    url: string;
+    presentation: EventMediaLinkPresentation;
+  }>;
+  worlds: Array<{
+    slug: string;
+    displayName: string;
+    tags: string[];
+    summary?: string;
+    heroImageUrl?: string;
+    association: {
+      sourceType: EventSourceType;
+      confirmationState: "confirmed";
+      confirmedAt?: number;
+    };
+  }>;
+  participants: Array<{
+    slug: string;
+    displayName: string;
+    roleLabel: string;
+    trustLabel: ProfileTrustLabel;
+    source: {
+      sourceType: EventSourceType;
+      label: string;
+      url?: string;
+    };
+  }>;
+};
+
+function safeImageBackground(imageUrl: string | undefined, overlay = false) {
+  if (!imageUrl) {
+    return undefined;
+  }
+
+  try {
+    const url = new URL(imageUrl);
+
+    if (url.protocol !== "https:") {
+      return undefined;
+    }
+
+    const image = `url(${JSON.stringify(url.href)})`;
+
+    return {
+      backgroundImage: overlay
+        ? `linear-gradient(135deg, rgba(25, 17, 31, 0.72), rgba(105, 56, 169, 0.2)), ${image}`
+        : image,
+    };
+  } catch {
+    return undefined;
+  }
+}
+
+function safeHttpsUrl(url: string | undefined): string | null {
+  if (!url) {
+    return null;
+  }
+
+  try {
+    const parsed = new URL(url);
+    return parsed.protocol === "https:" ? parsed.href : null;
+  } catch {
+    return null;
+  }
+}
+
+function eventSourceLabel(source: EventSourceType): string {
+  if (source === "ai_suggested") {
+    return "AI-suggested";
+  }
+
+  return source
+    .split("_")
+    .map((word) => `${word[0]?.toUpperCase() ?? ""}${word.slice(1)}`)
+    .join(" ");
+}
+
+function mediaLinkTypeLabel(type: EventMediaLinkType): string {
+  if (type === "event_page") {
+    return "Event page";
+  }
+
+  if (type === "vrcdn") {
+    return "VRCDN";
+  }
+
+  return eventSourceLabel(type as EventSourceType);
+}
+
+function formatEventDate(timestamp: number, timezone: string | undefined): string {
+  const baseOptions: Intl.DateTimeFormatOptions = {
+    month: "short",
+    day: "numeric",
+    hour: "numeric",
+    minute: "2-digit",
+  };
+
+  try {
+    return new Intl.DateTimeFormat("en", {
+      ...baseOptions,
+      ...(timezone ? { timeZone: timezone } : {}),
+    }).format(new Date(timestamp));
+  } catch {
+    return new Intl.DateTimeFormat("en", baseOptions).format(new Date(timestamp));
+  }
+}
+
+function trustLabel(label: ProfileTrustLabel): string {
+  if (label === "claimed_verified") {
+    return "Verified owner";
+  }
+
+  if (label === "claimed_unverified") {
+    return "Claimed";
+  }
+
+  if (label === "community_submitted") {
+    return "Community submitted";
+  }
+
+  return "Unclaimed";
+}
+
+export function EventPreviewCard({ event }: { event: PublicEventPreview }) {
+  const sourceUrl = safeHttpsUrl(event.source.url);
+  const posterStyle = safeImageBackground(event.posterImageUrl, true);
+
+  return (
+    <article className="group overflow-hidden rounded-2xl border border-border bg-surface-strong text-sm transition hover:-translate-y-0.5">
+      <div
+        className="min-h-28 bg-[radial-gradient(circle_at_top_left,rgba(214,106,77,0.22),transparent_34%),linear-gradient(135deg,#2c1d29,#60429a)] bg-cover bg-center px-4 py-4 text-white"
+        style={posterStyle}
+      >
+        <div className="flex flex-wrap items-center gap-2 text-xs text-white/80">
+          <time dateTime={new Date(event.startAt).toISOString()}>
+            {formatEventDate(event.startAt, event.timezone)}
+          </time>
+          {event.communityName ? <span>/ {event.communityName}</span> : null}
+        </div>
+        <h3 className="mt-4 text-2xl font-semibold tracking-[-0.04em]">
+          {event.slug ? <Link href={`/e/${event.slug}`}>{event.title}</Link> : event.title}
+        </h3>
+      </div>
+      <div className="grid gap-3 px-4 py-4">
+        {event.summary ? <p className="leading-6 text-muted">{event.summary}</p> : null}
+        <div className="flex flex-wrap gap-2 text-xs">
+          {event.participantCount > 0 ? (
+            <span className="rounded-full border border-border bg-white px-3 py-1">
+              {event.participantCount} linked profile{event.participantCount === 1 ? "" : "s"}
+            </span>
+          ) : null}
+          {event.worlds.map((world) => (
+            <span className="rounded-full border border-border bg-white px-3 py-1" key={world.slug}>
+              {world.displayName}
+            </span>
+          ))}
+          {sourceUrl ? (
+            <a
+              className="rounded-full border border-border bg-white px-3 py-1 font-medium"
+              href={sourceUrl}
+              rel="noreferrer"
+              target="_blank"
+            >
+              {event.source.label}
+            </a>
+          ) : (
+            <span className="rounded-full border border-border bg-white px-3 py-1">
+              {event.source.label}
+            </span>
+          )}
+        </div>
+      </div>
+    </article>
+  );
+}
+
+export function EventBackendNotice({ kind }: { kind: "missing-url" | "error" }) {
+  return (
+    <main className="min-h-screen px-6 py-10 text-foreground sm:px-10 lg:px-16">
+      <section className="mx-auto max-w-3xl rounded-[2rem] border border-border bg-surface px-6 py-8 shadow-[0_24px_80px_rgba(64,40,24,0.12)] sm:px-8">
+        <p className="font-mono text-xs uppercase tracking-[0.28em] text-muted">Event page</p>
+        <h1 className="mt-4 text-4xl font-semibold tracking-[-0.04em]">
+          {kind === "missing-url" ? "Convex URL not configured" : "Event read failed"}
+        </h1>
+        <p className="mt-4 max-w-2xl text-sm leading-7 text-muted">
+          {kind === "missing-url"
+            ? "Run the local backend bootstrap before loading public event pages from this worktree."
+            : "Start the local Convex backend and reload this page once the event query is reachable."}
+        </p>
+        <Link
+          className="mt-6 inline-flex rounded-full border border-border bg-surface-strong px-5 py-3 text-sm font-medium"
+          href="/"
+        >
+          Back to homepage
+        </Link>
+      </section>
+    </main>
+  );
+}
+
+export function EventPublicPage({ event }: { event: PublicEvent }) {
+  const posterStyle = safeImageBackground(event.posterImageUrl, true);
+  const sourceUrl = safeHttpsUrl(event.source.url);
+
+  return (
+    <main className="min-h-screen bg-[radial-gradient(circle_at_top_left,rgba(125,74,202,0.14),transparent_32%),linear-gradient(180deg,#faf7fb,#f3efe8)] px-6 py-8 text-foreground sm:px-10 lg:px-16">
+      <div className="mx-auto flex w-full max-w-6xl flex-col gap-6">
+        <nav className="flex flex-wrap items-center justify-between gap-3 text-sm">
+          <Link className="font-mono uppercase tracking-[0.28em] text-muted" href="/">
+            VRDex
+          </Link>
+          <div className="flex flex-wrap gap-2">
+            <Link className="rounded-full border border-border bg-white/80 px-4 py-2 font-medium" href="/events/new">
+              Add event
+            </Link>
+            <Link className="rounded-full border border-border bg-white/80 px-4 py-2 font-medium" href={`/events/${event.slug}/edit`}>
+              Edit event
+            </Link>
+          </div>
+        </nav>
+
+        <section className="overflow-hidden rounded-[2rem] border border-purple-950/10 bg-slate-950 shadow-[0_24px_90px_rgba(41,20,61,0.18)]">
+          <div
+            className="min-h-72 bg-[radial-gradient(circle_at_top_right,rgba(198,153,255,0.32),transparent_30%),linear-gradient(135deg,#17111f,#5d3b8e_52%,#20142f)] bg-cover bg-center p-6 text-white sm:p-8 lg:p-10"
+            style={posterStyle}
+          >
+            <div className="flex min-h-60 flex-col justify-between gap-10">
+              <div className="flex flex-wrap items-center gap-3">
+                <span className="rounded-full bg-white/15 px-3 py-1 font-mono text-xs uppercase tracking-[0.22em] text-white/82">
+                  Event
+                </span>
+                <span className="rounded-full bg-white/15 px-3 py-1 font-mono text-xs uppercase tracking-[0.22em] text-white/82">
+                  /e/{event.slug}
+                </span>
+              </div>
+
+              <div className="grid gap-6 lg:grid-cols-[1fr_auto] lg:items-end">
+                <div className="max-w-4xl">
+                  <time className="text-sm uppercase tracking-[0.24em] text-white/70" dateTime={new Date(event.startAt).toISOString()}>
+                    {formatEventDate(event.startAt, event.timezone)}
+                  </time>
+                  <h1 className="mt-4 text-5xl leading-none font-semibold tracking-[-0.05em] sm:text-7xl">
+                    {event.title}
+                  </h1>
+                  <p className="mt-4 max-w-2xl text-base leading-7 text-white/82 sm:text-lg">
+                    {event.summary ?? "A published VRDex event with source-aware community, world, and profile context."}
+                  </p>
+                </div>
+
+                <aside className="rounded-[1.5rem] border border-white/20 bg-white/14 p-4 backdrop-blur">
+                  <p className="font-mono text-xs uppercase tracking-[0.24em] text-white/70">Source</p>
+                  <h2 className="mt-3 text-2xl font-semibold tracking-[-0.03em]">
+                    {eventSourceLabel(event.source.sourceType)}
+                  </h2>
+                  <p className="mt-2 max-w-xs text-sm leading-6 text-white/76">
+                    {event.source.label}. Participant and world links are source-attributed and reviewable.
+                  </p>
+                </aside>
+              </div>
+            </div>
+          </div>
+        </section>
+
+        <section className="grid gap-4 lg:grid-cols-[1.1fr_0.9fr]">
+          <article className="rounded-[1.5rem] border border-border bg-white/80 px-5 py-6 shadow-sm sm:px-6">
+            <p className="font-mono text-xs uppercase tracking-[0.28em] text-muted">Event context</p>
+            <h2 className="mt-4 text-3xl font-semibold tracking-[-0.04em]">Hosted by and happening at</h2>
+            <div className="mt-5 grid gap-3 text-sm">
+              {event.communitySlug ? (
+                <Link className="rounded-2xl border border-border bg-surface px-4 py-3 font-medium" href={`/c/${event.communitySlug}`}>
+                  {event.communityName ?? "Community profile"}
+                </Link>
+              ) : event.communityName ? (
+                <div className="rounded-2xl border border-border bg-surface px-4 py-3 font-medium">
+                  {event.communityName}
+                </div>
+              ) : (
+                <p className="leading-6 text-muted">No public host community is linked yet.</p>
+              )}
+              {event.worlds.map((world) => (
+                <Link className="rounded-2xl border border-border bg-surface px-4 py-3" href={`/w/${world.slug}`} key={world.slug}>
+                  <span className="block font-medium">{world.displayName}</span>
+                  {world.summary ? <span className="mt-1 block text-muted">{world.summary}</span> : null}
+                </Link>
+              ))}
+            </div>
+          </article>
+
+          <aside className="rounded-[1.5rem] border border-border bg-white/80 px-5 py-6 shadow-sm sm:px-6">
+            <p className="font-mono text-xs uppercase tracking-[0.28em] text-muted">Public details</p>
+            <dl className="mt-5 space-y-4 text-sm">
+              <div className="border-b border-border pb-4">
+                <dt className="text-muted">Start</dt>
+                <dd className="mt-1 font-medium">{formatEventDate(event.startAt, event.timezone)}</dd>
+              </div>
+              <div className="border-b border-border pb-4">
+                <dt className="text-muted">End</dt>
+                <dd className="mt-1 font-medium">
+                  {event.endAt ? formatEventDate(event.endAt, event.timezone) : "Not listed"}
+                </dd>
+              </div>
+              <div>
+                <dt className="text-muted">Time zone</dt>
+                <dd className="mt-1 font-medium">{event.timezone ?? "Not listed"}</dd>
+              </div>
+            </dl>
+          </aside>
+        </section>
+
+        <section className="rounded-[1.5rem] border border-border bg-white/80 px-5 py-6 shadow-sm sm:px-6">
+          <div className="flex flex-col justify-between gap-3 sm:flex-row sm:items-end">
+            <div>
+              <p className="font-mono text-xs uppercase tracking-[0.28em] text-muted">Linked profiles</p>
+              <h2 className="mt-4 text-3xl font-semibold tracking-[-0.04em]">People associated with this event</h2>
+            </div>
+            <p className="max-w-md text-sm leading-6 text-muted">
+              These links can point at claimed or unclaimed published profiles. Approval and dispute workflows are tracked separately.
+            </p>
+          </div>
+          <div className="mt-5 grid gap-3 sm:grid-cols-2 lg:grid-cols-3">
+            {event.participants.length === 0 ? (
+              <p className="text-sm leading-6 text-muted">No public participant links yet.</p>
+            ) : (
+              event.participants.map((participant) => (
+                <Link className="rounded-2xl border border-border bg-surface px-4 py-4 text-sm" href={`/p/${participant.slug}`} key={participant.slug}>
+                  <span className="block text-lg font-semibold tracking-[-0.03em]">{participant.displayName}</span>
+                  <span className="mt-2 block text-muted">{participant.roleLabel}</span>
+                  <span className="mt-3 inline-flex rounded-full border border-border bg-white px-3 py-1 text-xs">
+                    {trustLabel(participant.trustLabel)}
+                  </span>
+                </Link>
+              ))
+            )}
+          </div>
+        </section>
+
+        <section className="grid gap-4 lg:grid-cols-[1fr_1fr]">
+          <article className="rounded-[1.5rem] border border-border bg-white/80 px-5 py-6 shadow-sm">
+            <p className="font-mono text-xs uppercase tracking-[0.28em] text-muted">Media and links</p>
+            <div className="mt-4 grid gap-3">
+              {event.mediaLinks.length === 0 && !sourceUrl ? (
+                <p className="text-sm leading-6 text-muted">No public event media links yet.</p>
+              ) : null}
+              {sourceUrl ? (
+                <a className="rounded-2xl border border-border bg-surface px-4 py-3 text-sm font-medium" href={sourceUrl} rel="noreferrer" target="_blank">
+                  {event.source.label}
+                </a>
+              ) : null}
+              {event.mediaLinks.map((link) => (
+                <a className="rounded-2xl border border-border bg-surface px-4 py-3 text-sm" href={link.url} key={`${link.type}-${link.url}`} rel="noreferrer" target="_blank">
+                  <span className="block font-medium">{link.label}</span>
+                  <span className="mt-1 block text-xs text-muted">
+                    {mediaLinkTypeLabel(link.type)} {link.presentation === "copy" ? "copyable link" : "external link"}
+                  </span>
+                </a>
+              ))}
+            </div>
+          </article>
+
+          <article className="rounded-[1.5rem] border border-border bg-white/80 px-5 py-6 shadow-sm">
+            <p className="font-mono text-xs uppercase tracking-[0.28em] text-muted">Notes</p>
+            <div className="mt-4 space-y-4 text-sm leading-7 text-muted">
+              {event.notes ? <p>{event.notes}</p> : <p>No public event notes yet.</p>}
+            </div>
+          </article>
+        </section>
+      </div>
+    </main>
+  );
+}

--- a/apps/web/src/app/_components/home-active-worlds.tsx
+++ b/apps/web/src/app/_components/home-active-worlds.tsx
@@ -89,13 +89,7 @@ function ActiveWorldCard({ world }: { world: PublicActiveWorld }) {
         </p>
         <div className="mt-5 rounded-2xl border border-white/16 bg-white/12 p-4 backdrop-blur">
           <p className="font-mono text-xs uppercase tracking-[0.2em] text-white/62">Next event</p>
-          <p className="mt-2 font-medium">
-            {world.nextEvent.slug ? (
-              <span className="underline-offset-4 group-hover:underline">{world.nextEvent.title}</span>
-            ) : (
-              world.nextEvent.title
-            )}
-          </p>
+          <p className="mt-2 font-medium">{world.nextEvent.title}</p>
           <p className="mt-1 text-sm text-white/72">
             {formatEventDate(world.nextEvent.startAt, world.nextEvent.timezone)}
             {world.nextEvent.communityName ? ` by ${world.nextEvent.communityName}` : ""}

--- a/apps/web/src/app/_components/home-active-worlds.tsx
+++ b/apps/web/src/app/_components/home-active-worlds.tsx
@@ -12,6 +12,7 @@ export type PublicActiveWorld = {
   activityLabel: "Hosting upcoming events";
   nextEvent: {
     title: string;
+    slug?: string;
     startAt: number;
     endAt?: number;
     timezone?: string;
@@ -88,7 +89,13 @@ function ActiveWorldCard({ world }: { world: PublicActiveWorld }) {
         </p>
         <div className="mt-5 rounded-2xl border border-white/16 bg-white/12 p-4 backdrop-blur">
           <p className="font-mono text-xs uppercase tracking-[0.2em] text-white/62">Next event</p>
-          <p className="mt-2 font-medium">{world.nextEvent.title}</p>
+          <p className="mt-2 font-medium">
+            {world.nextEvent.slug ? (
+              <span className="underline-offset-4 group-hover:underline">{world.nextEvent.title}</span>
+            ) : (
+              world.nextEvent.title
+            )}
+          </p>
           <p className="mt-1 text-sm text-white/72">
             {formatEventDate(world.nextEvent.startAt, world.nextEvent.timezone)}
             {world.nextEvent.communityName ? ` by ${world.nextEvent.communityName}` : ""}

--- a/apps/web/src/app/_components/profile-public-page.tsx
+++ b/apps/web/src/app/_components/profile-public-page.tsx
@@ -1,5 +1,7 @@
 import Link from "next/link";
 
+import { EventPreviewCard, type PublicEventPreview } from "./event-public-page";
+
 type ProfileTrustLabel =
   | "community_submitted"
   | "unclaimed"
@@ -53,6 +55,8 @@ type PublicProfileBase = {
     summary?: string;
     sourceLabel?: string;
   }>;
+  upcomingEvents: PublicEventPreview[];
+  hostedEvents: PublicEventPreview[];
 };
 
 type PublicPersonProfile = PublicProfileBase & {
@@ -338,6 +342,33 @@ export function ProfilePublicPage({ profile }: { profile: PublicProfile }) {
               )}
             </dl>
           </aside>
+        </section>
+
+        <section className="rounded-[1.5rem] border border-border bg-surface px-5 py-6 sm:px-6">
+          <div className="flex flex-col justify-between gap-3 sm:flex-row sm:items-end">
+            <div>
+              <p className="font-mono text-xs uppercase tracking-[0.28em] text-muted">
+                {isPerson ? "Upcoming events" : "Hosted events"}
+              </p>
+              <h2 className="mt-4 text-3xl font-semibold tracking-[-0.04em]">
+                {isPerson ? "Where this profile appears next" : "Upcoming community events"}
+              </h2>
+            </div>
+            <p className="max-w-md text-sm leading-6 text-muted">
+              {isPerson
+                ? "Derived from confirmed person-event links on published event records."
+                : "Published events linked to this community profile."}
+            </p>
+          </div>
+          <div className="mt-5 grid gap-3 lg:grid-cols-2">
+            {(isPerson ? profile.upcomingEvents : profile.hostedEvents).length === 0 ? (
+              <p className="text-sm leading-6 text-muted">No public upcoming events yet.</p>
+            ) : (
+              (isPerson ? profile.upcomingEvents : profile.hostedEvents).map((event) => (
+                <EventPreviewCard event={event} key={`${event.slug ?? event.title}-${event.startAt}`} />
+              ))
+            )}
+          </div>
         </section>
 
         <section className="rounded-[1.5rem] border border-border bg-surface px-5 py-6 sm:px-6">

--- a/apps/web/src/app/_components/world-public-page.tsx
+++ b/apps/web/src/app/_components/world-public-page.tsx
@@ -25,12 +25,20 @@ type WorldLinkSource = "owner_authored" | "reviewed" | "partner_provided";
 type EventSourceType = "manual" | "community" | "partner" | "import" | "ai_suggested";
 
 type PublicWorldEventPreview = {
+  slug?: string;
   title: string;
   startAt: number;
   endAt?: number;
   timezone?: string;
   communityName?: string;
   summary?: string;
+  posterImageUrl?: string;
+  mediaLinks: Array<{
+    type: "event_page" | "watch" | "stream" | "vrcdn" | "discord" | "ticket" | "other";
+    label: string;
+    url: string;
+    presentation: "open" | "copy";
+  }>;
   source: {
     sourceType: EventSourceType;
     label: string;
@@ -240,40 +248,56 @@ function EventList({
     <div className="grid gap-3">
       {events.map((event) => {
         const sourceUrl = event.source.url ? safeHttpsUrl(event.source.url) : null;
+        const posterStyle = safeImageBackground(event.posterImageUrl, true);
+        const posterTextClass = posterStyle ? "text-white/76" : "text-muted";
 
         return (
           <article
-            className="rounded-2xl border border-cyan-950/10 bg-surface px-4 py-4 text-sm"
+            className="overflow-hidden rounded-2xl border border-cyan-950/10 bg-surface text-sm"
             key={`${event.title}-${event.startAt}`}
           >
-            <div className="flex flex-wrap items-center gap-2 text-xs text-muted">
-              <time dateTime={new Date(event.startAt).toISOString()}>
-                {formatEventDate(event.startAt, event.timezone)}
-              </time>
-              <span aria-hidden="true">/</span>
-              <span>Confirmed venue</span>
+            <div
+              className="bg-[radial-gradient(circle_at_top_left,rgba(9,189,214,0.18),transparent_36%),linear-gradient(135deg,#ecfeff,#ffffff)] bg-cover bg-center px-4 py-4"
+              style={posterStyle}
+            >
+              <div className={`flex flex-wrap items-center gap-2 text-xs ${posterTextClass}`}>
+                <time dateTime={new Date(event.startAt).toISOString()}>
+                  {formatEventDate(event.startAt, event.timezone)}
+                </time>
+                <span aria-hidden="true">/</span>
+                <span>Confirmed venue</span>
+              </div>
+              <h3 className={`mt-3 text-lg font-semibold tracking-[-0.03em] ${posterStyle ? "text-white" : ""}`}>
+                {event.slug ? <Link href={`/e/${event.slug}`}>{event.title}</Link> : event.title}
+              </h3>
+              {event.communityName ? <p className={`mt-1 ${posterTextClass}`}>Hosted by {event.communityName}</p> : null}
             </div>
-            <h3 className="mt-3 text-lg font-semibold tracking-[-0.03em]">{event.title}</h3>
-            {event.communityName ? <p className="mt-1 text-muted">Hosted by {event.communityName}</p> : null}
-            {event.summary ? <p className="mt-3 leading-6 text-muted">{event.summary}</p> : null}
-            <div className="mt-4 flex flex-wrap gap-2 text-xs">
-              <span className="rounded-full bg-cyan-50 px-3 py-1 text-cyan-950">
-                {eventSourceLabel(event.worldAssociation.sourceType)} association
-              </span>
-              {sourceUrl ? (
-                <a
-                  className="rounded-full border border-border bg-white px-3 py-1 font-medium"
-                  href={sourceUrl}
-                  rel="noreferrer"
-                  target="_blank"
-                >
-                  {event.source.label}
-                </a>
-              ) : (
-                <span className="rounded-full border border-border bg-white px-3 py-1">
-                  {event.source.label}
+            <div className="px-4 py-4">
+              {event.summary ? <p className="leading-6 text-muted">{event.summary}</p> : null}
+              <div className="mt-4 flex flex-wrap gap-2 text-xs">
+                <span className="rounded-full bg-cyan-50 px-3 py-1 text-cyan-950">
+                  {eventSourceLabel(event.worldAssociation.sourceType)} association
                 </span>
-              )}
+                {event.mediaLinks.length > 0 ? (
+                  <span className="rounded-full border border-border bg-white px-3 py-1">
+                    {event.mediaLinks.length} media link{event.mediaLinks.length === 1 ? "" : "s"}
+                  </span>
+                ) : null}
+                {sourceUrl ? (
+                  <a
+                    className="rounded-full border border-border bg-white px-3 py-1 font-medium"
+                    href={sourceUrl}
+                    rel="noreferrer"
+                    target="_blank"
+                  >
+                    {event.source.label}
+                  </a>
+                ) : (
+                  <span className="rounded-full border border-border bg-white px-3 py-1">
+                    {event.source.label}
+                  </span>
+                )}
+              </div>
             </div>
           </article>
         );

--- a/apps/web/src/app/e/[slug]/page.tsx
+++ b/apps/web/src/app/e/[slug]/page.tsx
@@ -1,0 +1,27 @@
+import { notFound } from "next/navigation";
+
+import { EventBackendNotice, EventPublicPage } from "../../_components/event-public-page";
+import { fetchPublicEventBySlug } from "@/convex/server";
+
+export const dynamic = "force-dynamic";
+
+type EventPageProps = {
+  params: Promise<{
+    slug: string;
+  }>;
+};
+
+export default async function EventPage({ params }: EventPageProps) {
+  const { slug } = await params;
+  const result = await fetchPublicEventBySlug(slug);
+
+  if (result.kind === "missing-url" || result.kind === "error") {
+    return <EventBackendNotice kind={result.kind} />;
+  }
+
+  if (result.event === null) {
+    notFound();
+  }
+
+  return <EventPublicPage event={result.event} />;
+}

--- a/apps/web/src/app/e/[slug]/page.tsx
+++ b/apps/web/src/app/e/[slug]/page.tsx
@@ -5,6 +5,10 @@ import { fetchPublicEventBySlug } from "@/convex/server";
 
 export const dynamic = "force-dynamic";
 
+const eventEditorAuthReady =
+  process.env.NEXT_PUBLIC_VRDEX_EVENT_EDITOR_AUTH_READY === "true" ||
+  process.env.NEXT_PUBLIC_VRDEX_SUBMISSIONS_AUTH_READY === "true";
+
 type EventPageProps = {
   params: Promise<{
     slug: string;
@@ -23,5 +27,5 @@ export default async function EventPage({ params }: EventPageProps) {
     notFound();
   }
 
-  return <EventPublicPage event={result.event} />;
+  return <EventPublicPage event={result.event} showEditLink={eventEditorAuthReady} />;
 }

--- a/apps/web/src/app/events/[slug]/edit/page.tsx
+++ b/apps/web/src/app/events/[slug]/edit/page.tsx
@@ -1,0 +1,64 @@
+import Link from "next/link";
+import { notFound } from "next/navigation";
+
+import { EventEditorForm } from "../../event-editor-form";
+import { EventBackendNotice } from "../../../_components/event-public-page";
+import { fetchPublicEventBySlug } from "@/convex/server";
+
+export const dynamic = "force-dynamic";
+
+type EditEventPageProps = {
+  params: Promise<{
+    slug: string;
+  }>;
+};
+
+export default async function EditEventPage({ params }: EditEventPageProps) {
+  const { slug } = await params;
+  const result = await fetchPublicEventBySlug(slug);
+
+  if (result.kind === "missing-url" || result.kind === "error") {
+    return <EventBackendNotice kind={result.kind} />;
+  }
+
+  if (result.event === null) {
+    notFound();
+  }
+
+  return (
+    <main className="min-h-screen px-6 py-10 text-foreground sm:px-10 lg:px-16">
+      <div className="mx-auto flex w-full max-w-5xl flex-col gap-6">
+        <nav className="flex flex-wrap items-center justify-between gap-3 text-sm">
+          <Link className="font-mono uppercase tracking-[0.28em] text-muted" href="/">
+            VRDex
+          </Link>
+          <Link className="rounded-full border border-border bg-surface px-4 py-2 font-medium" href={`/e/${result.event.slug}`}>
+            View event
+          </Link>
+        </nav>
+
+        <section className="overflow-hidden rounded-[2rem] border border-border bg-surface shadow-[0_24px_80px_rgba(64,40,24,0.12)] backdrop-blur">
+          <div className="grid gap-8 px-6 py-8 sm:px-8 lg:grid-cols-[0.82fr_1.18fr] lg:px-10 lg:py-10">
+            <div className="flex flex-col justify-between gap-8">
+              <div>
+                <p className="font-mono text-xs uppercase tracking-[0.28em] text-muted">
+                  Event editing
+                </p>
+                <h1 className="mt-5 text-4xl leading-none font-semibold tracking-[-0.04em] sm:text-6xl">
+                  Update {result.event.title}.
+                </h1>
+                <p className="mt-5 max-w-xl text-base leading-7 text-muted sm:text-lg">
+                  Event slugs can be shortened or edited without changing the event identity. Durable generated short links are tracked separately.
+                </p>
+              </div>
+            </div>
+
+            <div className="rounded-[1.5rem] border border-border bg-white/45 px-5 py-6 sm:px-6">
+              <EventEditorForm event={result.event} />
+            </div>
+          </div>
+        </section>
+      </div>
+    </main>
+  );
+}

--- a/apps/web/src/app/events/event-editor-form.tsx
+++ b/apps/web/src/app/events/event-editor-form.tsx
@@ -21,6 +21,7 @@ type EventEditorStatus =
 
 const userSafeErrorPatterns = [
   /Event changes require a signed-in user\./,
+  /Event start time must be a valid timestamp\./,
   /Event title must be at least \d+ characters\./,
   /Event title must be \d+ characters or fewer\./,
   /Event end time must be after the start time\./,
@@ -29,6 +30,7 @@ const userSafeErrorPatterns = [
   /World profile was not found or is not published\./,
   /Person profile ".+" was not found\./,
   /You do not have permission to update this event\./,
+  /You do not have permission to move this event to another community\./,
 ];
 
 function eventEditorErrorMessage(error: unknown): string {
@@ -169,28 +171,28 @@ function ConnectedEventEditorForm({ event }: { event?: PublicEvent }) {
     submitEvent.preventDefault();
     const form = submitEvent.currentTarget;
     const formData = new FormData(form);
-    const startAt = fromLocalInputValue(stringField(formData.get("startAt")));
     const endAtInput = optionalString(stringField(formData.get("endAt")));
-    const payload = {
-      title: stringField(formData.get("title")),
-      preferredSlug: optionalString(stringField(formData.get("preferredSlug"))),
-      communitySlug: optionalString(stringField(formData.get("communitySlug"))),
-      worldSlug: optionalString(stringField(formData.get("worldSlug"))),
-      startAt,
-      ...(endAtInput ? { endAt: fromLocalInputValue(endAtInput) } : {}),
-      timezone: optionalString(stringField(formData.get("timezone"))),
-      summary: optionalString(stringField(formData.get("summary"))),
-      notes: optionalString(stringField(formData.get("notes"))),
-      sourceLabel: optionalString(stringField(formData.get("sourceLabel"))),
-      sourceUrl: optionalString(stringField(formData.get("sourceUrl"))),
-      posterImageUrl: optionalString(stringField(formData.get("posterImageUrl"))),
-      mediaLinks: parseMediaLinks(stringField(formData.get("mediaLinks"))),
-      participantLinks: parseParticipantLinks(stringField(formData.get("participantLinks"))),
-    };
 
     setStatus({ kind: "submitting" });
 
     try {
+      const startAt = fromLocalInputValue(stringField(formData.get("startAt")));
+      const payload = {
+        title: stringField(formData.get("title")),
+        preferredSlug: optionalString(stringField(formData.get("preferredSlug"))),
+        communitySlug: optionalString(stringField(formData.get("communitySlug"))),
+        worldSlug: optionalString(stringField(formData.get("worldSlug"))),
+        startAt,
+        ...(endAtInput ? { endAt: fromLocalInputValue(endAtInput) } : {}),
+        timezone: optionalString(stringField(formData.get("timezone"))),
+        summary: optionalString(stringField(formData.get("summary"))),
+        notes: optionalString(stringField(formData.get("notes"))),
+        sourceLabel: optionalString(stringField(formData.get("sourceLabel"))),
+        sourceUrl: optionalString(stringField(formData.get("sourceUrl"))),
+        posterImageUrl: optionalString(stringField(formData.get("posterImageUrl"))),
+        mediaLinks: parseMediaLinks(stringField(formData.get("mediaLinks"))),
+        participantLinks: parseParticipantLinks(stringField(formData.get("participantLinks"))),
+      };
       const result = event
         ? await updateEvent({ currentSlug: event.slug, ...payload })
         : await createEvent(payload);

--- a/apps/web/src/app/events/event-editor-form.tsx
+++ b/apps/web/src/app/events/event-editor-form.tsx
@@ -1,0 +1,316 @@
+"use client";
+
+import Link from "next/link";
+import { FormEvent, useState, useTransition } from "react";
+import { useMutation } from "convex/react";
+import { api } from "@convex-generated-api";
+import type { PublicEvent } from "../_components/event-public-page";
+
+type EventMediaLinkType = PublicEvent["mediaLinks"][number]["type"];
+
+const convexUrl = process.env.NEXT_PUBLIC_CONVEX_URL;
+const eventEditorAuthReady =
+  process.env.NEXT_PUBLIC_VRDEX_EVENT_EDITOR_AUTH_READY === "true" ||
+  process.env.NEXT_PUBLIC_VRDEX_SUBMISSIONS_AUTH_READY === "true";
+
+type EventEditorStatus =
+  | { kind: "idle" }
+  | { kind: "submitting" }
+  | { kind: "success"; result: { eventPath: string; slug: string } }
+  | { kind: "error"; message: string };
+
+const userSafeErrorPatterns = [
+  /Event changes require a signed-in user\./,
+  /Event title must be at least \d+ characters\./,
+  /Event title must be \d+ characters or fewer\./,
+  /Event end time must be after the start time\./,
+  /(?:Event source URL|Poster image URL|Media link URL|Participant source URL) must (?:use https|be a valid URL)\./,
+  /Community profile was not found\./,
+  /World profile was not found or is not published\./,
+  /Person profile ".+" was not found\./,
+  /You do not have permission to update this event\./,
+];
+
+function eventEditorErrorMessage(error: unknown): string {
+  const message = error instanceof Error ? error.message : String(error);
+
+  for (const pattern of userSafeErrorPatterns) {
+    const match = message.match(pattern);
+
+    if (match) {
+      return match[0];
+    }
+  }
+
+  return "Event save failed. Please try again once the backend is reachable.";
+}
+
+function stringField(value: FormDataEntryValue | null): string {
+  return typeof value === "string" ? value : "";
+}
+
+function optionalString(value: string): string | undefined {
+  const trimmed = value.trim();
+  return trimmed.length === 0 ? undefined : trimmed;
+}
+
+function toLocalInputValue(timestamp: number | undefined): string {
+  if (timestamp === undefined) {
+    return "";
+  }
+
+  const date = new Date(timestamp);
+  const offsetMs = date.getTimezoneOffset() * 60_000;
+  return new Date(date.getTime() - offsetMs).toISOString().slice(0, 16);
+}
+
+function fromLocalInputValue(value: string): number {
+  const timestamp = new Date(value).getTime();
+
+  if (!Number.isFinite(timestamp)) {
+    throw new Error("Event start time must be a valid timestamp.");
+  }
+
+  return timestamp;
+}
+
+function parseMediaLinks(value: string) {
+  return value
+    .split("\n")
+    .map((line) => line.trim())
+    .filter(Boolean)
+    .map((line) => {
+      const [type = "other", label = "Event link", url = "", presentation] = line
+        .split("|")
+        .map((part) => part.trim());
+
+      return {
+        type: normalizeMediaType(type),
+        label,
+        url,
+        presentation: presentation === "copy" ? ("copy" as const) : ("open" as const),
+      };
+    });
+}
+
+function normalizeMediaType(value: string): EventMediaLinkType {
+  const normalized = value.toLowerCase().replace(/[^a-z0-9]+/g, "_").replace(/^_+|_+$/g, "");
+
+  if (
+    normalized === "event_page" ||
+    normalized === "watch" ||
+    normalized === "stream" ||
+    normalized === "vrcdn" ||
+    normalized === "discord" ||
+    normalized === "ticket" ||
+    normalized === "other"
+  ) {
+    return normalized;
+  }
+
+  return "other" as const;
+}
+
+function parseParticipantLinks(value: string) {
+  return value
+    .split("\n")
+    .map((line) => line.trim())
+    .filter(Boolean)
+    .map((line) => {
+      const [personSlug = "", roleLabel = "Performer"] = line.split("|").map((part) => part.trim());
+
+      return { personSlug, roleLabel };
+    });
+}
+
+function serializeMediaLinks(event: PublicEvent | undefined): string {
+  return (event?.mediaLinks ?? [])
+    .map((link) => `${link.type} | ${link.label} | ${link.url} | ${link.presentation}`)
+    .join("\n");
+}
+
+function serializeParticipants(event: PublicEvent | undefined): string {
+  return (event?.participants ?? [])
+    .map((participant) => `${participant.slug} | ${participant.roleLabel}`)
+    .join("\n");
+}
+
+function DisabledEventEditorPanel() {
+  return (
+    <div className="rounded-[1.5rem] border border-dashed border-border bg-surface px-5 py-6">
+      <p className="font-mono text-xs uppercase tracking-[0.28em] text-muted">Event editor</p>
+      <h2 className="mt-4 text-2xl font-semibold tracking-[-0.03em]">Convex URL not configured</h2>
+      <p className="mt-3 text-sm leading-7 text-muted">
+        Run <code className="font-mono text-[0.95em]">pnpm bootstrap:backend:local</code> before testing event creation locally.
+      </p>
+    </div>
+  );
+}
+
+function SignInRequiredEventEditorPanel() {
+  return (
+    <div className="rounded-[1.5rem] border border-dashed border-border bg-surface px-5 py-6">
+      <p className="font-mono text-xs uppercase tracking-[0.28em] text-muted">Event editor</p>
+      <h2 className="mt-4 text-2xl font-semibold tracking-[-0.03em]">Sign-in required</h2>
+      <p className="mt-3 text-sm leading-7 text-muted">
+        The event mutations and form are wired, but the public editor stays locked until Convex auth is enabled for the web app.
+      </p>
+    </div>
+  );
+}
+
+function ConnectedEventEditorForm({ event }: { event?: PublicEvent }) {
+  const createEvent = useMutation(api.events.createCommunityEvent);
+  const updateEvent = useMutation(api.events.updateCommunityEvent);
+  const [status, setStatus] = useState<EventEditorStatus>({ kind: "idle" });
+  const [, startTransition] = useTransition();
+
+  async function onSubmit(submitEvent: FormEvent<HTMLFormElement>) {
+    submitEvent.preventDefault();
+    const form = submitEvent.currentTarget;
+    const formData = new FormData(form);
+    const startAt = fromLocalInputValue(stringField(formData.get("startAt")));
+    const endAtInput = optionalString(stringField(formData.get("endAt")));
+    const payload = {
+      title: stringField(formData.get("title")),
+      preferredSlug: optionalString(stringField(formData.get("preferredSlug"))),
+      communitySlug: optionalString(stringField(formData.get("communitySlug"))),
+      worldSlug: optionalString(stringField(formData.get("worldSlug"))),
+      startAt,
+      ...(endAtInput ? { endAt: fromLocalInputValue(endAtInput) } : {}),
+      timezone: optionalString(stringField(formData.get("timezone"))),
+      summary: optionalString(stringField(formData.get("summary"))),
+      notes: optionalString(stringField(formData.get("notes"))),
+      sourceLabel: optionalString(stringField(formData.get("sourceLabel"))),
+      sourceUrl: optionalString(stringField(formData.get("sourceUrl"))),
+      posterImageUrl: optionalString(stringField(formData.get("posterImageUrl"))),
+      mediaLinks: parseMediaLinks(stringField(formData.get("mediaLinks"))),
+      participantLinks: parseParticipantLinks(stringField(formData.get("participantLinks"))),
+    };
+
+    setStatus({ kind: "submitting" });
+
+    try {
+      const result = event
+        ? await updateEvent({ currentSlug: event.slug, ...payload })
+        : await createEvent(payload);
+
+      startTransition(() => setStatus({ kind: "success", result }));
+    } catch (error) {
+      startTransition(() => setStatus({ kind: "error", message: eventEditorErrorMessage(error) }));
+    }
+  }
+
+  const isSubmitting = status.kind === "submitting";
+
+  return (
+    <form className="grid gap-5" onSubmit={onSubmit}>
+      <div className="grid gap-4 sm:grid-cols-2">
+        <label className="grid gap-2 text-sm font-medium">
+          Event title
+          <input className="rounded-2xl border border-border bg-surface-strong px-4 py-3 font-normal outline-none transition focus:border-accent" defaultValue={event?.title} name="title" placeholder="Afterglow Harbor Sessions" required />
+        </label>
+        <label className="grid gap-2 text-sm font-medium">
+          Optional slug
+          <input className="rounded-2xl border border-border bg-surface-strong px-4 py-3 font-normal outline-none transition focus:border-accent" defaultValue={event?.slug} name="preferredSlug" placeholder="afterglow-harbor-sessions" />
+        </label>
+      </div>
+
+      <div className="grid gap-4 sm:grid-cols-2">
+        <label className="grid gap-2 text-sm font-medium">
+          Community slug
+          <input className="rounded-2xl border border-border bg-surface-strong px-4 py-3 font-normal outline-none transition focus:border-accent" defaultValue={event?.communitySlug} name="communitySlug" placeholder="afterglow-social" />
+        </label>
+        <label className="grid gap-2 text-sm font-medium">
+          Optional world slug
+          <input className="rounded-2xl border border-border bg-surface-strong px-4 py-3 font-normal outline-none transition focus:border-accent" defaultValue={event?.worlds[0]?.slug} name="worldSlug" placeholder="neon-harbor" />
+        </label>
+      </div>
+
+      <div className="grid gap-4 sm:grid-cols-3">
+        <label className="grid gap-2 text-sm font-medium">
+          Start
+          <input className="rounded-2xl border border-border bg-surface-strong px-4 py-3 font-normal outline-none transition focus:border-accent" defaultValue={toLocalInputValue(event?.startAt)} name="startAt" required type="datetime-local" />
+        </label>
+        <label className="grid gap-2 text-sm font-medium">
+          End
+          <input className="rounded-2xl border border-border bg-surface-strong px-4 py-3 font-normal outline-none transition focus:border-accent" defaultValue={toLocalInputValue(event?.endAt)} name="endAt" type="datetime-local" />
+        </label>
+        <label className="grid gap-2 text-sm font-medium">
+          Time zone
+          <input className="rounded-2xl border border-border bg-surface-strong px-4 py-3 font-normal outline-none transition focus:border-accent" defaultValue={event?.timezone} name="timezone" placeholder="America/New_York" />
+        </label>
+      </div>
+
+      <label className="grid gap-2 text-sm font-medium">
+        Summary
+        <input className="rounded-2xl border border-border bg-surface-strong px-4 py-3 font-normal outline-none transition focus:border-accent" defaultValue={event?.summary} name="summary" placeholder="Short public event summary" />
+      </label>
+
+      <label className="grid gap-2 text-sm font-medium">
+        Public notes
+        <textarea className="min-h-28 rounded-2xl border border-border bg-surface-strong px-4 py-3 font-normal outline-none transition focus:border-accent" defaultValue={event?.notes} name="notes" placeholder="Door notes, schedule notes, or other public context" />
+      </label>
+
+      <div className="grid gap-4 sm:grid-cols-3">
+        <label className="grid gap-2 text-sm font-medium sm:col-span-1">
+          Source label
+          <input className="rounded-2xl border border-border bg-surface-strong px-4 py-3 font-normal outline-none transition focus:border-accent" defaultValue={event?.source.label} name="sourceLabel" placeholder="Community event listing" />
+        </label>
+        <label className="grid gap-2 text-sm font-medium sm:col-span-1">
+          Source URL
+          <input className="rounded-2xl border border-border bg-surface-strong px-4 py-3 font-normal outline-none transition focus:border-accent" defaultValue={event?.source.url} name="sourceUrl" placeholder="https://..." />
+        </label>
+        <label className="grid gap-2 text-sm font-medium sm:col-span-1">
+          Poster image URL
+          <input className="rounded-2xl border border-border bg-surface-strong px-4 py-3 font-normal outline-none transition focus:border-accent" defaultValue={event?.posterImageUrl} name="posterImageUrl" placeholder="https://..." />
+        </label>
+      </div>
+
+      <label className="grid gap-2 text-sm font-medium">
+        Media links
+        <textarea className="min-h-28 rounded-2xl border border-border bg-surface-strong px-4 py-3 font-normal outline-none transition focus:border-accent" defaultValue={serializeMediaLinks(event)} name="mediaLinks" placeholder="watch | Twitch watch link | https://... | open&#10;vrcdn | VRCDN PC link | https://... | copy" />
+        <span className="text-xs leading-5 text-muted">One per line: type | label | https URL | open or copy.</span>
+      </label>
+
+      <label className="grid gap-2 text-sm font-medium">
+        Linked person profiles
+        <textarea className="min-h-28 rounded-2xl border border-border bg-surface-strong px-4 py-3 font-normal outline-none transition focus:border-accent" defaultValue={serializeParticipants(event)} name="participantLinks" placeholder="dj-aurora | Performer&#10;vj-lumen | Staff" />
+        <span className="text-xs leading-5 text-muted">One per line: person slug | freeform role label.</span>
+      </label>
+
+      <div className="rounded-[1.25rem] border border-border bg-surface-strong px-4 py-4 text-sm leading-6 text-muted">
+        Event links publish immediately when saved. Approval, disputes, RSVP/interested state, recurring events, and friend-aware discovery are tracked as follow-on issues.
+      </div>
+
+      <div className="flex flex-col gap-3 sm:flex-row sm:items-center">
+        <button className="inline-flex items-center justify-center rounded-full bg-accent px-5 py-3 text-sm font-medium text-white transition hover:bg-accent-strong disabled:cursor-not-allowed disabled:opacity-60" disabled={isSubmitting} type="submit">
+          {isSubmitting ? "Saving..." : event ? "Update event" : "Create event"}
+        </button>
+        {status.kind === "success" ? (
+          <Link className="inline-flex items-center justify-center rounded-full border border-border bg-surface-strong px-5 py-3 text-sm font-medium" href={status.result.eventPath}>
+            View {status.result.eventPath}
+          </Link>
+        ) : null}
+      </div>
+
+      {status.kind === "error" ? (
+        <p className="rounded-[1rem] border border-accent/35 bg-accent/10 px-4 py-3 text-sm leading-6 text-accent-strong">
+          {status.message}
+        </p>
+      ) : null}
+    </form>
+  );
+}
+
+export function EventEditorForm({ event }: { event?: PublicEvent }) {
+  if (!convexUrl) {
+    return <DisabledEventEditorPanel />;
+  }
+
+  if (!eventEditorAuthReady) {
+    return <SignInRequiredEventEditorPanel />;
+  }
+
+  return <ConnectedEventEditorForm event={event} />;
+}

--- a/apps/web/src/app/events/new/page.tsx
+++ b/apps/web/src/app/events/new/page.tsx
@@ -1,0 +1,51 @@
+import Link from "next/link";
+
+import { EventEditorForm } from "../event-editor-form";
+
+export default function NewEventPage() {
+  return (
+    <main className="min-h-screen px-6 py-10 text-foreground sm:px-10 lg:px-16">
+      <div className="mx-auto flex w-full max-w-5xl flex-col gap-6">
+        <nav className="flex flex-wrap items-center justify-between gap-3 text-sm">
+          <Link className="font-mono uppercase tracking-[0.28em] text-muted" href="/">
+            VRDex
+          </Link>
+          <Link className="rounded-full border border-border bg-surface px-4 py-2 font-medium" href="/submit">
+            Add profile
+          </Link>
+        </nav>
+
+        <section className="overflow-hidden rounded-[2rem] border border-border bg-surface shadow-[0_24px_80px_rgba(64,40,24,0.12)] backdrop-blur">
+          <div className="grid gap-8 px-6 py-8 sm:px-8 lg:grid-cols-[0.82fr_1.18fr] lg:px-10 lg:py-10">
+            <div className="flex flex-col justify-between gap-8">
+              <div>
+                <p className="font-mono text-xs uppercase tracking-[0.28em] text-muted">
+                  Event publishing
+                </p>
+                <h1 className="mt-5 text-4xl leading-none font-semibold tracking-[-0.04em] sm:text-6xl">
+                  Add a VRDex event.
+                </h1>
+                <p className="mt-5 max-w-xl text-base leading-7 text-muted sm:text-lg">
+                  Create a source-aware event with a readable slug, community host, optional world link, media links, poster image, and published person associations.
+                </p>
+              </div>
+
+              <div className="rounded-[1.5rem] border border-border bg-surface-strong px-5 py-5">
+                <p className="font-mono text-xs uppercase tracking-[0.28em] text-muted">
+                  Scope guard
+                </p>
+                <p className="mt-3 text-sm leading-7 text-muted">
+                  This first editor keeps approval, disputes, RSVP, recurring events, short links, and social discovery in follow-up issues while preserving room for them in the data model.
+                </p>
+              </div>
+            </div>
+
+            <div className="rounded-[1.5rem] border border-border bg-white/45 px-5 py-6 sm:px-6">
+              <EventEditorForm />
+            </div>
+          </div>
+        </section>
+      </div>
+    </main>
+  );
+}

--- a/apps/web/src/app/page.tsx
+++ b/apps/web/src/app/page.tsx
@@ -39,6 +39,12 @@ export default async function Home() {
                 </Link>
                 <Link
                   className="inline-flex items-center justify-center rounded-full border border-border bg-surface-strong px-5 py-3 text-sm font-medium transition hover:-translate-y-0.5"
+                  href="/events/new"
+                >
+                  Add an event
+                </Link>
+                <Link
+                  className="inline-flex items-center justify-center rounded-full border border-border bg-surface-strong px-5 py-3 text-sm font-medium transition hover:-translate-y-0.5"
                   href="/server-status"
                 >
                   Server-side baseline

--- a/apps/web/src/convex/playwright-fixtures.ts
+++ b/apps/web/src/convex/playwright-fixtures.ts
@@ -1,10 +1,36 @@
 import type { PublicProfile } from "@/app/_components/profile-public-page";
 import type { PublicActiveWorld } from "@/app/_components/home-active-worlds";
+import type { PublicEvent } from "@/app/_components/event-public-page";
 import type { PublicWorld } from "@/app/_components/world-public-page";
 
 const personSlug = "playwright-dj-aurora";
 const communitySlug = "playwright-afterglow-social";
 const worldSlug = "playwright-neon-harbor";
+const eventSlug = "playwright-afterglow-harbor-sessions";
+
+const eventPreview = {
+  slug: eventSlug,
+  title: "Afterglow Harbor Sessions",
+  startAt: Date.UTC(2026, 5, 14, 22, 0, 0),
+  endAt: Date.UTC(2026, 5, 15, 1, 0, 0),
+  timezone: "UTC",
+  communityName: "Afterglow Social",
+  communitySlug,
+  summary: "A fixture venue night that keeps event-profile context visible in screenshots.",
+  posterImageUrl: "https://example.invalid/events/afterglow-harbor-poster.png",
+  source: {
+    sourceType: "manual" as const,
+    label: "Fixture event listing",
+    url: "https://example.invalid/events/afterglow-harbor-sessions",
+  },
+  worlds: [
+    {
+      slug: worldSlug,
+      displayName: "Neon Harbor",
+    },
+  ],
+  participantCount: 1,
+};
 
 const personProfile: PublicProfile = {
   profileType: "person",
@@ -42,6 +68,8 @@ const personProfile: PublicProfile = {
       sourceLabel: "Fixture attribution",
     },
   ],
+  upcomingEvents: [eventPreview],
+  hostedEvents: [],
   person: {
     pronouns: "she/they",
     roleTags: ["DJ", "Producer", "Host"],
@@ -78,6 +106,8 @@ const communityProfile: PublicProfile = {
       sourceLabel: "Fixture attribution",
     },
   ],
+  upcomingEvents: [],
+  hostedEvents: [eventPreview],
   community: {
     subtype: "Club night",
     categoryTags: ["Music", "Dancing", "Social"],
@@ -136,12 +166,22 @@ const worldProfile: PublicWorld = {
   eventContext: {
     upcoming: [
       {
+        slug: eventSlug,
         title: "Afterglow Harbor Sessions",
         startAt: Date.UTC(2026, 5, 14, 22, 0, 0),
         endAt: Date.UTC(2026, 5, 15, 1, 0, 0),
         timezone: "UTC",
         communityName: "Afterglow Social",
         summary: "A fixture venue night that keeps world-event context visible in screenshots.",
+        posterImageUrl: "https://example.invalid/events/afterglow-harbor-poster.png",
+        mediaLinks: [
+          {
+            type: "watch",
+            label: "Fixture watch link",
+            url: "https://example.invalid/events/afterglow-watch",
+            presentation: "open",
+          },
+        ],
         source: {
           sourceType: "manual",
           label: "Fixture event listing",
@@ -161,6 +201,7 @@ const worldProfile: PublicWorld = {
         timezone: "UTC",
         communityName: "Afterglow Social",
         summary: "A past fixture event used to exercise recent world activity presentation.",
+        mediaLinks: [],
         source: {
           sourceType: "community",
           label: "Community-submitted event",
@@ -184,6 +225,7 @@ const activeWorlds: PublicActiveWorld[] = [
     upcomingEventCount: 2,
     activityLabel: "Hosting upcoming events",
     nextEvent: {
+      slug: eventSlug,
       title: "Afterglow Harbor Sessions",
       startAt: Date.UTC(2026, 5, 14, 22, 0, 0),
       timezone: "UTC",
@@ -196,6 +238,51 @@ const activeWorlds: PublicActiveWorld[] = [
     },
   },
 ];
+
+const publicEvent: PublicEvent = {
+  ...eventPreview,
+  slug: eventSlug,
+  notes: "Fixture event notes make the standalone event route useful during visual review.",
+  mediaLinks: [
+    {
+      type: "watch",
+      label: "Fixture watch link",
+      url: "https://example.invalid/events/afterglow-watch",
+      presentation: "open",
+    },
+    {
+      type: "vrcdn",
+      label: "Fixture VRCDN copy link",
+      url: "https://example.invalid/events/afterglow-vrcdn",
+      presentation: "copy",
+    },
+  ],
+  worlds: [
+    {
+      slug: worldSlug,
+      displayName: "Neon Harbor",
+      tags: ["Club world", "Cyberpunk", "Dance floor"],
+      summary: "A fixture VRChat venue page for world discovery visual review.",
+      association: {
+        sourceType: "manual",
+        confirmationState: "confirmed",
+        confirmedAt: Date.UTC(2026, 4, 1, 12, 0, 0),
+      },
+    },
+  ],
+  participants: [
+    {
+      slug: personSlug,
+      displayName: "DJ Aurora",
+      roleLabel: "Performer",
+      trustLabel: "community_submitted",
+      source: {
+        sourceType: "community",
+        label: "Fixture lineup",
+      },
+    },
+  ],
+};
 
 export function getPlaywrightPublicProfileFixture(
   slug: string,
@@ -234,6 +321,21 @@ export function getPlaywrightPublicWorldFixture(slug: string): PublicWorld | nul
   return null;
 }
 
+export function getPlaywrightPublicEventFixture(slug: string): PublicEvent | null {
+  if (
+    process.env.NODE_ENV === "production" ||
+    process.env.VRDEX_ENABLE_PLAYWRIGHT_FIXTURES !== "true"
+  ) {
+    return null;
+  }
+
+  if (slug === eventSlug) {
+    return publicEvent;
+  }
+
+  return null;
+}
+
 export function getPlaywrightActiveWorldFixtures(): PublicActiveWorld[] | null {
   if (
     process.env.NODE_ENV === "production" ||
@@ -249,4 +351,5 @@ export const playwrightPublicProfilePaths = {
   personPath: `/p/${personSlug}`,
   communityPath: `/c/${communitySlug}`,
   worldPath: `/w/${worldSlug}`,
+  eventPath: `/e/${eventSlug}`,
 };

--- a/apps/web/src/convex/server.ts
+++ b/apps/web/src/convex/server.ts
@@ -2,6 +2,7 @@ import { fetchQuery } from "convex/nextjs";
 import { api } from "@convex-generated-api";
 import {
   getPlaywrightActiveWorldFixtures,
+  getPlaywrightPublicEventFixture,
   getPlaywrightPublicProfileFixture,
   getPlaywrightPublicWorldFixture,
 } from "./playwright-fixtures";
@@ -46,7 +47,11 @@ export async function fetchPublicProfileBySlug(slug: string, profileType: Public
   }
 
   try {
-    const profile = await fetchQuery(api.profiles.getPublicBySlug, { slug, profileType });
+    const profile = await fetchQuery(api.profiles.getPublicBySlug, {
+      slug,
+      profileType,
+      now: Date.now(),
+    });
 
     return {
       kind: "live" as const,
@@ -56,6 +61,38 @@ export async function fetchPublicProfileBySlug(slug: string, profileType: Public
     const message = error instanceof Error ? error.message : String(error);
 
     console.error(`Server-side Convex profile fetch failed: ${message}`);
+
+    return {
+      kind: "error" as const,
+    };
+  }
+}
+
+export async function fetchPublicEventBySlug(slug: string) {
+  const fixtureEvent = getPlaywrightPublicEventFixture(slug);
+
+  if (fixtureEvent !== null) {
+    return {
+      kind: "live" as const,
+      event: fixtureEvent,
+    };
+  }
+
+  if (!process.env.NEXT_PUBLIC_CONVEX_URL) {
+    return { kind: "missing-url" as const };
+  }
+
+  try {
+    const event = await fetchQuery(api.events.getPublicBySlug, { slug });
+
+    return {
+      kind: "live" as const,
+      event,
+    };
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+
+    console.error(`Server-side Convex event fetch failed: ${message}`);
 
     return {
       kind: "error" as const,

--- a/convex/README.md
+++ b/convex/README.md
@@ -14,6 +14,8 @@ This directory holds the initial Convex backend slice for `VRDex`.
 - `_worldSlugs.ts` contains pure world slug validation, generation, and lookup helpers
 - `_worldPublic.ts` contains public world projection helpers
 - `worlds.ts` exposes public world reads
+- `_eventSlugs.ts`, `_eventInputs.ts`, and `_eventPublic.ts` contain event slug, input, and public projection helpers
+- `events.ts` exposes public event reads and authenticated event editor mutations
 - `_generated/` contains committed Convex codegen output and should not be edited by hand
 - `tsconfig.json` is the Convex-managed TypeScript config for backend functions
 
@@ -32,3 +34,5 @@ The profile schema and community submission contracts live in `docs/backend/prof
 The slug, permission, and claim-state contracts live in `docs/backend/profile-slugs.md` and `docs/backend/profile-access-and-claims.md`.
 
 The first world-discovery planning contract lives in `docs/planning/world-discovery.md`.
+
+The event schema and profile-association contracts live in `docs/backend/event-schema.md`.

--- a/convex/_communityAuthority.ts
+++ b/convex/_communityAuthority.ts
@@ -1,0 +1,56 @@
+import type { Id } from "./_generated/dataModel";
+import type { DatabaseReader } from "./_generated/server";
+
+export type AuthSubject = {
+  tokenIdentifier: string;
+  issuer: string;
+  subject: string;
+  displayName?: string;
+};
+
+type IdentityLike = {
+  tokenIdentifier: string;
+  issuer: string;
+  subject: string;
+  name?: string;
+};
+
+type CommunityCapability =
+  | "manage_profile"
+  | "manage_events"
+  | "manage_staff"
+  | "manage_integrations"
+  | "manage_billing";
+
+export function toAuthSubject(identity: IdentityLike): AuthSubject {
+  return {
+    tokenIdentifier: identity.tokenIdentifier,
+    issuer: identity.issuer,
+    subject: identity.subject,
+    ...(identity.name ? { displayName: identity.name.slice(0, 120) } : {}),
+  };
+}
+
+export function isSameAuthSubject(first: AuthSubject | undefined, second: AuthSubject): boolean {
+  return first?.tokenIdentifier === second.tokenIdentifier;
+}
+
+export async function subjectHasCommunityCapability(
+  db: DatabaseReader,
+  communityProfileId: Id<"profiles">,
+  subject: AuthSubject,
+  capability: CommunityCapability,
+): Promise<boolean> {
+  const authorities = await db
+    .query("communityAuthorities")
+    .withIndex("by_subjectTokenIdentifier_state", (query) =>
+      query.eq("subjectTokenIdentifier", subject.tokenIdentifier).eq("state", "active"),
+    )
+    .take(20);
+
+  return authorities.some(
+    (authority) =>
+      authority.communityProfileId === communityProfileId &&
+      authority.capabilities.includes(capability),
+  );
+}

--- a/convex/_communityAuthority.ts
+++ b/convex/_communityAuthority.ts
@@ -43,14 +43,13 @@ export async function subjectHasCommunityCapability(
 ): Promise<boolean> {
   const authorities = await db
     .query("communityAuthorities")
-    .withIndex("by_subjectTokenIdentifier_state", (query) =>
-      query.eq("subjectTokenIdentifier", subject.tokenIdentifier).eq("state", "active"),
+    .withIndex("by_subjectTokenIdentifier_state_communityProfileId", (query) =>
+      query
+        .eq("subjectTokenIdentifier", subject.tokenIdentifier)
+        .eq("state", "active")
+        .eq("communityProfileId", communityProfileId),
     )
-    .take(20);
+    .take(1);
 
-  return authorities.some(
-    (authority) =>
-      authority.communityProfileId === communityProfileId &&
-      authority.capabilities.includes(capability),
-  );
+  return authorities.some((authority) => authority.capabilities.includes(capability));
 }

--- a/convex/_eventInputs.ts
+++ b/convex/_eventInputs.ts
@@ -1,0 +1,315 @@
+import { normalizeProfileInlineText, sanitizeProfileTextList } from "./_profileSubmissions";
+
+export const EVENT_TITLE_MIN_LENGTH = 2;
+export const EVENT_TITLE_MAX_LENGTH = 120;
+export const EVENT_SUMMARY_MAX_LENGTH = 240;
+export const EVENT_NOTES_MAX_LENGTH = 1_200;
+export const EVENT_TIMEZONE_MAX_LENGTH = 64;
+export const EVENT_SOURCE_LABEL_MAX_LENGTH = 120;
+export const EVENT_MEDIA_LINK_MAX_COUNT = 8;
+export const EVENT_MEDIA_LABEL_MAX_LENGTH = 80;
+export const EVENT_PARTICIPANT_MAX_COUNT = 40;
+export const EVENT_PARTICIPANT_ROLE_MAX_LENGTH = 48;
+
+type EventMediaLinkType =
+  | "event_page"
+  | "watch"
+  | "stream"
+  | "vrcdn"
+  | "discord"
+  | "ticket"
+  | "other";
+
+type EventMediaLinkPresentation = "open" | "copy";
+
+export type EventMediaLinkInput = {
+  type: EventMediaLinkType;
+  label: string;
+  url: string;
+  presentation?: EventMediaLinkPresentation;
+};
+
+export type SanitizedEventMediaLink = {
+  type: EventMediaLinkType;
+  label: string;
+  url: string;
+  presentation: EventMediaLinkPresentation;
+};
+
+export type EventParticipantInput = {
+  personSlug: string;
+  roleLabel?: string;
+  sourceLabel?: string;
+  sourceUrl?: string;
+  notes?: string;
+};
+
+export type SanitizedEventParticipantInput = {
+  personSlug: string;
+  roleLabel: string;
+  sourceLabel: string;
+  sourceUrl?: string;
+  notes?: string;
+};
+
+export type EventDraftInput = {
+  title: string;
+  startAt: number;
+  endAt?: number;
+  timezone?: string;
+  communitySlug?: string;
+  summary?: string;
+  notes?: string;
+  sourceLabel?: string;
+  sourceUrl?: string;
+  posterImageUrl?: string;
+  mediaLinks?: EventMediaLinkInput[];
+  participantLinks?: EventParticipantInput[];
+  worldSlug?: string;
+  preferredSlug?: string;
+};
+
+export type SanitizedEventDraftInput = {
+  title: string;
+  sortTitle: string;
+  startAt: number;
+  endAt?: number;
+  timezone?: string;
+  communitySlug?: string;
+  summary?: string;
+  notes?: string;
+  sourceLabel: string;
+  sourceUrl?: string;
+  posterImageUrl?: string;
+  mediaLinks: SanitizedEventMediaLink[];
+  participantLinks: SanitizedEventParticipantInput[];
+  worldSlug?: string;
+  preferredSlug?: string;
+};
+
+const eventMediaLinkTypes = new Set<EventMediaLinkType>([
+  "event_page",
+  "watch",
+  "stream",
+  "vrcdn",
+  "discord",
+  "ticket",
+  "other",
+]);
+
+function requireBoundedText(
+  input: string,
+  fieldName: string,
+  minLength: number,
+  maxLength: number,
+): string {
+  const value = normalizeProfileInlineText(input);
+
+  if (value.length < minLength) {
+    throw new Error(`${fieldName} must be at least ${minLength} characters.`);
+  }
+
+  if (value.length > maxLength) {
+    throw new Error(`${fieldName} must be ${maxLength} characters or fewer.`);
+  }
+
+  return value;
+}
+
+function optionalBoundedText(
+  input: string | undefined,
+  fieldName: string,
+  maxLength: number,
+): string | undefined {
+  if (input === undefined) {
+    return undefined;
+  }
+
+  const value = normalizeProfileInlineText(input);
+
+  if (value.length === 0) {
+    return undefined;
+  }
+
+  if (value.length > maxLength) {
+    throw new Error(`${fieldName} must be ${maxLength} characters or fewer.`);
+  }
+
+  return value;
+}
+
+export function createEventSortTitle(title: string): string {
+  const asciiSortTitle = normalizeProfileInlineText(
+    title
+      .normalize("NFKD")
+      .replace(/[\u0300-\u036f]/g, "")
+      .toLowerCase()
+      .replace(/[^a-z0-9]+/g, " "),
+  );
+
+  return asciiSortTitle || normalizeProfileInlineText(title).toLowerCase();
+}
+
+function requireValidTimestamp(input: number, fieldName: string): number {
+  if (!Number.isFinite(input)) {
+    throw new Error(`${fieldName} must be a valid timestamp.`);
+  }
+
+  return input;
+}
+
+function optionalHttpsUrl(input: string | undefined, fieldName: string): string | undefined {
+  const value = optionalBoundedText(input, fieldName, 2_048);
+
+  if (value === undefined) {
+    return undefined;
+  }
+
+  try {
+    const url = new URL(value);
+
+    if (url.protocol !== "https:") {
+      throw new Error(`${fieldName} must use https.`);
+    }
+
+    return url.href;
+  } catch (error) {
+    if (error instanceof Error && error.message === `${fieldName} must use https.`) {
+      throw error;
+    }
+
+    throw new Error(`${fieldName} must be a valid URL.`);
+  }
+}
+
+function sanitizeEventMediaLinks(input: EventMediaLinkInput[] | undefined): SanitizedEventMediaLink[] {
+  const links: SanitizedEventMediaLink[] = [];
+  const seenUrls = new Set<string>();
+
+  for (const link of input ?? []) {
+    if (!eventMediaLinkTypes.has(link.type)) {
+      throw new Error("Event media link type is not supported.");
+    }
+
+    const label = requireBoundedText(link.label, "Media link label", 1, EVENT_MEDIA_LABEL_MAX_LENGTH);
+    const url = optionalHttpsUrl(link.url, "Media link URL");
+
+    if (url === undefined) {
+      continue;
+    }
+
+    const key = url.toLowerCase();
+    if (seenUrls.has(key)) {
+      continue;
+    }
+
+    if (links.length >= EVENT_MEDIA_LINK_MAX_COUNT) {
+      throw new Error(`Media links can include at most ${EVENT_MEDIA_LINK_MAX_COUNT} entries.`);
+    }
+
+    seenUrls.add(key);
+    links.push({
+      type: link.type,
+      label,
+      url,
+      presentation: link.presentation ?? (link.type === "vrcdn" ? "copy" : "open"),
+    });
+  }
+
+  return links;
+}
+
+function sanitizeParticipantLinks(
+  input: EventParticipantInput[] | undefined,
+  fallbackSourceLabel: string,
+): SanitizedEventParticipantInput[] {
+  const links: SanitizedEventParticipantInput[] = [];
+  const seenSlugs = new Set<string>();
+
+  for (const link of input ?? []) {
+    const [personSlug] = sanitizeProfileTextList([link.personSlug], "Participant profile slugs", {
+      maxItems: 1,
+      maxLength: 64,
+    });
+
+    if (personSlug === undefined) {
+      continue;
+    }
+
+    const key = personSlug.toLowerCase();
+    if (seenSlugs.has(key)) {
+      continue;
+    }
+
+    if (links.length >= EVENT_PARTICIPANT_MAX_COUNT) {
+      throw new Error(`Participant links can include at most ${EVENT_PARTICIPANT_MAX_COUNT} entries.`);
+    }
+
+    const roleLabel = optionalBoundedText(
+      link.roleLabel,
+      "Participant role",
+      EVENT_PARTICIPANT_ROLE_MAX_LENGTH,
+    ) ?? "Performer";
+    const sourceLabel = optionalBoundedText(
+      link.sourceLabel,
+      "Participant source label",
+      EVENT_SOURCE_LABEL_MAX_LENGTH,
+    ) ?? fallbackSourceLabel;
+    const sourceUrl = optionalHttpsUrl(link.sourceUrl, "Participant source URL");
+    const notes = optionalBoundedText(link.notes, "Participant notes", EVENT_NOTES_MAX_LENGTH);
+
+    seenSlugs.add(key);
+    links.push({
+      personSlug,
+      roleLabel,
+      sourceLabel,
+      ...(sourceUrl ? { sourceUrl } : {}),
+      ...(notes ? { notes } : {}),
+    });
+  }
+
+  return links;
+}
+
+export function sanitizeEventDraftInput(input: EventDraftInput): SanitizedEventDraftInput {
+  const title = requireBoundedText(
+    input.title,
+    "Event title",
+    EVENT_TITLE_MIN_LENGTH,
+    EVENT_TITLE_MAX_LENGTH,
+  );
+  const startAt = requireValidTimestamp(input.startAt, "Event start time");
+  const endAt = input.endAt === undefined ? undefined : requireValidTimestamp(input.endAt, "Event end time");
+
+  if (endAt !== undefined && endAt <= startAt) {
+    throw new Error("Event end time must be after the start time.");
+  }
+
+  const sourceLabel = optionalBoundedText(
+    input.sourceLabel,
+    "Event source label",
+    EVENT_SOURCE_LABEL_MAX_LENGTH,
+  ) ?? "Community-submitted event";
+
+  return {
+    title,
+    sortTitle: createEventSortTitle(title),
+    startAt,
+    ...(endAt ? { endAt } : {}),
+    ...optionalObjectField("timezone", optionalBoundedText(input.timezone, "Time zone", EVENT_TIMEZONE_MAX_LENGTH)),
+    ...optionalObjectField("communitySlug", optionalBoundedText(input.communitySlug, "Community slug", 64)),
+    ...optionalObjectField("summary", optionalBoundedText(input.summary, "Event summary", EVENT_SUMMARY_MAX_LENGTH)),
+    ...optionalObjectField("notes", optionalBoundedText(input.notes, "Event notes", EVENT_NOTES_MAX_LENGTH)),
+    sourceLabel,
+    ...optionalObjectField("sourceUrl", optionalHttpsUrl(input.sourceUrl, "Event source URL")),
+    ...optionalObjectField("posterImageUrl", optionalHttpsUrl(input.posterImageUrl, "Poster image URL")),
+    mediaLinks: sanitizeEventMediaLinks(input.mediaLinks),
+    participantLinks: sanitizeParticipantLinks(input.participantLinks, sourceLabel),
+    ...optionalObjectField("worldSlug", optionalBoundedText(input.worldSlug, "World slug", 64)),
+    ...optionalObjectField("preferredSlug", optionalBoundedText(input.preferredSlug, "Event slug", 64)),
+  };
+}
+
+function optionalObjectField<T>(key: string, value: T | undefined): Record<string, T> {
+  return value === undefined ? {} : { [key]: value };
+}

--- a/convex/_eventPublic.ts
+++ b/convex/_eventPublic.ts
@@ -1,0 +1,331 @@
+import type { Doc, Id } from "./_generated/dataModel";
+import type { DatabaseReader } from "./_generated/server";
+import { optionalField, safeHttpsUrl } from "./_publicFields";
+import { canReadProfile } from "./_profilePermissions";
+import { getProfileTrustLabel } from "./_profileStates";
+
+const EVENT_PREVIEW_LIMIT = 6;
+const EVENT_ASSOCIATION_LIMIT = 80;
+
+type PublicEventSourceType = "manual" | "community" | "partner" | "import" | "ai_suggested";
+type PublicEventMediaLinkType =
+  | "event_page"
+  | "watch"
+  | "stream"
+  | "vrcdn"
+  | "discord"
+  | "ticket"
+  | "other";
+type PublicEventMediaLinkPresentation = "open" | "copy";
+
+export type PublicEventRecord = {
+  event: Doc<"events">;
+  community?: Doc<"profiles">;
+  worlds: Array<{ association: Doc<"eventWorlds">; world: Doc<"worlds"> }>;
+  participants: PublicEventParticipantRecord[];
+};
+
+type PublicEventParticipantRecord = {
+  association: Doc<"eventParticipants">;
+  profile: Doc<"profiles">;
+};
+
+export type PublicEventPreview = {
+  slug?: string;
+  title: string;
+  startAt: number;
+  endAt?: number;
+  timezone?: string;
+  communityName?: string;
+  communitySlug?: string;
+  summary?: string;
+  posterImageUrl?: string;
+  source: {
+    sourceType: PublicEventSourceType;
+    label: string;
+    url?: string;
+  };
+  worlds: Array<{
+    slug: string;
+    displayName: string;
+  }>;
+  participantCount: number;
+};
+
+export type PublicEvent = PublicEventPreview & {
+  slug: string;
+  notes?: string;
+  mediaLinks: Array<{
+    type: PublicEventMediaLinkType;
+    label: string;
+    url: string;
+    presentation: PublicEventMediaLinkPresentation;
+  }>;
+  worlds: Array<{
+    slug: string;
+    displayName: string;
+    tags: string[];
+    summary?: string;
+    heroImageUrl?: string;
+    association: {
+      sourceType: PublicEventSourceType;
+      confirmationState: "confirmed";
+      confirmedAt?: number;
+    };
+  }>;
+  participants: Array<{
+    slug: string;
+    displayName: string;
+    roleLabel: string;
+    trustLabel: "community_submitted" | "unclaimed" | "claimed_unverified" | "claimed_verified";
+    source: {
+      sourceType: PublicEventSourceType;
+      label: string;
+      url?: string;
+    };
+  }>;
+};
+
+function eventEndsAt(event: Pick<Doc<"events">, "startAt" | "endAt">): number {
+  return event.endAt ?? event.startAt;
+}
+
+function createPublicEventMediaLinks(event: Doc<"events">): PublicEvent["mediaLinks"] {
+  return (event.mediaLinks ?? []).flatMap((link) => {
+    const url = safeHttpsUrl(link.url);
+
+    if (url === undefined) {
+      return [];
+    }
+
+    return [{ ...link, url }];
+  });
+}
+
+export function toPublicEventPreviewFromRecord(record: PublicEventRecord): PublicEventPreview {
+  const { community, event, participants, worlds } = record;
+  const sourceUrl = safeHttpsUrl(event.sourceUrl);
+  const posterImageUrl = safeHttpsUrl(event.posterImageUrl);
+
+  return {
+    ...optionalField("slug", event.slug),
+    title: event.title,
+    startAt: event.startAt,
+    source: {
+      sourceType: event.sourceType,
+      label: event.sourceLabel,
+      ...optionalField("url", sourceUrl),
+    },
+    worlds: worlds.map(({ world }) => ({
+      slug: world.slug,
+      displayName: world.displayName,
+    })),
+    participantCount: participants.length,
+    ...optionalField("endAt", event.endAt),
+    ...optionalField("timezone", event.timezone),
+    ...optionalField("communityName", community?.displayName ?? event.communityName),
+    ...optionalField("communitySlug", community?.slug),
+    ...optionalField("summary", event.summary),
+    ...optionalField("posterImageUrl", posterImageUrl),
+  };
+}
+
+export function toPublicEvent(record: PublicEventRecord): PublicEvent | null {
+  if (record.event.slug === undefined) {
+    return null;
+  }
+
+  const preview = toPublicEventPreviewFromRecord(record);
+
+  return {
+    ...preview,
+    slug: record.event.slug,
+    mediaLinks: createPublicEventMediaLinks(record.event),
+    worlds: record.worlds.map(({ association, world }) => {
+      const heroImageUrl = safeHttpsUrl(world.heroImageUrl);
+
+      return {
+        slug: world.slug,
+        displayName: world.displayName,
+        tags: world.tags,
+        association: {
+          sourceType: association.sourceType,
+          confirmationState: "confirmed" as const,
+          ...optionalField("confirmedAt", association.confirmedAt),
+        },
+        ...optionalField("summary", world.summary),
+        ...optionalField("heroImageUrl", heroImageUrl),
+      };
+    }),
+    participants: record.participants.map(({ association, profile }) => {
+      const sourceUrl = safeHttpsUrl(association.sourceUrl);
+
+      return {
+        slug: profile.slug,
+        displayName: profile.displayName,
+        roleLabel: association.roleLabel,
+        trustLabel: getProfileTrustLabel(profile.claimState, profile.creationSource),
+        source: {
+          sourceType: association.sourceType,
+          label: association.sourceLabel,
+          ...optionalField("url", sourceUrl),
+        },
+      };
+    }),
+    ...optionalField("notes", record.event.notes),
+  };
+}
+
+async function getPublishedCommunity(db: DatabaseReader, event: Doc<"events">) {
+  if (event.communityProfileId === undefined) {
+    return undefined;
+  }
+
+  const community = await db.get(event.communityProfileId);
+
+  if (
+    community === null ||
+    community.profileType !== "community" ||
+    !canReadProfile("public", community)
+  ) {
+    return undefined;
+  }
+
+  return community;
+}
+
+async function getPublicEventWorldRecords(db: DatabaseReader, event: Doc<"events">) {
+  const associations = await db
+    .query("eventWorlds")
+    .withIndex("by_eventId", (query) => query.eq("eventId", event._id))
+    .filter((query) => query.eq(query.field("confirmationState"), "confirmed"))
+    .take(EVENT_ASSOCIATION_LIMIT);
+
+  const records = await Promise.all(
+    associations.map(async (association) => {
+      const world = await db.get(association.worldId);
+
+      if (world === null || world.publicationState !== "published") {
+        return null;
+      }
+
+      return { association, world };
+    }),
+  );
+
+  return records.filter((record): record is { association: Doc<"eventWorlds">; world: Doc<"worlds"> } =>
+    record !== null,
+  );
+}
+
+async function getPublicEventParticipantRecords(db: DatabaseReader, event: Doc<"events">) {
+  const associations = await db
+    .query("eventParticipants")
+    .withIndex("by_eventId", (query) => query.eq("eventId", event._id))
+    .filter((query) => query.eq(query.field("confirmationState"), "confirmed"))
+    .take(EVENT_ASSOCIATION_LIMIT);
+
+  const records: Array<PublicEventParticipantRecord | null> = await Promise.all(
+    associations.map(async (association) => {
+      const profile = await db.get(association.personProfileId);
+
+      if (
+        profile === null ||
+        profile.profileType !== "person" ||
+        !canReadProfile("public", profile)
+      ) {
+        return null;
+      }
+
+      return { association, profile };
+    }),
+  );
+
+  return records.filter((record): record is PublicEventParticipantRecord => record !== null);
+}
+
+async function getPublicEventRecord(
+  db: DatabaseReader,
+  event: Doc<"events">,
+): Promise<PublicEventRecord | null> {
+  if (event.publicationState !== "published") {
+    return null;
+  }
+
+  const [community, worlds, participants] = await Promise.all([
+    getPublishedCommunity(db, event),
+    getPublicEventWorldRecords(db, event),
+    getPublicEventParticipantRecords(db, event),
+  ]);
+
+  return { event, worlds, participants, ...optionalField("community", community) };
+}
+
+export async function getPublicEventBySlug(
+  db: DatabaseReader,
+  event: Doc<"events"> | null,
+): Promise<PublicEvent | null> {
+  if (event === null) {
+    return null;
+  }
+
+  const record = await getPublicEventRecord(db, event);
+
+  return record === null ? null : toPublicEvent(record);
+}
+
+export async function getPublicEventPreviews(
+  db: DatabaseReader,
+  events: Doc<"events">[],
+  options: { now?: number; limit?: number } = {},
+): Promise<PublicEventPreview[]> {
+  const now = options.now;
+  const limit = Math.max(1, Math.min(options.limit ?? EVENT_PREVIEW_LIMIT, EVENT_PREVIEW_LIMIT));
+  const records = (
+    await Promise.all(events.map((event) => getPublicEventRecord(db, event)))
+  ).filter((record): record is PublicEventRecord => record !== null);
+
+  return records
+    .filter(({ event }) => now === undefined || eventEndsAt(event) >= now)
+    .sort((first, second) => first.event.startAt - second.event.startAt)
+    .map(toPublicEventPreviewFromRecord)
+    .slice(0, limit);
+}
+
+export async function getPublicCommunityHostedEvents(
+  db: DatabaseReader,
+  communityProfileId: Id<"profiles">,
+  now: number,
+  limit = EVENT_PREVIEW_LIMIT,
+): Promise<PublicEventPreview[]> {
+  const events = await db
+    .query("events")
+    .withIndex("by_communityProfileId_startAt", (query) =>
+      query.eq("communityProfileId", communityProfileId).gte("startAt", now),
+    )
+    .take(EVENT_ASSOCIATION_LIMIT);
+
+  return getPublicEventPreviews(db, events, { now, limit });
+}
+
+export async function getPublicPersonUpcomingEvents(
+  db: DatabaseReader,
+  personProfileId: Id<"profiles">,
+  now: number,
+  limit = EVENT_PREVIEW_LIMIT,
+): Promise<PublicEventPreview[]> {
+  const participantLinks = await db
+    .query("eventParticipants")
+    .withIndex("by_personProfileId_confirmationState_eventStartAt", (query) =>
+      query
+        .eq("personProfileId", personProfileId)
+        .eq("confirmationState", "confirmed")
+        .gte("eventStartAt", now),
+    )
+    .take(EVENT_ASSOCIATION_LIMIT);
+  const events = (
+    await Promise.all(participantLinks.map((link) => db.get(link.eventId)))
+  ).filter((event): event is Doc<"events"> => event !== null);
+
+  return getPublicEventPreviews(db, events, { now, limit });
+}

--- a/convex/_eventPublic.ts
+++ b/convex/_eventPublic.ts
@@ -4,8 +4,9 @@ import { optionalField, safeHttpsUrl } from "./_publicFields";
 import { canReadProfile } from "./_profilePermissions";
 import { getProfileTrustLabel } from "./_profileStates";
 
-const EVENT_PREVIEW_LIMIT = 6;
+const EVENT_PREVIEW_DEFAULT_LIMIT = 6;
 const EVENT_ASSOCIATION_LIMIT = 80;
+const EVENT_PREVIEW_MAX_LIMIT = EVENT_ASSOCIATION_LIMIT;
 
 type PublicEventSourceType = "manual" | "community" | "partner" | "import" | "ai_suggested";
 type PublicEventMediaLinkType =
@@ -280,7 +281,10 @@ export async function getPublicEventPreviews(
   options: { now?: number; limit?: number } = {},
 ): Promise<PublicEventPreview[]> {
   const now = options.now;
-  const limit = Math.max(1, Math.min(options.limit ?? EVENT_PREVIEW_LIMIT, EVENT_PREVIEW_LIMIT));
+  const limit = Math.max(
+    1,
+    Math.min(options.limit ?? EVENT_PREVIEW_DEFAULT_LIMIT, EVENT_PREVIEW_MAX_LIMIT),
+  );
   const records = (
     await Promise.all(events.map((event) => getPublicEventRecord(db, event)))
   ).filter((record): record is PublicEventRecord => record !== null);
@@ -296,7 +300,7 @@ export async function getPublicCommunityHostedEvents(
   db: DatabaseReader,
   communityProfileId: Id<"profiles">,
   now: number,
-  limit = EVENT_PREVIEW_LIMIT,
+  limit = EVENT_PREVIEW_DEFAULT_LIMIT,
 ): Promise<PublicEventPreview[]> {
   const events = await db
     .query("events")
@@ -312,7 +316,7 @@ export async function getPublicPersonUpcomingEvents(
   db: DatabaseReader,
   personProfileId: Id<"profiles">,
   now: number,
-  limit = EVENT_PREVIEW_LIMIT,
+  limit = EVENT_PREVIEW_DEFAULT_LIMIT,
 ): Promise<PublicEventPreview[]> {
   const participantLinks = await db
     .query("eventParticipants")

--- a/convex/_eventSlugs.ts
+++ b/convex/_eventSlugs.ts
@@ -1,0 +1,195 @@
+import type { Id } from "./_generated/dataModel";
+import type { DatabaseReader } from "./_generated/server";
+import {
+  PROFILE_SLUG_MAX_LENGTH,
+  PROFILE_SLUG_MIN_LENGTH,
+  PROFILE_SLUG_PATTERN,
+  normalizeProfileSlugInput,
+} from "./_profileSlugs";
+
+export const EVENT_SLUG_MIN_LENGTH = PROFILE_SLUG_MIN_LENGTH;
+export const EVENT_SLUG_MAX_LENGTH = PROFILE_SLUG_MAX_LENGTH;
+export const EVENT_SLUG_PATTERN = PROFILE_SLUG_PATTERN;
+export const EVENT_SLUG_FALLBACK_BASE = "event-page";
+
+export const RESERVED_EVENT_SLUGS = [
+  "about",
+  "account",
+  "admin",
+  "api",
+  "auth",
+  "billing",
+  "blog",
+  "c",
+  "calendar",
+  "contact",
+  "dashboard",
+  "docs",
+  "e",
+  "events",
+  "help",
+  "l",
+  "login",
+  "logout",
+  "me",
+  "moderation",
+  "new",
+  "p",
+  "people",
+  "pricing",
+  "privacy",
+  "profile",
+  "search",
+  "settings",
+  "signup",
+  "support",
+  "terms",
+  "vrdex",
+  "w",
+  "worlds",
+] as const;
+
+export type EventSlugValidationReason =
+  | "empty"
+  | "too_short"
+  | "too_long"
+  | "invalid_format"
+  | "reserved";
+
+export type EventSlugValidationResult =
+  | { ok: true; slug: string }
+  | { ok: false; reason: EventSlugValidationReason };
+
+export type EventSlugAvailabilityResult =
+  | { available: true; slug: string }
+  | { available: false; slug: string; reason: "invalid" | "reserved" | "taken" };
+
+const RESERVED_EVENT_SLUG_SET = new Set<string>(RESERVED_EVENT_SLUGS);
+
+export function normalizeEventSlugInput(input: string): string {
+  return normalizeProfileSlugInput(input);
+}
+
+export function validateEventSlug(slug: string): EventSlugValidationResult {
+  if (slug.length === 0) {
+    return { ok: false, reason: "empty" };
+  }
+
+  if (slug.length < EVENT_SLUG_MIN_LENGTH) {
+    return { ok: false, reason: "too_short" };
+  }
+
+  if (slug.length > EVENT_SLUG_MAX_LENGTH) {
+    return { ok: false, reason: "too_long" };
+  }
+
+  if (!EVENT_SLUG_PATTERN.test(slug)) {
+    return { ok: false, reason: "invalid_format" };
+  }
+
+  if (RESERVED_EVENT_SLUG_SET.has(slug)) {
+    return { ok: false, reason: "reserved" };
+  }
+
+  return { ok: true, slug };
+}
+
+export function toEventSlug(input: string): EventSlugValidationResult {
+  return validateEventSlug(normalizeEventSlugInput(input));
+}
+
+function eventDateSlugPart(startAt: number): string {
+  const date = new Date(startAt);
+
+  if (Number.isNaN(date.getTime())) {
+    return "date";
+  }
+
+  return date.toISOString().slice(0, 10);
+}
+
+export function createEventSlugBase(title: string, startAt?: number): string {
+  const titlePart = normalizeEventSlugInput(title) || EVENT_SLUG_FALLBACK_BASE;
+  const datedTitle = startAt === undefined ? titlePart : `${titlePart}-${eventDateSlugPart(startAt)}`;
+  let slug = datedTitle;
+
+  for (let attempt = 0; attempt < 5; attempt += 1) {
+    if (slug.length < EVENT_SLUG_MIN_LENGTH || RESERVED_EVENT_SLUG_SET.has(slug)) {
+      slug = `${slug}-event`;
+    }
+
+    if (slug.length > EVENT_SLUG_MAX_LENGTH) {
+      slug = slug.slice(0, EVENT_SLUG_MAX_LENGTH).replace(/-+$/g, "");
+    }
+
+    const validated = validateEventSlug(slug);
+    if (validated.ok) {
+      return validated.slug;
+    }
+  }
+
+  return EVENT_SLUG_FALLBACK_BASE;
+}
+
+export function createEventSlugCandidate(base: string, attempt: number): string {
+  if (attempt <= 1) {
+    return base;
+  }
+
+  const suffix = `-${attempt}`;
+  const maxBaseLength = EVENT_SLUG_MAX_LENGTH - suffix.length;
+  return `${base.slice(0, maxBaseLength).replace(/-+$/g, "")}${suffix}`;
+}
+
+export async function getEventBySlug(db: DatabaseReader, slug: string) {
+  return await db.query("events").withIndex("by_slug", (q) => q.eq("slug", slug)).unique();
+}
+
+export async function checkEventSlugAvailability(
+  db: DatabaseReader,
+  slug: string,
+  excludingEventId?: Id<"events">,
+): Promise<EventSlugAvailabilityResult> {
+  const validation = validateEventSlug(slug);
+
+  if (!validation.ok) {
+    return {
+      available: false,
+      slug,
+      reason: validation.reason === "reserved" ? "reserved" : "invalid",
+    };
+  }
+
+  const existingEvent = await getEventBySlug(db, validation.slug);
+
+  if (existingEvent !== null && existingEvent._id !== excludingEventId) {
+    return { available: false, slug: validation.slug, reason: "taken" };
+  }
+
+  return { available: true, slug: validation.slug };
+}
+
+export async function findAvailableEventSlug(
+  db: DatabaseReader,
+  input: { title: string; startAt?: number; preferredSlug?: string },
+  options: { excludingEventId?: Id<"events">; maxAttempts?: number } = {},
+): Promise<string> {
+  const preferred = input.preferredSlug ? toEventSlug(input.preferredSlug) : null;
+  if (preferred !== null && !preferred.ok) {
+    throw new Error("Event slug must be lowercase letters, numbers, and single hyphens.");
+  }
+
+  const base = preferred?.ok ? preferred.slug : createEventSlugBase(input.title, input.startAt);
+  const maxAttempts = options.maxAttempts ?? 50;
+
+  for (let attempt = 1; attempt <= maxAttempts; attempt += 1) {
+    const candidate = createEventSlugCandidate(base, attempt);
+    const availability = await checkEventSlugAvailability(db, candidate, options.excludingEventId);
+
+    if (availability.available) {
+      return availability.slug;
+    }
+  }
+
+  throw new Error(`Unable to find an available event slug for "${base}".`);
+}

--- a/convex/_generated/api.d.ts
+++ b/convex/_generated/api.d.ts
@@ -8,6 +8,10 @@
  * @module
  */
 
+import type * as _communityAuthority from "../_communityAuthority.js";
+import type * as _eventInputs from "../_eventInputs.js";
+import type * as _eventPublic from "../_eventPublic.js";
+import type * as _eventSlugs from "../_eventSlugs.js";
 import type * as _profilePermissions from "../_profilePermissions.js";
 import type * as _profilePublic from "../_profilePublic.js";
 import type * as _profileSlugs from "../_profileSlugs.js";
@@ -19,6 +23,7 @@ import type * as _worldEvents from "../_worldEvents.js";
 import type * as _worldIds from "../_worldIds.js";
 import type * as _worldPublic from "../_worldPublic.js";
 import type * as _worldSlugs from "../_worldSlugs.js";
+import type * as events from "../events.js";
 import type * as health from "../health.js";
 import type * as profiles from "../profiles.js";
 import type * as worlds from "../worlds.js";
@@ -30,6 +35,10 @@ import type {
 } from "convex/server";
 
 declare const fullApi: ApiFromModules<{
+  _communityAuthority: typeof _communityAuthority;
+  _eventInputs: typeof _eventInputs;
+  _eventPublic: typeof _eventPublic;
+  _eventSlugs: typeof _eventSlugs;
   _profilePermissions: typeof _profilePermissions;
   _profilePublic: typeof _profilePublic;
   _profileSlugs: typeof _profileSlugs;
@@ -41,6 +50,7 @@ declare const fullApi: ApiFromModules<{
   _worldIds: typeof _worldIds;
   _worldPublic: typeof _worldPublic;
   _worldSlugs: typeof _worldSlugs;
+  events: typeof events;
   health: typeof health;
   profiles: typeof profiles;
   worlds: typeof worlds;

--- a/convex/_worldEvents.ts
+++ b/convex/_worldEvents.ts
@@ -20,12 +20,20 @@ type PublicActiveWorldRecord = PublicWorldEventRecord & {
 };
 
 export type PublicWorldEventPreview = {
+  slug?: string;
   title: string;
   startAt: number;
   endAt?: number;
   timezone?: string;
   communityName?: string;
   summary?: string;
+  posterImageUrl?: string;
+  mediaLinks: Array<{
+    type: "event_page" | "watch" | "stream" | "vrcdn" | "discord" | "ticket" | "other";
+    label: string;
+    url: string;
+    presentation: "open" | "copy";
+  }>;
   source: {
     sourceType: PublicEventSourceType;
     label: string;
@@ -53,6 +61,7 @@ export type PublicActiveWorldPreview = {
   activityLabel: "Hosting upcoming events";
   nextEvent: {
     title: string;
+    slug?: string;
     startAt: number;
     endAt?: number;
     timezone?: string;
@@ -83,10 +92,21 @@ function toPublicWorldEventPreview(
   }
 
   const sourceUrl = safeHttpsUrl(event.sourceUrl);
+  const posterImageUrl = safeHttpsUrl(event.posterImageUrl);
 
   return {
+    ...optionalField("slug", event.slug),
     title: event.title,
     startAt: event.startAt,
+    mediaLinks: (event.mediaLinks ?? []).flatMap((link) => {
+      const linkUrl = safeHttpsUrl(link.url);
+
+      if (linkUrl === undefined) {
+        return [];
+      }
+
+      return [{ ...link, url: linkUrl }];
+    }),
     source: {
       sourceType: event.sourceType,
       label: event.sourceLabel,
@@ -101,6 +121,7 @@ function toPublicWorldEventPreview(
     ...optionalField("timezone", event.timezone),
     ...optionalField("communityName", event.communityName),
     ...optionalField("summary", event.summary),
+    ...optionalField("posterImageUrl", posterImageUrl),
   };
 }
 
@@ -176,6 +197,7 @@ export function createPublicActiveWorldPreviews(
           upcomingEventCount: sortedEvents.length,
           activityLabel: "Hosting upcoming events" as const,
           nextEvent: {
+            ...optionalField("slug", nextEvent.slug),
             title: nextEvent.title,
             startAt: nextEvent.startAt,
             source: {

--- a/convex/events.ts
+++ b/convex/events.ts
@@ -1,0 +1,385 @@
+import { v } from "convex/values";
+
+import type { Doc, Id } from "./_generated/dataModel";
+import { mutation, query, type DatabaseReader, type DatabaseWriter, type MutationCtx } from "./_generated/server";
+import {
+  isSameAuthSubject,
+  subjectHasCommunityCapability,
+  toAuthSubject,
+  type AuthSubject,
+} from "./_communityAuthority";
+import { sanitizeEventDraftInput } from "./_eventInputs";
+import { getPublicCommunityHostedEvents, getPublicEventBySlug } from "./_eventPublic";
+import { findAvailableEventSlug, getEventBySlug, validateEventSlug } from "./_eventSlugs";
+import { getProfileBySlug, validateProfileSlug } from "./_profileSlugs";
+import { getWorldBySlug, validateWorldSlug } from "./_worldSlugs";
+
+const eventMediaLinkType = v.union(
+  v.literal("event_page"),
+  v.literal("watch"),
+  v.literal("stream"),
+  v.literal("vrcdn"),
+  v.literal("discord"),
+  v.literal("ticket"),
+  v.literal("other"),
+);
+
+const eventMediaLinkPresentation = v.union(v.literal("open"), v.literal("copy"));
+
+const eventDraftArgs = {
+  title: v.string(),
+  startAt: v.number(),
+  endAt: v.optional(v.number()),
+  timezone: v.optional(v.string()),
+  communitySlug: v.optional(v.string()),
+  summary: v.optional(v.string()),
+  notes: v.optional(v.string()),
+  sourceLabel: v.optional(v.string()),
+  sourceUrl: v.optional(v.string()),
+  posterImageUrl: v.optional(v.string()),
+  mediaLinks: v.optional(
+    v.array(
+      v.object({
+        type: eventMediaLinkType,
+        label: v.string(),
+        url: v.string(),
+        presentation: v.optional(eventMediaLinkPresentation),
+      }),
+    ),
+  ),
+  participantLinks: v.optional(
+    v.array(
+      v.object({
+        personSlug: v.string(),
+        roleLabel: v.optional(v.string()),
+        sourceLabel: v.optional(v.string()),
+        sourceUrl: v.optional(v.string()),
+        notes: v.optional(v.string()),
+      }),
+    ),
+  ),
+  worldSlug: v.optional(v.string()),
+  preferredSlug: v.optional(v.string()),
+};
+
+async function requireAuthenticatedSubject(ctx: MutationCtx) {
+  const identity = await ctx.auth.getUserIdentity();
+
+  if (identity === null || typeof identity !== "object") {
+    throw new Error("Event changes require a signed-in user.");
+  }
+
+  return toAuthSubject(
+    identity as {
+      tokenIdentifier: string;
+      issuer: string;
+      subject: string;
+      name?: string;
+    },
+  );
+}
+
+async function getPublishedCommunityBySlug(
+  db: DatabaseReader,
+  slug: string | undefined,
+): Promise<Doc<"profiles"> | undefined> {
+  if (slug === undefined) {
+    return undefined;
+  }
+
+  const validation = validateProfileSlug(slug);
+  if (!validation.ok) {
+    throw new Error("Community slug is invalid.");
+  }
+
+  const profile = await getProfileBySlug(db, validation.slug);
+
+  if (profile === null || profile.profileType !== "community") {
+    throw new Error("Community profile was not found.");
+  }
+
+  if (profile.publicationState !== "published") {
+    throw new Error("Community profile must be published before events can be linked.");
+  }
+
+  return profile;
+}
+
+async function getPublishedWorldBySlug(
+  db: DatabaseReader,
+  slug: string | undefined,
+) {
+  if (slug === undefined) {
+    return undefined;
+  }
+
+  const validation = validateWorldSlug(slug);
+  if (!validation.ok) {
+    throw new Error("World slug is invalid.");
+  }
+
+  const world = await getWorldBySlug(db, validation.slug);
+
+  if (world === null || world.publicationState !== "published") {
+    throw new Error("World profile was not found or is not published.");
+  }
+
+  return world;
+}
+
+async function getPublishedPersonBySlug(db: DatabaseReader, slug: string) {
+  const validation = validateProfileSlug(slug);
+  if (!validation.ok) {
+    throw new Error(`Person profile slug "${slug}" is invalid.`);
+  }
+
+  const profile = await getProfileBySlug(db, validation.slug);
+
+  if (profile === null || profile.profileType !== "person") {
+    throw new Error(`Person profile "${slug}" was not found.`);
+  }
+
+  if (profile.publicationState !== "published") {
+    throw new Error(`Person profile "${slug}" must be published before event association.`);
+  }
+
+  return profile;
+}
+
+async function canUpdateEvent(
+  db: DatabaseReader,
+  event: Doc<"events">,
+  subject: AuthSubject,
+): Promise<boolean> {
+  if (isSameAuthSubject(event.submitter, subject)) {
+    return true;
+  }
+
+  if (event.communityProfileId === undefined) {
+    return false;
+  }
+
+  return subjectHasCommunityCapability(db, event.communityProfileId, subject, "manage_events");
+}
+
+async function replaceEventWorldLink(
+  db: DatabaseWriter,
+  eventId: Id<"events">,
+  startAt: number,
+  world: Doc<"worlds"> | undefined,
+  now: number,
+) {
+  const existing = await db
+    .query("eventWorlds")
+    .withIndex("by_eventId", (query) => query.eq("eventId", eventId))
+    .take(20);
+
+  await Promise.all(existing.map((association) => db.delete(association._id)));
+
+  if (world === undefined) {
+    return;
+  }
+
+  await db.insert("eventWorlds", {
+    eventId,
+    worldId: world._id,
+    eventStartAt: startAt,
+    sourceType: "community",
+    confidence: 1,
+    confirmationState: "confirmed",
+    confirmedAt: now,
+    updatedAt: now,
+  });
+}
+
+async function replaceEventParticipants(
+  db: DatabaseWriter,
+  eventId: Id<"events">,
+  startAt: number,
+  participants: ReturnType<typeof sanitizeEventDraftInput>["participantLinks"],
+  now: number,
+) {
+  const existing = await db
+    .query("eventParticipants")
+    .withIndex("by_eventId", (query) => query.eq("eventId", eventId))
+    .take(100);
+
+  await Promise.all(existing.map((participant) => db.delete(participant._id)));
+
+  for (const participant of participants) {
+    const profile = await getPublishedPersonBySlug(db, participant.personSlug);
+
+    await db.insert("eventParticipants", {
+      eventId,
+      personProfileId: profile._id,
+      eventStartAt: startAt,
+      roleLabel: participant.roleLabel,
+      sourceType: "community",
+      sourceLabel: participant.sourceLabel,
+      ...optionalValue("sourceUrl", participant.sourceUrl),
+      confirmationState: "confirmed",
+      confirmedAt: now,
+      ...optionalValue("notes", participant.notes),
+      updatedAt: now,
+    });
+  }
+}
+
+function optionalValue<T>(key: string, value: T | undefined): Record<string, T> {
+  return value === undefined ? {} : { [key]: value };
+}
+
+export const getPublicBySlug = query({
+  args: {
+    slug: v.string(),
+  },
+  handler: async (ctx, args) => {
+    const validation = validateEventSlug(args.slug);
+
+    if (!validation.ok) {
+      return null;
+    }
+
+    return getPublicEventBySlug(ctx.db, await getEventBySlug(ctx.db, validation.slug));
+  },
+});
+
+export const listHostedByCommunitySlug = query({
+  args: {
+    communitySlug: v.string(),
+    now: v.number(),
+    limit: v.optional(v.number()),
+  },
+  handler: async (ctx, args) => {
+    const validation = validateProfileSlug(args.communitySlug);
+
+    if (!validation.ok) {
+      return [];
+    }
+
+    const community = await getProfileBySlug(ctx.db, validation.slug);
+
+    if (
+      community === null ||
+      community.profileType !== "community" ||
+      community.publicationState !== "published"
+    ) {
+      return [];
+    }
+
+    return getPublicCommunityHostedEvents(ctx.db, community._id, args.now, args.limit);
+  },
+});
+
+export const createCommunityEvent = mutation({
+  args: eventDraftArgs,
+  handler: async (ctx, args) => {
+    const subject = await requireAuthenticatedSubject(ctx);
+    const input = sanitizeEventDraftInput(args);
+    const community = await getPublishedCommunityBySlug(ctx.db, input.communitySlug);
+    const world = await getPublishedWorldBySlug(ctx.db, input.worldSlug);
+    const now = Date.now();
+    const slug = await findAvailableEventSlug(ctx.db, {
+      title: input.title,
+      startAt: input.startAt,
+      preferredSlug: input.preferredSlug,
+    });
+    const eventId = await ctx.db.insert("events", {
+      slug,
+      title: input.title,
+      sortTitle: input.sortTitle,
+      startAt: input.startAt,
+      ...optionalValue("endAt", input.endAt),
+      ...optionalValue("timezone", input.timezone),
+      ...optionalValue("communityProfileId", community?._id),
+      ...optionalValue("communityName", community?.displayName),
+      ...optionalValue("summary", input.summary),
+      ...optionalValue("notes", input.notes),
+      ...optionalValue("posterImageUrl", input.posterImageUrl),
+      mediaLinks: input.mediaLinks,
+      sourceType: "community",
+      sourceLabel: input.sourceLabel,
+      ...optionalValue("sourceUrl", input.sourceUrl),
+      submitter: subject,
+      publicationState: "published",
+      publishedAt: now,
+      createdAt: now,
+      updatedAt: now,
+    });
+
+    await replaceEventWorldLink(ctx.db, eventId, input.startAt, world, now);
+    await replaceEventParticipants(ctx.db, eventId, input.startAt, input.participantLinks, now);
+
+    return {
+      eventId,
+      slug,
+      eventPath: `/e/${slug}`,
+    };
+  },
+});
+
+export const updateCommunityEvent = mutation({
+  args: {
+    currentSlug: v.string(),
+    ...eventDraftArgs,
+  },
+  handler: async (ctx, args) => {
+    const subject = await requireAuthenticatedSubject(ctx);
+    const validation = validateEventSlug(args.currentSlug);
+
+    if (!validation.ok) {
+      throw new Error("Current event slug is invalid.");
+    }
+
+    const event = await getEventBySlug(ctx.db, validation.slug);
+
+    if (event === null) {
+      throw new Error("Event was not found.");
+    }
+
+    if (!(await canUpdateEvent(ctx.db, event, subject))) {
+      throw new Error("You do not have permission to update this event.");
+    }
+
+    const input = sanitizeEventDraftInput(args);
+    const community = await getPublishedCommunityBySlug(ctx.db, input.communitySlug);
+    const world = await getPublishedWorldBySlug(ctx.db, input.worldSlug);
+    const now = Date.now();
+    const slug = await findAvailableEventSlug(
+      ctx.db,
+      {
+        title: input.title,
+        startAt: input.startAt,
+        preferredSlug: input.preferredSlug ?? event.slug,
+      },
+      { excludingEventId: event._id },
+    );
+
+    await ctx.db.patch(event._id, {
+      slug,
+      title: input.title,
+      sortTitle: input.sortTitle,
+      startAt: input.startAt,
+      endAt: input.endAt,
+      timezone: input.timezone,
+      communityProfileId: community?._id,
+      communityName: community?.displayName,
+      summary: input.summary,
+      notes: input.notes,
+      posterImageUrl: input.posterImageUrl,
+      mediaLinks: input.mediaLinks,
+      sourceLabel: input.sourceLabel,
+      sourceUrl: input.sourceUrl,
+      updatedAt: now,
+    });
+
+    await replaceEventWorldLink(ctx.db, event._id, input.startAt, world, now);
+    await replaceEventParticipants(ctx.db, event._id, input.startAt, input.participantLinks, now);
+
+    return {
+      eventId: event._id,
+      slug,
+      eventPath: `/e/${slug}`,
+    };
+  },
+});

--- a/convex/events.ts
+++ b/convex/events.ts
@@ -337,12 +337,19 @@ export const updateCommunityEvent = mutation({
       throw new Error("Event was not found.");
     }
 
+    const isSubmitter = isSameAuthSubject(event.submitter, subject);
+
     if (!(await canUpdateEvent(ctx.db, event, subject))) {
       throw new Error("You do not have permission to update this event.");
     }
 
     const input = sanitizeEventDraftInput(args);
     const community = await getPublishedCommunityBySlug(ctx.db, input.communitySlug);
+
+    if (!isSubmitter && community?._id !== event.communityProfileId) {
+      throw new Error("You do not have permission to move this event to another community.");
+    }
+
     const world = await getPublishedWorldBySlug(ctx.db, input.worldSlug);
     const now = Date.now();
     const slug = await findAvailableEventSlug(

--- a/convex/profiles.ts
+++ b/convex/profiles.ts
@@ -1,6 +1,7 @@
 import { v } from "convex/values";
 
 import { mutation, query } from "./_generated/server";
+import { getPublicCommunityHostedEvents, getPublicPersonUpcomingEvents } from "./_eventPublic";
 import { canReadProfile } from "./_profilePermissions";
 import { toPublicProfile } from "./_profilePublic";
 import { findAvailableProfileSlug, getProfileBySlug, validateProfileSlug } from "./_profileSlugs";
@@ -23,6 +24,7 @@ export const getPublicBySlug = query({
   args: {
     slug: v.string(),
     profileType: v.optional(profileType),
+    now: v.optional(v.number()),
   },
   handler: async (ctx, args) => {
     const validation = validateProfileSlug(args.slug);
@@ -45,12 +47,25 @@ export const getPublicBySlug = query({
       return null;
     }
 
+    const now = args.now ?? Date.now();
+    const eventContext =
+      profile.profileType === "person"
+        ? {
+            upcomingEvents: await getPublicPersonUpcomingEvents(ctx.db, profile._id, now),
+            hostedEvents: [],
+          }
+        : {
+            upcomingEvents: [],
+            hostedEvents: await getPublicCommunityHostedEvents(ctx.db, profile._id, now),
+          };
+
     return {
       ...toPublicProfile(profile),
       worldCredits: await getPublicProfileWorldCredits(ctx.db, {
         profileType: profile.profileType,
         slug: profile.slug,
       }),
+      ...eventContext,
     };
   },
 });

--- a/convex/schema.ts
+++ b/convex/schema.ts
@@ -352,5 +352,10 @@ export default defineSchema({
     updatedAt: v.number(),
   })
     .index("by_communityProfileId_state", ["communityProfileId", "state"])
-    .index("by_subjectTokenIdentifier_state", ["subjectTokenIdentifier", "state"]),
+    .index("by_subjectTokenIdentifier_state", ["subjectTokenIdentifier", "state"])
+    .index("by_subjectTokenIdentifier_state_communityProfileId", [
+      "subjectTokenIdentifier",
+      "state",
+      "communityProfileId",
+    ]),
 });

--- a/convex/schema.ts
+++ b/convex/schema.ts
@@ -89,11 +89,46 @@ const eventSourceType = v.union(
   v.literal("ai_suggested"),
 );
 
+const eventMediaLinkType = v.union(
+  v.literal("event_page"),
+  v.literal("watch"),
+  v.literal("stream"),
+  v.literal("vrcdn"),
+  v.literal("discord"),
+  v.literal("ticket"),
+  v.literal("other"),
+);
+
+const eventMediaLinkPresentation = v.union(v.literal("open"), v.literal("copy"));
+
 const eventWorldConfirmationState = v.union(
   v.literal("unconfirmed"),
   v.literal("confirmed"),
   v.literal("disputed"),
 );
+
+const eventParticipantConfirmationState = v.union(
+  v.literal("unconfirmed"),
+  v.literal("confirmed"),
+  v.literal("disputed"),
+);
+
+const communityCapability = v.union(
+  v.literal("manage_profile"),
+  v.literal("manage_events"),
+  v.literal("manage_staff"),
+  v.literal("manage_integrations"),
+  v.literal("manage_billing"),
+);
+
+const communityAuthorityState = v.union(v.literal("active"), v.literal("revoked"));
+
+const authSubject = v.object({
+  tokenIdentifier: v.string(),
+  issuer: v.string(),
+  subject: v.string(),
+  displayName: v.optional(v.string()),
+});
 
 const sharedProfileFields = {
   slug: v.string(),
@@ -223,6 +258,7 @@ export default defineSchema({
     .index("by_vrchatWorldId", ["vrchatWorldId"])
     .index("by_publicationState_sortName", ["publicationState", "sortName"]),
   events: defineTable({
+    slug: v.optional(v.string()),
     title: v.string(),
     sortTitle: v.string(),
     startAt: v.number(),
@@ -231,12 +267,28 @@ export default defineSchema({
     communityProfileId: v.optional(v.id("profiles")),
     communityName: v.optional(v.string()),
     summary: v.optional(v.string()),
+    notes: v.optional(v.string()),
+    posterImageUrl: v.optional(v.string()),
+    mediaLinks: v.optional(
+      v.array(
+        v.object({
+          type: eventMediaLinkType,
+          label: v.string(),
+          url: v.string(),
+          presentation: eventMediaLinkPresentation,
+        }),
+      ),
+    ),
     sourceType: eventSourceType,
     sourceLabel: v.string(),
     sourceUrl: v.optional(v.string()),
+    submitter: v.optional(authSubject),
     publicationState,
+    publishedAt: v.optional(v.number()),
+    createdAt: v.optional(v.number()),
     updatedAt: v.number(),
   })
+    .index("by_slug", ["slug"])
     .index("by_publicationState_startAt", ["publicationState", "startAt"])
     .index("by_communityProfileId_startAt", ["communityProfileId", "startAt"]),
   eventWorlds: defineTable({
@@ -268,4 +320,37 @@ export default defineSchema({
   })
     .index("by_profileType_profileSlug", ["profileType", "profileSlug"])
     .index("by_worldId", ["worldId"]),
+  eventParticipants: defineTable({
+    eventId: v.id("events"),
+    personProfileId: v.id("profiles"),
+    eventStartAt: v.number(),
+    roleLabel: v.string(),
+    sourceType: eventSourceType,
+    sourceLabel: v.string(),
+    sourceUrl: v.optional(v.string()),
+    confirmationState: eventParticipantConfirmationState,
+    confirmedAt: v.optional(v.number()),
+    notes: v.optional(v.string()),
+    updatedAt: v.number(),
+  })
+    .index("by_eventId", ["eventId"])
+    .index("by_personProfileId_confirmationState_eventStartAt", [
+      "personProfileId",
+      "confirmationState",
+      "eventStartAt",
+    ]),
+  communityAuthorities: defineTable({
+    communityProfileId: v.id("profiles"),
+    subjectTokenIdentifier: v.string(),
+    subject: authSubject,
+    roleKey: v.string(),
+    roleLabel: v.string(),
+    capabilities: v.array(communityCapability),
+    state: communityAuthorityState,
+    grantedAt: v.number(),
+    revokedAt: v.optional(v.number()),
+    updatedAt: v.number(),
+  })
+    .index("by_communityProfileId_state", ["communityProfileId", "state"])
+    .index("by_subjectTokenIdentifier_state", ["subjectTokenIdentifier", "state"]),
 });

--- a/docs/README.md
+++ b/docs/README.md
@@ -7,6 +7,7 @@ This repo keeps durable markdown under `docs/` so product, engineering, and agen
 - `docs/planning/README.md` - product, architecture, roadmap, backlog, and issue-planning docs
 - `docs/agentic/README.md` - software-factory, onboarding, control-loop, and agent workflow docs
 - `docs/backend/convex-bootstrap.md` - backend bootstrap workflow and structure notes
+- `docs/backend/event-schema.md` - event records, participant links, media links, and world-association notes
 - `docs/deployment/vercel-preview.md` - initial Vercel hosted-preview setup and validation path
 
 Useful starting points:

--- a/docs/backend/event-schema.md
+++ b/docs/backend/event-schema.md
@@ -1,0 +1,87 @@
+# Event Schema
+
+## Status
+
+Current recommendation and implementation note for `#34`, `#35`, and `#36`.
+
+## Event Records
+
+Events are the primary scheduling object. They are not modeled as appearances, slots, or profile-page blocks.
+
+Current event fields include:
+
+- editable readable slug for `/e/<slug>` public routes
+- title and sort title
+- start time and optional end time
+- optional time zone
+- optional linked community profile
+- optional public summary and notes
+- optional primary poster image URL
+- source type, source label, and optional source URL
+- typed media links
+- publication state
+- submitter identity for first-slice edit authority
+
+Generated durable short links such as `/l/<code>` are tracked separately in `#92`. Event slugs are readable and may become owner-editable; short links should remain stable after slug edits.
+
+## Community Authority
+
+The first event editor supports submitter-owned edits so the event flow can work before full community ownership and staff roles land.
+
+A small `communityAuthorities` table is reserved for the next authority layer:
+
+- one community owner in v1
+- familiar starter roles such as `admin` and `mod`
+- capability flags such as `manage_events`
+
+The fuller ownership and staff-role foundation is tracked in `#93`.
+
+## Event Participants
+
+`eventParticipants` links person profiles to events. This keeps profile-facing event views derived from a canonical event record rather than making `appearance` the core object.
+
+Participant links support:
+
+- claimed and unclaimed published person profiles
+- freeform role labels such as `Performer`, `Staff`, or a community-specific label
+- source type, source label, and optional source URL
+- confirmation state
+- optional notes
+
+Public person profile pages should only render published events through confirmed participant links to public person profiles.
+
+Approval, dispute handling, notifications, recurring events, RSVP/interested state, and friend-aware discovery are follow-on work tracked outside this first `#35` association slice.
+
+## Event Media Links
+
+Event media links are intentionally more flexible than a rigid platform dropdown.
+
+The first typed set is:
+
+- `event_page`
+- `watch`
+- `stream`
+- `vrcdn`
+- `discord`
+- `ticket`
+- `other`
+
+Each media link has a label, HTTPS URL, and presentation hint:
+
+- `open` for normal outbound links
+- `copy` for operational links such as VRCDN links that may need to be pasted into a world or tool
+
+Future smart labeling, remembered vocabularies, URL-derived icons, and platform-specific UX are tracked in `#90`.
+
+## Event-World Links
+
+World linkage uses explicit `eventWorlds` records rather than storing world context only as event text.
+
+Public world and Home activity surfaces should continue to use only:
+
+- published events
+- confirmed event-world associations
+- published world records
+- HTTPS-filtered public URLs
+
+Automatic world inference, live VRChat presence, scraped popularity, and private attendance data remain non-goals for this slice.

--- a/docs/planning/architecture.md
+++ b/docs/planning/architecture.md
@@ -296,6 +296,14 @@ Related policy recommendation:
 - includes start/end, title, source, confidence, and linked entities
 - should support a primary event poster/image asset when available
 
+Implementation status:
+
+- `events` stores canonical event data and readable `/e/<slug>` routing slugs
+- `eventParticipants` links published person profiles to events with source and confirmation metadata
+- `eventWorlds` links events to world records with source, confidence, and confirmation metadata
+- `communityAuthorities` reserves a small capability-based seam for community-owned event management without implementing the full staff-role product yet
+- `docs/backend/event-schema.md` is the backend reference for the first event foundation slice
+
 Likely near-term additions:
 
 - linked VRChat world id when known

--- a/docs/planning/prd.md
+++ b/docs/planning/prd.md
@@ -374,6 +374,14 @@ Current recommendation:
 - when a claimed person is added to an event association in v1, they should receive a passive in-app notification
 - claimed people should be able to choose whether they are simply notified when added; stronger approval gates can land later
 
+Locked decision for the first implementation slice:
+
+- event pages use readable `/e/<slug>` routes
+- editable slugs and future generated short links are separate concepts
+- participant role labels start as freeform text rather than a fixed dropdown
+- person-event links can appear immediately when they reference published profiles and published events
+- notifications, approval gates, disputes, RSVP/interested state, recurring events, and friend-aware discovery stay out of the first event CRUD PR and remain tracked as follow-up work
+
 Candidate direction:
 
 - disputed event associations may need the community page and person page to diverge temporarily

--- a/docs/planning/product-spec.md
+++ b/docs/planning/product-spec.md
@@ -341,6 +341,15 @@ Current recommendation for initial event fields:
 - notes optional
 - poster/image optional
 
+Implementation status for the first event foundation slice:
+
+- events use editable readable slugs under `/e/<slug>`
+- generated durable `/l/<code>` short links are deferred to `#92`
+- public person pages derive upcoming events from confirmed `eventParticipants` links
+- public community pages derive hosted upcoming events from canonical event records
+- participant role labels are freeform text for now; reusable vocabulary memory is deferred to `#90`
+- approval, dispute, notification, RSVP/interested, recurring event, and friend-aware discovery flows are deferred to follow-up issues
+
 Important future-aware extensions:
 
 - VRChat world linkage

--- a/tests/backend/event-foundation.test.ts
+++ b/tests/backend/event-foundation.test.ts
@@ -1,0 +1,220 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+
+import type { Doc } from "../../convex/_generated/dataModel";
+import { sanitizeEventDraftInput } from "../../convex/_eventInputs";
+import { toPublicEvent, toPublicEventPreviewFromRecord } from "../../convex/_eventPublic";
+import {
+  createEventSlugBase,
+  createEventSlugCandidate,
+  toEventSlug,
+  validateEventSlug,
+} from "../../convex/_eventSlugs";
+
+describe("event slug helpers", () => {
+  it("normalizes event names into dated readable slugs", () => {
+    assert.equal(
+      createEventSlugBase(" Afterglow Harbor Sessions!! ", Date.UTC(2026, 5, 14, 22, 0, 0)),
+      "afterglow-harbor-sessions-2026-06-14",
+    );
+  });
+
+  it("validates canonical event slug rules", () => {
+    assert.deepEqual(validateEventSlug("afterglow-harbor"), {
+      ok: true,
+      slug: "afterglow-harbor",
+    });
+    assert.deepEqual(validateEventSlug("Afterglow-Harbor"), {
+      ok: false,
+      reason: "invalid_format",
+    });
+    assert.deepEqual(validateEventSlug("events"), {
+      ok: false,
+      reason: "reserved",
+    });
+  });
+
+  it("keeps retry candidates inside the maximum length", () => {
+    const base = "a".repeat(64);
+    const candidate = createEventSlugCandidate(base, 12);
+
+    assert.equal(candidate.length, 64);
+    assert.equal(candidate.endsWith("-12"), true);
+  });
+
+  it("turns freeform slug input into canonical event slugs", () => {
+    assert.deepEqual(toEventSlug("Afterglow Harbor"), {
+      ok: true,
+      slug: "afterglow-harbor",
+    });
+  });
+});
+
+describe("event draft input", () => {
+  it("sanitizes media links, participants, and optional event fields", () => {
+    const startAt = Date.UTC(2026, 5, 14, 22, 0, 0);
+    const input = sanitizeEventDraftInput({
+      title: "  Afterglow Harbor Sessions  ",
+      communitySlug: "afterglow-social",
+      worldSlug: "neon-harbor",
+      startAt,
+      endAt: startAt + 10_800_000,
+      sourceLabel: " Fixture listing ",
+      sourceUrl: "https://example.invalid/events/afterglow",
+      posterImageUrl: "https://example.invalid/poster.png",
+      mediaLinks: [
+        {
+          type: "watch",
+          label: " Twitch ",
+          url: "https://example.invalid/watch",
+        },
+        {
+          type: "vrcdn",
+          label: " VRCDN PC ",
+          url: "https://example.invalid/vrcdn",
+        },
+      ],
+      participantLinks: [
+        {
+          personSlug: "dj-aurora",
+          roleLabel: " Headliner ",
+        },
+      ],
+    });
+
+    assert.equal(input.title, "Afterglow Harbor Sessions");
+    assert.equal(input.sortTitle, "afterglow harbor sessions");
+    assert.equal(input.mediaLinks[0]?.presentation, "open");
+    assert.equal(input.mediaLinks[1]?.presentation, "copy");
+    assert.equal(input.participantLinks[0]?.roleLabel, "Headliner");
+  });
+
+  it("rejects non-https public URLs", () => {
+    assert.throws(
+      () =>
+        sanitizeEventDraftInput({
+          title: "Afterglow Harbor Sessions",
+          startAt: Date.UTC(2026, 5, 14, 22, 0, 0),
+          sourceUrl: "http://example.invalid/events/afterglow",
+        }),
+      /Event source URL must use https\./,
+    );
+  });
+});
+
+describe("public event projection", () => {
+  it("projects event details with safe URLs and public participant links", () => {
+    const now = Date.UTC(2026, 4, 24, 12, 0, 0);
+    const event = {
+      _id: "event123",
+      slug: "afterglow-harbor-sessions-2026-06-14",
+      title: "Afterglow Harbor Sessions",
+      sortTitle: "afterglow harbor sessions",
+      startAt: now + 86_400_000,
+      endAt: now + 90_000_000,
+      timezone: "UTC",
+      communityName: "Afterglow Social",
+      summary: "A confirmed fixture event.",
+      notes: "Bring water.",
+      posterImageUrl: "https://example.invalid/poster.png",
+      mediaLinks: [
+        {
+          type: "watch",
+          label: "Watch",
+          url: "https://example.invalid/watch",
+          presentation: "open",
+        },
+        {
+          type: "other",
+          label: "Unsafe",
+          url: "http://example.invalid/unsafe",
+          presentation: "open",
+        },
+      ],
+      sourceType: "community",
+      sourceLabel: "Community listing",
+      sourceUrl: "http://example.invalid/source",
+      publicationState: "published",
+      updatedAt: now,
+    } as unknown as Doc<"events">;
+    const world = {
+      slug: "neon-harbor",
+      displayName: "Neon Harbor",
+      tags: ["Club world"],
+      summary: "A venue world.",
+      visibilityStatus: "public",
+      platformCompatibility: ["pc"],
+      media: [],
+      creatorAttributions: [],
+      outboundLinks: [],
+      publicationState: "published",
+      creationSource: "self",
+      updatedAt: now,
+    } as unknown as Doc<"worlds">;
+    const worldAssociation = {
+      eventId: "event123",
+      worldId: "world123",
+      eventStartAt: event.startAt,
+      sourceType: "manual",
+      confidence: 1,
+      confirmationState: "confirmed",
+      updatedAt: now,
+    } as unknown as Doc<"eventWorlds">;
+    const person = {
+      slug: "dj-aurora",
+      displayName: "DJ Aurora",
+      sortName: "dj aurora",
+      aliases: [],
+      tags: [],
+      claimState: "unclaimed",
+      publicationState: "published",
+      creationSource: "community",
+      updatedAt: now,
+      profileType: "person",
+      person: {
+        roleTags: ["DJ"],
+      },
+    } as unknown as Doc<"profiles">;
+    const participant = {
+      eventId: "event123",
+      personProfileId: "profile123",
+      eventStartAt: event.startAt,
+      roleLabel: "Performer",
+      sourceType: "community",
+      sourceLabel: "Fixture lineup",
+      confirmationState: "confirmed",
+      updatedAt: now,
+    } as unknown as Doc<"eventParticipants">;
+
+    const publicEvent = toPublicEvent({
+      event,
+      worlds: [{ association: worldAssociation, world }],
+      participants: [{ association: participant, profile: person }],
+    });
+
+    assert.notEqual(publicEvent, null);
+    assert.equal(publicEvent?.slug, "afterglow-harbor-sessions-2026-06-14");
+    assert.equal(publicEvent?.mediaLinks.length, 1);
+    assert.equal(publicEvent?.worlds[0]?.displayName, "Neon Harbor");
+    assert.equal(publicEvent?.participants[0]?.displayName, "DJ Aurora");
+    assert.equal("url" in publicEvent!.source, false);
+  });
+
+  it("creates compact previews for profile and community event sections", () => {
+    const event = {
+      slug: "afterglow-harbor-sessions-2026-06-14",
+      title: "Afterglow Harbor Sessions",
+      sortTitle: "afterglow harbor sessions",
+      startAt: Date.UTC(2026, 5, 14, 22, 0, 0),
+      sourceType: "community",
+      sourceLabel: "Community listing",
+      publicationState: "published",
+      updatedAt: 1,
+    } as unknown as Doc<"events">;
+    const preview = toPublicEventPreviewFromRecord({ event, worlds: [], participants: [] });
+
+    assert.equal(preview.slug, "afterglow-harbor-sessions-2026-06-14");
+    assert.equal(preview.participantCount, 0);
+    assert.deepEqual(preview.worlds, []);
+  });
+});

--- a/tests/backend/event-foundation.test.ts
+++ b/tests/backend/event-foundation.test.ts
@@ -2,8 +2,13 @@ import assert from "node:assert/strict";
 import { describe, it } from "node:test";
 
 import type { Doc } from "../../convex/_generated/dataModel";
+import type { DatabaseReader } from "../../convex/_generated/server";
 import { sanitizeEventDraftInput } from "../../convex/_eventInputs";
-import { toPublicEvent, toPublicEventPreviewFromRecord } from "../../convex/_eventPublic";
+import {
+  getPublicEventPreviews,
+  toPublicEvent,
+  toPublicEventPreviewFromRecord,
+} from "../../convex/_eventPublic";
 import {
   createEventSlugBase,
   createEventSlugCandidate,
@@ -103,6 +108,21 @@ describe("event draft input", () => {
 });
 
 describe("public event projection", () => {
+  function createEmptyEventAssociationDb() {
+    const query = {
+      withIndex: () => ({
+        filter: () => ({
+          take: async () => [],
+        }),
+      }),
+    };
+
+    return {
+      get: async () => null,
+      query: () => query,
+    } as unknown as DatabaseReader;
+  }
+
   it("projects event details with safe URLs and public participant links", () => {
     const now = Date.UTC(2026, 4, 24, 12, 0, 0);
     const event = {
@@ -216,5 +236,31 @@ describe("public event projection", () => {
     assert.equal(preview.slug, "afterglow-harbor-sessions-2026-06-14");
     assert.equal(preview.participantCount, 0);
     assert.deepEqual(preview.worlds, []);
+  });
+
+  it("allows explicit preview limits above the compact section default", async () => {
+    const now = Date.UTC(2026, 4, 24, 12, 0, 0);
+    const events = Array.from(
+      { length: 8 },
+      (_, index) =>
+        ({
+          slug: `afterglow-harbor-${index + 1}`,
+          title: `Afterglow Harbor ${index + 1}`,
+          sortTitle: `afterglow harbor ${index + 1}`,
+          startAt: now + index * 3_600_000,
+          sourceType: "community",
+          sourceLabel: "Community listing",
+          publicationState: "published",
+          updatedAt: now,
+        }) as unknown as Doc<"events">,
+    );
+    const db = createEmptyEventAssociationDb();
+
+    const defaultPreviews = await getPublicEventPreviews(db, events, { now });
+    const expandedPreviews = await getPublicEventPreviews(db, events, { now, limit: 8 });
+
+    assert.equal(defaultPreviews.length, 6);
+    assert.equal(expandedPreviews.length, 8);
+    assert.equal(expandedPreviews[7]?.title, "Afterglow Harbor 8");
   });
 });


### PR DESCRIPTION
## Summary
- add canonical Convex event records with readable `/e/<slug>` routes, create/update mutations, source attribution, media links, poster image, optional world linkage, and a small community authority seam
- add person-to-event participant links and derived upcoming/hosted event sections on person and community profiles
- add public event pages, auth-aware create/edit event UI, world/home event context rendering, Playwright fixtures, backend tests, and event schema docs

## Verification
- `pnpm verify`
- `pnpm test:e2e`
- `pnpm test:e2e:visual`
- visual screenshots reviewed for desktop/mobile event page and related profile/world surfaces

Closes #7
Closes #34
Closes #35
Closes #36