### PR TITLE
Add public discovery engine foundation

### DIFF
--- a/apps/web/e2e/public-routes.ts
+++ b/apps/web/e2e/public-routes.ts
@@ -163,10 +163,19 @@ export async function captureRouteScreenshot(page: Page, testInfo: TestInfo, nam
 }
 
 export async function expectHomePage(page: Page) {
-  await expect(page.getByRole("heading", { name: /Profiles, communities/i })).toBeVisible();
+  await expect(page.getByRole("heading", { name: /Find what is happening/i })).toBeVisible();
+  await expect(page.getByRole("button", { name: /Search VRDex/i })).toBeVisible();
   await expect(page.getByRole("heading", { name: "Worlds hosting events soon" })).toBeVisible();
   await expect(page.getByRole("heading", { name: "Neon Harbor", exact: true })).toBeVisible();
-  await expect(page.getByText(/Afterglow Harbor Sessions/i)).toBeVisible();
+  await expect(page.getByRole("link", { name: /Afterglow Harbor Sessions/i }).first()).toBeVisible();
+}
+
+export async function expectDiscoverPage(page: Page) {
+  await expect(page.getByRole("heading", { name: /Find the night/i })).toBeVisible();
+  await expect(page.getByRole("button", { name: /Search VRDex/i })).toBeVisible();
+  await expect(page.getByRole("heading", { name: /Events worth checking first/i })).toBeVisible();
+  await expect(page.getByRole("link", { name: /Afterglow Harbor Sessions/i }).first()).toBeVisible();
+  await expect(page.getByRole("link", { name: /DJ Aurora/i })).toBeVisible();
 }
 
 export async function expectSubmitPage(page: Page) {
@@ -186,7 +195,7 @@ export async function expectDeploymentPage(page: Page) {
 
 export async function expectPersonProfilePage(page: Page) {
   await expect(page.getByRole("heading", { name: "DJ Aurora" })).toBeVisible();
-  await expect(page.getByText(/Community submitted/i)).toBeVisible();
+  await expect(page.getByText(/Source: Community submitted on Jan 1, 2025/i)).toBeVisible();
   await expect(page.getByRole("heading", { name: /Where this profile appears next/i })).toBeVisible();
   await expect(page.getByRole("heading", { name: "Afterglow Harbor Sessions" })).toBeVisible();
   await expect(page.getByText(/Creator links/i)).toBeVisible();
@@ -231,6 +240,11 @@ export const capturedRoutes: CapturedRoute[] = [
     name: "submit",
     path: "/submit",
     expectPage: expectSubmitPage,
+  },
+  {
+    name: "discover",
+    path: "/discover?q=afterglow",
+    expectPage: expectDiscoverPage,
   },
   {
     name: "server-status",

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -19,6 +19,7 @@
   "dependencies": {
     "convex": "^1.32.0",
     "next": "16.1.6",
+    "posthog-js": "^1.376.2",
     "react": "19.2.3",
     "react-dom": "19.2.3"
   },

--- a/apps/web/src/app/PostHogProvider.tsx
+++ b/apps/web/src/app/PostHogProvider.tsx
@@ -1,0 +1,30 @@
+"use client";
+
+import posthog from "posthog-js";
+import { PostHogProvider as Provider } from "posthog-js/react";
+import { useEffect, type ReactNode } from "react";
+
+const posthogKey = process.env.NEXT_PUBLIC_POSTHOG_KEY;
+const posthogHost = process.env.NEXT_PUBLIC_POSTHOG_HOST ?? "https://us.i.posthog.com";
+
+export function PostHogProvider({ children }: { children: ReactNode }) {
+  useEffect(() => {
+    if (!posthogKey || (posthog as { __loaded?: boolean }).__loaded) {
+      return;
+    }
+
+    posthog.init(posthogKey, {
+      api_host: posthogHost,
+      capture_pageview: true,
+      capture_pageleave: true,
+      defaults: "2025-05-24",
+      loaded: (client) => {
+        if (process.env.NODE_ENV !== "production") {
+          client.opt_out_capturing();
+        }
+      },
+    });
+  }, []);
+
+  return <Provider client={posthog}>{children}</Provider>;
+}

--- a/apps/web/src/app/_components/discovery-analytics.tsx
+++ b/apps/web/src/app/_components/discovery-analytics.tsx
@@ -1,0 +1,65 @@
+"use client";
+
+import Link, { type LinkProps } from "next/link";
+import { usePostHog } from "posthog-js/react";
+import { type FormEvent, type ReactNode } from "react";
+
+type DiscoveryEventProperties = Record<string, string | number | boolean | undefined>;
+
+export function DiscoverySearchForm({ defaultQuery }: { defaultQuery?: string }) {
+  const posthog = usePostHog();
+
+  function onSubmit(event: FormEvent<HTMLFormElement>) {
+    const formData = new FormData(event.currentTarget);
+    const query = String(formData.get("q") ?? "").trim();
+
+    if (query) {
+      posthog?.capture("search_submitted", {
+        query,
+        surface: "discover",
+      });
+    }
+  }
+
+  return (
+    <form className="mt-8 flex flex-col gap-3 sm:flex-row" action="/discover" onSubmit={onSubmit}>
+      <input
+        className="min-h-14 flex-1 rounded-full border border-white/25 bg-white/16 px-5 text-base text-white outline-none placeholder:text-white/62 focus:border-white/70"
+        defaultValue={defaultQuery}
+        name="q"
+        placeholder="Search DJs, communities, worlds, events, genres..."
+      />
+      <button
+        className="inline-flex min-h-14 items-center justify-center rounded-full bg-white px-6 text-sm font-semibold text-foreground transition hover:-translate-y-0.5"
+        type="submit"
+      >
+        Search VRDex
+      </button>
+    </form>
+  );
+}
+
+export function TrackedDiscoveryLink({
+  children,
+  eventName,
+  properties,
+  ...props
+}: LinkProps & {
+  children: ReactNode;
+  className?: string;
+  eventName: string;
+  properties: DiscoveryEventProperties;
+}) {
+  const posthog = usePostHog();
+
+  return (
+    <Link
+      {...props}
+      onClick={() => {
+        posthog?.capture(eventName, properties);
+      }}
+    >
+      {children}
+    </Link>
+  );
+}

--- a/apps/web/src/app/_components/discovery-public-page.tsx
+++ b/apps/web/src/app/_components/discovery-public-page.tsx
@@ -1,0 +1,300 @@
+import Link from "next/link";
+
+import { DiscoverySearchForm, TrackedDiscoveryLink } from "./discovery-analytics";
+
+type EntityType = "profile" | "world" | "event";
+type ProfileType = "person" | "community";
+
+export type PublicSearchResult = {
+  entityType: EntityType;
+  profileType?: ProfileType;
+  slug: string;
+  routePath: string;
+  title: string;
+  subtitle?: string;
+  summary?: string;
+  imageUrl?: string;
+  startsAt?: number;
+  source?: {
+    sourceType?: string;
+    label: string;
+  };
+  score: number;
+};
+
+export type PublicDiscoveryData = {
+  featured: PublicSearchResult[];
+  upcomingEvents: PublicSearchResult[];
+  people: PublicSearchResult[];
+  communities: PublicSearchResult[];
+  worlds: PublicSearchResult[];
+  terms: Array<{
+    scope: string;
+    key: string;
+    label: string;
+    usageCount: number;
+  }>;
+};
+
+type DiscoveryStatus = "live" | "missing-url" | "error";
+
+function entityLabel(result: PublicSearchResult): string {
+  if (result.entityType === "profile") {
+    return result.profileType === "community" ? "Community" : "Person";
+  }
+
+  return result.entityType === "event" ? "Event" : "World";
+}
+
+function formatEventTime(value: number | undefined): string | null {
+  if (value === undefined) {
+    return null;
+  }
+
+  return new Intl.DateTimeFormat("en", {
+    month: "short",
+    day: "numeric",
+    hour: "numeric",
+    minute: "2-digit",
+  }).format(new Date(value));
+}
+
+function initialsFor(name: string): string {
+  return name
+    .split(/\s+/)
+    .filter(Boolean)
+    .slice(0, 2)
+    .map((part) => part[0]?.toUpperCase())
+    .join("") || "VR";
+}
+
+function resultImageStyle(imageUrl: string | undefined) {
+  if (!imageUrl) {
+    return undefined;
+  }
+
+  try {
+    const url = new URL(imageUrl);
+    if (url.protocol !== "https:") {
+      return undefined;
+    }
+
+    return { backgroundImage: `url(${JSON.stringify(url.href)})` };
+  } catch {
+    return undefined;
+  }
+}
+
+function DiscoveryCard({ result, surface }: { result: PublicSearchResult; surface: string }) {
+  const imageStyle = resultImageStyle(result.imageUrl);
+  const time = formatEventTime(result.startsAt);
+
+  return (
+    <TrackedDiscoveryLink
+      className="group grid gap-4 rounded-[1.5rem] border border-border bg-surface px-4 py-4 transition hover:-translate-y-1 hover:shadow-[0_18px_60px_rgba(64,40,24,0.12)] sm:grid-cols-[8rem_1fr]"
+      eventName={result.entityType === "event" ? "event_card_clicked" : "search_result_clicked"}
+      href={result.routePath}
+      properties={{
+        entity_type: result.entityType,
+        profile_type: result.profileType,
+        result_slug: result.slug,
+        surface,
+      }}
+    >
+      <span
+        className="flex aspect-[4/3] items-center justify-center rounded-[1.15rem] bg-[linear-gradient(135deg,#2f211b,#d66a4d)] bg-cover bg-center text-2xl font-semibold text-white"
+        style={imageStyle}
+      >
+        {!imageStyle ? initialsFor(result.title) : null}
+      </span>
+      <span className="flex min-w-0 flex-col gap-3">
+        <span className="flex flex-wrap items-center gap-2">
+          <span className="rounded-full border border-border bg-surface-strong px-3 py-1 font-mono text-[0.68rem] uppercase tracking-[0.2em] text-muted">
+            {entityLabel(result)}
+          </span>
+          {time ? (
+            <span className="rounded-full bg-accent/10 px-3 py-1 text-xs font-medium text-accent-strong">
+              {time}
+            </span>
+          ) : null}
+        </span>
+        <span className="text-xl font-semibold tracking-[-0.03em] group-hover:text-accent-strong">
+          {result.title}
+        </span>
+        {result.subtitle ? <span className="text-sm text-muted">{result.subtitle}</span> : null}
+        {result.summary ? (
+          <span className="line-clamp-2 text-sm leading-6 text-muted">{result.summary}</span>
+        ) : null}
+        {result.source ? (
+          <span className="text-xs text-muted">Source: {result.source.label}</span>
+        ) : null}
+      </span>
+    </TrackedDiscoveryLink>
+  );
+}
+
+function PosterCard({ result }: { result: PublicSearchResult }) {
+  const imageStyle = resultImageStyle(result.imageUrl);
+
+  return (
+    <TrackedDiscoveryLink
+      className="group min-h-80 overflow-hidden rounded-[1.6rem] border border-white/15 bg-[#241814] text-white shadow-[0_24px_80px_rgba(20,12,8,0.18)]"
+      eventName="featured_card_clicked"
+      href={result.routePath}
+      properties={{ entity_type: result.entityType, result_slug: result.slug, surface: "featured" }}
+    >
+      <span
+        className="flex min-h-80 flex-col justify-end bg-[radial-gradient(circle_at_top_left,rgba(214,106,77,0.45),transparent_34%),linear-gradient(145deg,#221512,#74311f)] bg-cover bg-center p-5"
+        style={imageStyle}
+      >
+        <span className="rounded-full bg-white/16 px-3 py-1 font-mono text-[0.68rem] uppercase tracking-[0.22em] text-white/78">
+          Featured {entityLabel(result)}
+        </span>
+        <span className="mt-4 block text-3xl font-semibold tracking-[-0.04em]">
+          {result.title}
+        </span>
+        {result.summary ? (
+          <span className="mt-3 line-clamp-3 block text-sm leading-6 text-white/76">
+            {result.summary}
+          </span>
+        ) : null}
+      </span>
+    </TrackedDiscoveryLink>
+  );
+}
+
+function Section({
+  title,
+  eyebrow,
+  empty,
+  results,
+}: {
+  title: string;
+  eyebrow: string;
+  empty: string;
+  results: PublicSearchResult[];
+}) {
+  return (
+    <section className="rounded-[1.8rem] border border-border bg-white/34 px-5 py-6 backdrop-blur sm:px-6">
+      <p className="font-mono text-xs uppercase tracking-[0.28em] text-muted">{eyebrow}</p>
+      <h2 className="mt-3 text-3xl font-semibold tracking-[-0.04em]">{title}</h2>
+      <div className="mt-5 grid gap-4 lg:grid-cols-2">
+        {results.length === 0 ? (
+          <p className="text-sm leading-6 text-muted">{empty}</p>
+        ) : (
+          results.map((result) => (
+            <DiscoveryCard key={`${result.entityType}-${result.slug}`} result={result} surface={eyebrow} />
+          ))
+        )}
+      </div>
+    </section>
+  );
+}
+
+export function DiscoveryBackendNotice({ kind }: { kind: "missing-url" | "error" }) {
+  return (
+    <div className="rounded-[1.5rem] border border-dashed border-white/25 bg-white/14 px-5 py-4 text-sm leading-6 text-white/78">
+      {kind === "missing-url"
+        ? "Convex is not configured, so this page is showing fixture discovery content when available."
+        : "Discovery reads failed; check the local Convex backend and retry."}
+    </div>
+  );
+}
+
+export function DiscoveryPublicPage({
+  data,
+  query,
+  results,
+  status,
+}: {
+  data: PublicDiscoveryData;
+  query?: string;
+  results: PublicSearchResult[];
+  status: DiscoveryStatus;
+}) {
+  const hasQuery = Boolean(query?.trim());
+
+  return (
+    <main className="min-h-screen px-6 py-8 text-foreground sm:px-10 lg:px-16">
+      <div className="mx-auto flex w-full max-w-7xl flex-col gap-8">
+        <nav className="flex flex-wrap items-center justify-between gap-3 text-sm">
+          <Link className="font-mono uppercase tracking-[0.28em] text-muted" href="/">
+            VRDex
+          </Link>
+          <div className="flex flex-wrap gap-2">
+            <Link className="rounded-full border border-border bg-surface px-4 py-2 font-medium" href="/submit">
+              Add profile
+            </Link>
+            <Link className="rounded-full border border-border bg-surface px-4 py-2 font-medium" href="/events/new">
+              Add event
+            </Link>
+          </div>
+        </nav>
+
+        <section className="overflow-hidden rounded-[2.2rem] bg-[#221512] text-white shadow-[0_28px_90px_rgba(64,40,24,0.18)]">
+          <div className="grid gap-8 bg-[radial-gradient(circle_at_top_left,rgba(214,106,77,0.34),transparent_34%),linear-gradient(135deg,#221512,#7c321f)] px-6 py-8 sm:px-8 lg:grid-cols-[1.1fr_0.9fr] lg:px-10 lg:py-12">
+            <div>
+              <p className="font-mono text-xs uppercase tracking-[0.3em] text-white/68">
+                Search the VRChat scene
+              </p>
+              <h1 className="mt-4 text-5xl leading-none font-semibold tracking-[-0.055em] sm:text-7xl">
+                Find the night, the people, and the worlds behind it.
+              </h1>
+              <p className="mt-5 max-w-2xl text-base leading-7 text-white/76 sm:text-lg">
+                VRDex discovery combines trustworthy public profiles, event posters, world context, and source-aware ranking without pretending unverified data is official.
+              </p>
+              <DiscoverySearchForm defaultQuery={query} />
+              <div className="mt-5 flex flex-wrap gap-2">
+                {data.terms.slice(0, 8).map((term) => (
+                  <TrackedDiscoveryLink
+                    className="rounded-full bg-white/14 px-3 py-1 text-xs text-white/78 transition hover:bg-white/22"
+                    eventName="discovery_filter_selected"
+                    href={`/discover?q=${encodeURIComponent(term.label)}`}
+                    key={`${term.scope}-${term.key}`}
+                    properties={{ scope: term.scope, term: term.label, surface: "hero_terms" }}
+                  >
+                    {term.label}
+                  </TrackedDiscoveryLink>
+                ))}
+              </div>
+            </div>
+            <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-1 xl:grid-cols-2">
+              {data.featured.slice(0, 2).map((result) => (
+                <PosterCard key={`${result.entityType}-${result.slug}`} result={result} />
+              ))}
+            </div>
+          </div>
+        </section>
+
+        {status === "live" ? null : <DiscoveryBackendNotice kind={status} />}
+
+        {hasQuery ? (
+          <Section
+            empty="No public results matched that search yet."
+            eyebrow="Search results"
+            results={results}
+            title={`Results for “${query}”`}
+          />
+        ) : null}
+
+        <Section
+          empty="No upcoming events are public yet."
+          eyebrow="Tonight and soon"
+          results={data.upcomingEvents}
+          title="Events worth checking first"
+        />
+
+        <section className="grid gap-5 xl:grid-cols-3">
+          <Section empty="No people are discoverable yet." eyebrow="People" results={data.people} title="People" />
+          <Section
+            empty="No communities are discoverable yet."
+            eyebrow="Communities"
+            results={data.communities}
+            title="Communities"
+          />
+          <Section empty="No worlds are discoverable yet." eyebrow="Worlds" results={data.worlds} title="Worlds" />
+        </section>
+      </div>
+    </main>
+  );
+}

--- a/apps/web/src/app/_components/profile-public-page.tsx
+++ b/apps/web/src/app/_components/profile-public-page.tsx
@@ -41,6 +41,11 @@ type PublicProfileBase = {
   region?: string;
   timezone?: string;
   trustLabel: ProfileTrustLabel;
+  source?: {
+    sourceType: "community";
+    label: string;
+    submittedAt?: number;
+  };
   outboundLinks: Array<{
     type: ProfileLinkType;
     label: string;
@@ -159,6 +164,16 @@ function linkSourceLabel(source: LinkSource): string {
   }
 
   return "Reviewed";
+}
+
+function formatSubmittedAt(value: number | undefined): string | null {
+  if (value === undefined) {
+    return null;
+  }
+
+  return new Intl.DateTimeFormat("en", { month: "short", day: "numeric", year: "numeric" }).format(
+    new Date(value),
+  );
 }
 
 function roleLabel(role: WorldCreatorRole): string {
@@ -291,6 +306,14 @@ export function ProfilePublicPage({ profile }: { profile: PublicProfile }) {
                   <p className="mt-2 max-w-xs text-sm leading-6 text-white/76">
                     {trust.description}
                   </p>
+                  {profile.source ? (
+                    <p className="mt-3 text-xs leading-5 text-white/64">
+                      Source: {profile.source.label}
+                      {formatSubmittedAt(profile.source.submittedAt)
+                        ? ` on ${formatSubmittedAt(profile.source.submittedAt)}`
+                        : ""}
+                    </p>
+                  ) : null}
                 </aside>
               </div>
             </div>

--- a/apps/web/src/app/discover/page.tsx
+++ b/apps/web/src/app/discover/page.tsx
@@ -1,0 +1,29 @@
+import { DiscoveryPublicPage } from "../_components/discovery-public-page";
+import { fetchDiscovery, fetchDiscoverySearch } from "@/convex/server";
+
+export const dynamic = "force-dynamic";
+
+type DiscoverPageProps = {
+  searchParams: Promise<{
+    q?: string;
+  }>;
+};
+
+export default async function DiscoverPage({ searchParams }: DiscoverPageProps) {
+  const { q } = await searchParams;
+  const query = q?.trim() ?? "";
+  const [discovery, search] = await Promise.all([
+    fetchDiscovery(),
+    query ? fetchDiscoverySearch(query) : Promise.resolve({ kind: "live" as const, results: [] }),
+  ]);
+  const status = discovery.kind === "live" ? search.kind : discovery.kind;
+
+  return (
+    <DiscoveryPublicPage
+      data={discovery.data}
+      query={query}
+      results={search.results}
+      status={status}
+    />
+  );
+}

--- a/apps/web/src/app/layout.tsx
+++ b/apps/web/src/app/layout.tsx
@@ -1,6 +1,7 @@
 import type { Metadata } from "next";
 import { IBM_Plex_Mono, Space_Grotesk } from "next/font/google";
 import { ConvexClientProvider } from "./ConvexClientProvider";
+import { PostHogProvider } from "./PostHogProvider";
 import "./globals.css";
 
 const spaceGrotesk = Space_Grotesk({
@@ -29,7 +30,9 @@ export default function RootLayout({
       <body
         className={`${spaceGrotesk.variable} ${ibmPlexMono.variable} antialiased`}
       >
-        <ConvexClientProvider>{children}</ConvexClientProvider>
+        <PostHogProvider>
+          <ConvexClientProvider>{children}</ConvexClientProvider>
+        </PostHogProvider>
       </body>
     </html>
   );

--- a/apps/web/src/app/page.tsx
+++ b/apps/web/src/app/page.tsx
@@ -1,99 +1,94 @@
 import Link from "next/link";
+import { DiscoverySearchForm } from "./_components/discovery-analytics";
 import { HomeActiveWorldsSection } from "./_components/home-active-worlds";
 import { BackendStatusCard } from "./backend-status-card";
-import { fetchHomeActiveWorlds } from "@/convex/server";
+import { fetchDiscovery, fetchHomeActiveWorlds } from "@/convex/server";
 
 export const dynamic = "force-dynamic";
 
+function formatHomeEventTime(value: number | undefined): string | null {
+  if (value === undefined) {
+    return null;
+  }
+
+  return new Intl.DateTimeFormat("en", {
+    month: "short",
+    day: "numeric",
+    hour: "numeric",
+    minute: "2-digit",
+  }).format(new Date(value));
+}
+
 export default async function Home() {
-  const activeWorlds = await fetchHomeActiveWorlds();
+  const [activeWorlds, discovery] = await Promise.all([fetchHomeActiveWorlds(), fetchDiscovery()]);
+  const featuredEvents = discovery.data.upcomingEvents.slice(0, 3);
 
   return (
     <main className="min-h-screen px-6 py-10 text-foreground sm:px-10 lg:px-16">
       <div className="mx-auto flex w-full max-w-6xl flex-col gap-8">
-        <section className="overflow-hidden rounded-[2rem] border border-border bg-surface shadow-[0_24px_80px_rgba(64,40,24,0.12)] backdrop-blur">
-          <div className="grid gap-10 px-6 py-8 sm:px-8 lg:grid-cols-[1.4fr_0.9fr] lg:px-10 lg:py-10">
+        <section className="overflow-hidden rounded-[2rem] bg-[#221512] text-white shadow-[0_24px_80px_rgba(64,40,24,0.18)]">
+          <div className="grid gap-10 bg-[radial-gradient(circle_at_top_left,rgba(214,106,77,0.34),transparent_34%),linear-gradient(135deg,#221512,#7c321f)] px-6 py-8 sm:px-8 lg:grid-cols-[1.35fr_0.9fr] lg:px-10 lg:py-12">
             <div className="flex flex-col gap-8">
-              <div className="flex items-center gap-3 text-sm uppercase tracking-[0.28em] text-muted">
-                <span className="rounded-full border border-border px-3 py-1">VRDex</span>
-                <span>Web + Convex runtime path</span>
+              <div className="flex items-center gap-3 text-sm uppercase tracking-[0.28em] text-white/68">
+                <span className="rounded-full border border-white/25 px-3 py-1">VRDex</span>
+                <span>Search-first discovery</span>
               </div>
 
               <div className="max-w-3xl space-y-5">
-                <h1 className="text-4xl leading-none font-semibold tracking-[-0.04em] sm:text-6xl">
-                  Profiles, communities, and scene presence for VRChat.
+                <h1 className="text-5xl leading-none font-semibold tracking-[-0.055em] sm:text-7xl">
+                  Find what is happening in VRChat tonight.
                 </h1>
-                <p className="max-w-2xl text-base leading-7 text-muted sm:text-lg">
-                  VRDex now has the first submit-to-public-profile path: signed-in
-                  community members can seed unclaimed people and communities, and
-                  published profiles render at their canonical URLs.
+                <p className="max-w-2xl text-base leading-7 text-white/76 sm:text-lg">
+                  Search people, communities, worlds, and events with trust labels, source-aware ranking, and featured posters built for the VRChat scene.
                 </p>
               </div>
 
+              <DiscoverySearchForm />
+
               <div className="flex flex-col gap-3 sm:flex-row">
                 <Link
-                  className="inline-flex items-center justify-center rounded-full bg-accent px-5 py-3 text-sm font-medium text-white transition hover:bg-accent-strong"
-                  href="/submit"
+                  className="inline-flex items-center justify-center rounded-full bg-white px-5 py-3 text-sm font-semibold text-foreground transition hover:-translate-y-0.5"
+                  href="/discover"
                 >
-                  Add a profile
+                  Explore discovery
                 </Link>
                 <Link
-                  className="inline-flex items-center justify-center rounded-full border border-border bg-surface-strong px-5 py-3 text-sm font-medium transition hover:-translate-y-0.5"
+                  className="inline-flex items-center justify-center rounded-full border border-white/25 bg-white/12 px-5 py-3 text-sm font-medium text-white transition hover:-translate-y-0.5"
                   href="/events/new"
                 >
                   Add an event
                 </Link>
                 <Link
-                  className="inline-flex items-center justify-center rounded-full border border-border bg-surface-strong px-5 py-3 text-sm font-medium transition hover:-translate-y-0.5"
-                  href="/server-status"
+                  className="inline-flex items-center justify-center rounded-full border border-white/25 bg-white/12 px-5 py-3 text-sm font-medium text-white transition hover:-translate-y-0.5"
+                  href="/submit"
                 >
-                  Server-side baseline
+                  Add a profile
                 </Link>
-                <Link
-                  className="inline-flex items-center justify-center rounded-full border border-border bg-surface-strong px-5 py-3 text-sm font-medium transition hover:-translate-y-0.5"
-                  href="/deployment"
-                >
-                  Deployment check
-                </Link>
-                <a
-                  className="inline-flex items-center justify-center rounded-full border border-border bg-surface-strong px-5 py-3 text-sm font-medium transition hover:-translate-y-0.5"
-                  href="https://www.convex.dev/"
-                  target="_blank"
-                  rel="noreferrer"
-                >
-                  Convex next
-                </a>
               </div>
             </div>
 
-            <aside className="rounded-[1.5rem] border border-border bg-surface-strong p-5">
-              <p className="font-mono text-xs uppercase tracking-[0.3em] text-muted">
-                Scaffold choices
+            <aside className="rounded-[1.5rem] border border-white/18 bg-white/14 p-5 backdrop-blur">
+              <p className="font-mono text-xs uppercase tracking-[0.3em] text-white/64">
+                Tonight and soon
               </p>
-              <dl className="mt-5 space-y-4 text-sm">
-                <div className="flex items-start justify-between gap-4 border-b border-border pb-4">
-                  <dt className="text-muted">Framework</dt>
-                  <dd className="text-right font-medium">Next.js 16 App Router</dd>
-                </div>
-                <div className="flex items-start justify-between gap-4 border-b border-border pb-4">
-                  <dt className="text-muted">Language</dt>
-                  <dd className="text-right font-medium">TypeScript</dd>
-                </div>
-                <div className="flex items-start justify-between gap-4 border-b border-border pb-4">
-                  <dt className="text-muted">Styling</dt>
-                  <dd className="text-right font-medium">Tailwind CSS v4</dd>
-                </div>
-                <div className="flex items-start justify-between gap-4 border-b border-border pb-4">
-                  <dt className="text-muted">Package manager</dt>
-                  <dd className="text-right font-medium">pnpm workspace</dd>
-                </div>
-                <div className="flex items-start justify-between gap-4">
-                  <dt className="text-muted">Next issues</dt>
-                  <dd className="text-right font-medium">#18, #59, #61</dd>
-                </div>
-              </dl>
+              <div className="mt-5 grid gap-3">
+                {featuredEvents.length === 0 ? (
+                  <p className="text-sm leading-6 text-white/74">Public event posters will land here as events are added.</p>
+                ) : (
+                  featuredEvents.map((event) => (
+                    <Link
+                      className="rounded-[1.2rem] border border-white/14 bg-white/12 px-4 py-4 transition hover:-translate-y-0.5"
+                      href={event.routePath}
+                      key={`${event.entityType}-${event.slug}`}
+                    >
+                      <span className="block text-lg font-semibold tracking-[-0.03em]">{event.title}</span>
+                      <span className="mt-1 block text-sm text-white/70">{formatHomeEventTime(event.startsAt) ?? event.subtitle}</span>
+                    </Link>
+                  ))
+                )}
+              </div>
 
-              <div className="mt-5 border-t border-border pt-5">
+              <div className="mt-5 border-t border-white/15 pt-5 text-foreground">
                 <BackendStatusCard />
               </div>
             </aside>

--- a/apps/web/src/app/privacy/suppression/page.tsx
+++ b/apps/web/src/app/privacy/suppression/page.tsx
@@ -1,0 +1,38 @@
+import Link from "next/link";
+
+import { SuppressionRequestForm } from "./suppression-request-form";
+
+export const dynamic = "force-dynamic";
+
+export default function SuppressionRequestPage() {
+  return (
+    <main className="min-h-screen px-6 py-8 text-foreground sm:px-10 lg:px-16">
+      <div className="mx-auto flex w-full max-w-4xl flex-col gap-6">
+        <nav className="flex flex-wrap items-center justify-between gap-3 text-sm">
+          <Link className="font-mono uppercase tracking-[0.28em] text-muted" href="/">
+            VRDex
+          </Link>
+          <Link className="rounded-full border border-border bg-surface px-4 py-2 font-medium" href="/discover">
+            Back to discovery
+          </Link>
+        </nav>
+
+        <section className="rounded-[2rem] border border-border bg-surface px-6 py-8 shadow-[0_24px_80px_rgba(64,40,24,0.12)] sm:px-8">
+          <p className="font-mono text-xs uppercase tracking-[0.28em] text-muted">
+            Privacy and suppression
+          </p>
+          <h1 className="mt-4 text-4xl leading-none font-semibold tracking-[-0.04em] sm:text-6xl">
+            Request review of a public listing.
+          </h1>
+          <p className="mt-5 max-w-2xl text-sm leading-7 text-muted sm:text-base">
+            VRDex supports owner opt-out and pre-claim safety review as separate paths. This first form records the request and keeps final hiding decisions explicit so search, event, and profile surfaces can enforce them consistently.
+          </p>
+        </section>
+
+        <section className="rounded-[1.5rem] border border-border bg-surface px-5 py-6 sm:px-6">
+          <SuppressionRequestForm />
+        </section>
+      </div>
+    </main>
+  );
+}

--- a/apps/web/src/app/privacy/suppression/suppression-request-form.tsx
+++ b/apps/web/src/app/privacy/suppression/suppression-request-form.tsx
@@ -1,0 +1,151 @@
+"use client";
+
+import { FormEvent, useState, useTransition } from "react";
+import { useMutation } from "convex/react";
+import { api } from "@convex-generated-api";
+
+const convexUrl = process.env.NEXT_PUBLIC_CONVEX_URL;
+
+type Status =
+  | { kind: "idle" }
+  | { kind: "submitting" }
+  | { kind: "success" }
+  | { kind: "error"; message: string };
+
+function textField(value: FormDataEntryValue | null): string {
+  return typeof value === "string" ? value : "";
+}
+
+export function SuppressionRequestForm() {
+  const requestSuppression = useMutation(api.suppressions.requestProfileSuppression);
+  const [status, setStatus] = useState<Status>({ kind: "idle" });
+  const [, startTransition] = useTransition();
+
+  if (!convexUrl) {
+    return (
+      <div className="rounded-[1.5rem] border border-dashed border-border bg-surface px-5 py-6 text-sm leading-7 text-muted">
+        Convex is not configured. Run the local backend before submitting suppression requests.
+      </div>
+    );
+  }
+
+  async function onSubmit(event: FormEvent<HTMLFormElement>) {
+    event.preventDefault();
+    const form = event.currentTarget;
+    const formData = new FormData(form);
+
+    setStatus({ kind: "submitting" });
+
+    try {
+      await requestSuppression({
+        requestType: textField(formData.get("requestType")) as
+          | "owner_opt_out"
+          | "pre_claim_safety",
+        profileSlug: textField(formData.get("profileSlug")) || undefined,
+        profileType: (textField(formData.get("profileType")) || undefined) as
+          | "person"
+          | "community"
+          | undefined,
+        displayName: textField(formData.get("displayName")) || undefined,
+        requesterContact: textField(formData.get("requesterContact")) || undefined,
+        requesterNote: textField(formData.get("requesterNote")) || undefined,
+      });
+      form.reset();
+      startTransition(() => setStatus({ kind: "success" }));
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      startTransition(() =>
+        setStatus({ kind: "error", message: message || "Suppression request failed." }),
+      );
+    }
+  }
+
+  return (
+    <form className="grid gap-5" onSubmit={onSubmit}>
+      <div className="grid gap-4 sm:grid-cols-2">
+        <label className="grid gap-2 text-sm font-medium">
+          Request type
+          <select
+            className="rounded-2xl border border-border bg-surface-strong px-4 py-3 font-normal outline-none transition focus:border-accent"
+            name="requestType"
+          >
+            <option value="owner_opt_out">I own this listing and want it opted out</option>
+            <option value="pre_claim_safety">This unclaimed listing needs safety review</option>
+          </select>
+        </label>
+
+        <label className="grid gap-2 text-sm font-medium">
+          Profile type
+          <select
+            className="rounded-2xl border border-border bg-surface-strong px-4 py-3 font-normal outline-none transition focus:border-accent"
+            name="profileType"
+          >
+            <option value="person">Person</option>
+            <option value="community">Community</option>
+          </select>
+        </label>
+      </div>
+
+      <div className="grid gap-4 sm:grid-cols-2">
+        <label className="grid gap-2 text-sm font-medium">
+          Profile slug
+          <input
+            className="rounded-2xl border border-border bg-surface-strong px-4 py-3 font-normal outline-none transition placeholder:text-muted/65 focus:border-accent"
+            name="profileSlug"
+            placeholder="dj-aurora"
+          />
+        </label>
+
+        <label className="grid gap-2 text-sm font-medium">
+          Display name if slug is unknown
+          <input
+            className="rounded-2xl border border-border bg-surface-strong px-4 py-3 font-normal outline-none transition placeholder:text-muted/65 focus:border-accent"
+            name="displayName"
+            placeholder="DJ Aurora"
+          />
+        </label>
+      </div>
+
+      <label className="grid gap-2 text-sm font-medium">
+        Contact for follow-up
+        <input
+          className="rounded-2xl border border-border bg-surface-strong px-4 py-3 font-normal outline-none transition placeholder:text-muted/65 focus:border-accent"
+          name="requesterContact"
+          placeholder="Email or Discord handle"
+        />
+      </label>
+
+      <label className="grid gap-2 text-sm font-medium">
+        Note
+        <textarea
+          className="min-h-32 rounded-2xl border border-border bg-surface-strong px-4 py-3 font-normal outline-none transition placeholder:text-muted/65 focus:border-accent"
+          name="requesterNote"
+          placeholder="Briefly explain the request. Do not include sensitive proof in this first form."
+        />
+      </label>
+
+      <div className="rounded-[1.25rem] border border-border bg-surface-strong px-4 py-4 text-sm leading-6 text-muted">
+        Submitted requests do not automatically hide a listing. Accepted opt-out or suppression states are enforced across profile pages, search, and event/person references.
+      </div>
+
+      <button
+        className="inline-flex w-fit items-center justify-center rounded-full bg-accent px-5 py-3 text-sm font-medium text-white transition hover:bg-accent-strong disabled:cursor-not-allowed disabled:opacity-60"
+        disabled={status.kind === "submitting"}
+        type="submit"
+      >
+        {status.kind === "submitting" ? "Submitting..." : "Submit request"}
+      </button>
+
+      {status.kind === "success" ? (
+        <p className="rounded-[1rem] border border-green-700/20 bg-green-700/10 px-4 py-3 text-sm leading-6 text-green-900">
+          Request submitted for review.
+        </p>
+      ) : null}
+      {status.kind === "error" ? (
+        <p className="rounded-[1rem] border border-accent/35 bg-accent/10 px-4 py-3 text-sm leading-6 text-accent-strong">
+          {status.message}
+        </p>
+      ) : null}
+    </form>
+  );
+}

--- a/apps/web/src/app/search/page.tsx
+++ b/apps/web/src/app/search/page.tsx
@@ -1,0 +1,5 @@
+import DiscoverPage from "../discover/page";
+
+export const dynamic = "force-dynamic";
+
+export default DiscoverPage;

--- a/apps/web/src/convex/playwright-fixtures.ts
+++ b/apps/web/src/convex/playwright-fixtures.ts
@@ -1,5 +1,9 @@
 import type { PublicProfile } from "@/app/_components/profile-public-page";
 import type { PublicActiveWorld } from "@/app/_components/home-active-worlds";
+import type {
+  PublicDiscoveryData,
+  PublicSearchResult,
+} from "@/app/_components/discovery-public-page";
 import type { PublicEvent } from "@/app/_components/event-public-page";
 import type { PublicWorld } from "@/app/_components/world-public-page";
 
@@ -44,6 +48,11 @@ const personProfile: PublicProfile = {
   region: "EU",
   timezone: "UTC+1",
   trustLabel: "community_submitted",
+  source: {
+    sourceType: "community",
+    label: "Community submitted",
+    submittedAt: Date.UTC(2025, 0, 1, 12, 0, 0),
+  },
   outboundLinks: [
     {
       type: "kofi",
@@ -88,6 +97,11 @@ const communityProfile: PublicProfile = {
   region: "Global",
   timezone: "UTC",
   trustLabel: "community_submitted",
+  source: {
+    sourceType: "community",
+    label: "Community submitted",
+    submittedAt: Date.UTC(2025, 0, 1, 12, 0, 0),
+  },
   outboundLinks: [
     {
       type: "website",
@@ -284,6 +298,79 @@ const publicEvent: PublicEvent = {
   ],
 };
 
+const discoveryResults: PublicSearchResult[] = [
+  {
+    entityType: "event",
+    slug: eventSlug,
+    routePath: `/e/${eventSlug}`,
+    title: "Afterglow Harbor Sessions",
+    subtitle: "Afterglow Social",
+    summary: "A poster-forward fixture event for tonight-and-soon discovery.",
+    imageUrl: "https://example.invalid/events/afterglow-harbor-poster.png",
+    startsAt: Date.UTC(2026, 5, 14, 22, 0, 0),
+    source: {
+      sourceType: "manual",
+      label: "Fixture event listing",
+    },
+    score: 280,
+  },
+  {
+    entityType: "profile",
+    profileType: "person",
+    slug: personSlug,
+    routePath: `/p/${personSlug}`,
+    title: "DJ Aurora",
+    subtitle: "Person profile",
+    summary: "Melodic house sets for late-night VRChat floors.",
+    source: {
+      sourceType: "community",
+      label: "Community submitted",
+    },
+    score: 170,
+  },
+  {
+    entityType: "profile",
+    profileType: "community",
+    slug: communitySlug,
+    routePath: `/c/${communitySlug}`,
+    title: "Afterglow Social",
+    subtitle: "Community profile",
+    summary: "A warm VRChat club night for music-first communities.",
+    source: {
+      sourceType: "community",
+      label: "Community submitted",
+    },
+    score: 160,
+  },
+  {
+    entityType: "world",
+    slug: worldSlug,
+    routePath: `/w/${worldSlug}`,
+    title: "Neon Harbor",
+    subtitle: "World",
+    summary: "A fixture VRChat venue page for world discovery visual review.",
+    source: {
+      sourceType: "owner",
+      label: "Fixture owner-authored metadata",
+    },
+    score: 150,
+  },
+];
+
+const discoveryData: PublicDiscoveryData = {
+  featured: [discoveryResults[0]!, discoveryResults[3]!],
+  upcomingEvents: [discoveryResults[0]!],
+  people: [discoveryResults[1]!],
+  communities: [discoveryResults[2]!],
+  worlds: [discoveryResults[3]!],
+  terms: [
+    { scope: "profile_tag", key: "melodic_house", label: "Melodic House", usageCount: 2 },
+    { scope: "event_tag", key: "tonight", label: "Tonight", usageCount: 1 },
+    { scope: "world_tag", key: "club_world", label: "Club world", usageCount: 1 },
+    { scope: "community_subtype", key: "club", label: "Club", usageCount: 1 },
+  ],
+};
+
 export function getPlaywrightPublicProfileFixture(
   slug: string,
   profileType: "person" | "community",
@@ -304,6 +391,40 @@ export function getPlaywrightPublicProfileFixture(
   }
 
   return null;
+}
+
+export function getPlaywrightDiscoveryFixture(): PublicDiscoveryData | null {
+  if (
+    process.env.NODE_ENV === "production" ||
+    process.env.VRDEX_ENABLE_PLAYWRIGHT_FIXTURES !== "true"
+  ) {
+    return null;
+  }
+
+  return discoveryData;
+}
+
+export function searchPlaywrightDiscoveryFixture(query: string): PublicSearchResult[] | null {
+  if (
+    process.env.NODE_ENV === "production" ||
+    process.env.VRDEX_ENABLE_PLAYWRIGHT_FIXTURES !== "true"
+  ) {
+    return null;
+  }
+
+  const normalized = query.trim().toLowerCase();
+
+  if (!normalized) {
+    return [];
+  }
+
+  return discoveryResults.filter((result) =>
+    [result.title, result.subtitle, result.summary, result.source?.label]
+      .filter(Boolean)
+      .join(" ")
+      .toLowerCase()
+      .includes(normalized),
+  );
 }
 
 export function getPlaywrightPublicWorldFixture(slug: string): PublicWorld | null {

--- a/apps/web/src/convex/server.ts
+++ b/apps/web/src/convex/server.ts
@@ -2,9 +2,11 @@ import { fetchQuery } from "convex/nextjs";
 import { api } from "@convex-generated-api";
 import {
   getPlaywrightActiveWorldFixtures,
+  getPlaywrightDiscoveryFixture,
   getPlaywrightPublicEventFixture,
   getPlaywrightPublicProfileFixture,
   getPlaywrightPublicWorldFixture,
+  searchPlaywrightDiscoveryFixture,
 } from "./playwright-fixtures";
 
 type PublicProfileType = "person" | "community";
@@ -163,4 +165,81 @@ export async function fetchHomeActiveWorlds() {
       worlds: [],
     };
   }
+}
+
+export async function fetchDiscovery() {
+  const fixtureDiscovery = getPlaywrightDiscoveryFixture();
+
+  if (fixtureDiscovery !== null) {
+    return {
+      kind: "live" as const,
+      data: fixtureDiscovery,
+    };
+  }
+
+  if (!process.env.NEXT_PUBLIC_CONVEX_URL) {
+    return { kind: "missing-url" as const, data: emptyDiscoveryData() };
+  }
+
+  try {
+    const data = await fetchQuery(api.search.listDiscovery, { now: Date.now() });
+
+    return {
+      kind: "live" as const,
+      data,
+    };
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+
+    console.error(`Server-side Convex discovery fetch failed: ${message}`);
+
+    return {
+      kind: "error" as const,
+      data: emptyDiscoveryData(),
+    };
+  }
+}
+
+export async function fetchDiscoverySearch(query: string) {
+  const fixtureResults = searchPlaywrightDiscoveryFixture(query);
+
+  if (fixtureResults !== null) {
+    return {
+      kind: "live" as const,
+      results: fixtureResults,
+    };
+  }
+
+  if (!process.env.NEXT_PUBLIC_CONVEX_URL) {
+    return { kind: "missing-url" as const, results: [] };
+  }
+
+  try {
+    const results = await fetchQuery(api.search.searchUniversal, { query, limit: 24 });
+
+    return {
+      kind: "live" as const,
+      results,
+    };
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+
+    console.error(`Server-side Convex search fetch failed: ${message}`);
+
+    return {
+      kind: "error" as const,
+      results: [],
+    };
+  }
+}
+
+function emptyDiscoveryData() {
+  return {
+    featured: [],
+    upcomingEvents: [],
+    people: [],
+    communities: [],
+    worlds: [],
+    terms: [],
+  };
 }

--- a/convex/README.md
+++ b/convex/README.md
@@ -16,6 +16,7 @@ This directory holds the initial Convex backend slice for `VRDex`.
 - `worlds.ts` exposes public world reads
 - `_eventSlugs.ts`, `_eventInputs.ts`, and `_eventPublic.ts` contain event slug, input, and public projection helpers
 - `events.ts` exposes public event reads and authenticated event editor mutations
+- `migrations.ts` contains internal one-off data backfills for schema additions
 - `_searchDocuments.ts`, `_vocabulary.ts`, `search.ts`, and `suppressions.ts` contain public discovery, vocabulary, and suppression helpers
 - `_generated/` contains committed Convex codegen output and should not be edited by hand
 - `tsconfig.json` is the Convex-managed TypeScript config for backend functions

--- a/convex/README.md
+++ b/convex/README.md
@@ -16,6 +16,7 @@ This directory holds the initial Convex backend slice for `VRDex`.
 - `worlds.ts` exposes public world reads
 - `_eventSlugs.ts`, `_eventInputs.ts`, and `_eventPublic.ts` contain event slug, input, and public projection helpers
 - `events.ts` exposes public event reads and authenticated event editor mutations
+- `_searchDocuments.ts`, `_vocabulary.ts`, `search.ts`, and `suppressions.ts` contain public discovery, vocabulary, and suppression helpers
 - `_generated/` contains committed Convex codegen output and should not be edited by hand
 - `tsconfig.json` is the Convex-managed TypeScript config for backend functions
 
@@ -36,3 +37,5 @@ The slug, permission, and claim-state contracts live in `docs/backend/profile-sl
 The first world-discovery planning contract lives in `docs/planning/world-discovery.md`.
 
 The event schema and profile-association contracts live in `docs/backend/event-schema.md`.
+
+Search, discovery, and vocabulary contracts live in `docs/backend/search-discovery.md` and `docs/backend/vocabulary-model.md`.

--- a/convex/_generated/api.d.ts
+++ b/convex/_generated/api.d.ts
@@ -27,6 +27,7 @@ import type * as _worldPublic from "../_worldPublic.js";
 import type * as _worldSlugs from "../_worldSlugs.js";
 import type * as events from "../events.js";
 import type * as health from "../health.js";
+import type * as migrations from "../migrations.js";
 import type * as profiles from "../profiles.js";
 import type * as search from "../search.js";
 import type * as suppressions from "../suppressions.js";
@@ -58,6 +59,7 @@ declare const fullApi: ApiFromModules<{
   _worldSlugs: typeof _worldSlugs;
   events: typeof events;
   health: typeof health;
+  migrations: typeof migrations;
   profiles: typeof profiles;
   search: typeof search;
   suppressions: typeof suppressions;

--- a/convex/_generated/api.d.ts
+++ b/convex/_generated/api.d.ts
@@ -19,6 +19,8 @@ import type * as _profileStates from "../_profileStates.js";
 import type * as _profileSubmissions from "../_profileSubmissions.js";
 import type * as _profileWorldCredits from "../_profileWorldCredits.js";
 import type * as _publicFields from "../_publicFields.js";
+import type * as _searchDocuments from "../_searchDocuments.js";
+import type * as _vocabulary from "../_vocabulary.js";
 import type * as _worldEvents from "../_worldEvents.js";
 import type * as _worldIds from "../_worldIds.js";
 import type * as _worldPublic from "../_worldPublic.js";
@@ -26,6 +28,8 @@ import type * as _worldSlugs from "../_worldSlugs.js";
 import type * as events from "../events.js";
 import type * as health from "../health.js";
 import type * as profiles from "../profiles.js";
+import type * as search from "../search.js";
+import type * as suppressions from "../suppressions.js";
 import type * as worlds from "../worlds.js";
 
 import type {
@@ -46,6 +50,8 @@ declare const fullApi: ApiFromModules<{
   _profileSubmissions: typeof _profileSubmissions;
   _profileWorldCredits: typeof _profileWorldCredits;
   _publicFields: typeof _publicFields;
+  _searchDocuments: typeof _searchDocuments;
+  _vocabulary: typeof _vocabulary;
   _worldEvents: typeof _worldEvents;
   _worldIds: typeof _worldIds;
   _worldPublic: typeof _worldPublic;
@@ -53,6 +59,8 @@ declare const fullApi: ApiFromModules<{
   events: typeof events;
   health: typeof health;
   profiles: typeof profiles;
+  search: typeof search;
+  suppressions: typeof suppressions;
   worlds: typeof worlds;
 }>;
 

--- a/convex/_profilePermissions.ts
+++ b/convex/_profilePermissions.ts
@@ -43,18 +43,21 @@ function isFieldCompatibleWithProfileType(
 
 export function canReadProfile(
   subject: ProfilePermissionSubject,
-  profile: Pick<Doc<"profiles">, "publicationState">,
+  profile: Pick<Doc<"profiles">, "publicationState" | "publicSurfacingState">,
 ): boolean {
   if (subject === "claimed_owner" || subject === "moderator") {
     return true;
   }
 
-  return profile.publicationState === "published";
+  return profile.publicationState === "published" && profile.publicSurfacingState === "public";
 }
 
 export function canEditProfileField(
   subject: ProfilePermissionSubject,
-  profile: Pick<Doc<"profiles">, "claimState" | "profileType" | "publicationState">,
+  profile: Pick<
+    Doc<"profiles">,
+    "claimState" | "profileType" | "publicationState" | "publicSurfacingState"
+  >,
   field: ProfileEditableField,
 ): boolean {
   if (!isFieldCompatibleWithProfileType(profile.profileType, field)) {

--- a/convex/_profilePublic.ts
+++ b/convex/_profilePublic.ts
@@ -3,6 +3,13 @@ import { optionalField, safeHttpsUrl } from "./_publicFields";
 import { getProfileTrustLabel } from "./_profileStates";
 
 export function toPublicProfile(profile: Doc<"profiles">) {
+  const source = profile.sourceAttribution
+    ? {
+        sourceType: "community" as const,
+        label: "Community submitted",
+        submittedAt: profile.sourceAttribution.submittedAt,
+      }
+    : undefined;
   const shared = {
     profileType: profile.profileType,
     slug: profile.slug,
@@ -10,6 +17,7 @@ export function toPublicProfile(profile: Doc<"profiles">) {
     aliases: profile.aliases,
     tags: profile.tags,
     trustLabel: getProfileTrustLabel(profile.claimState, profile.creationSource),
+    ...optionalField("source", source),
     outboundLinks: (profile.outboundLinks ?? []).flatMap((link) => {
       const linkUrl = safeHttpsUrl(link.url);
 

--- a/convex/_searchDocuments.ts
+++ b/convex/_searchDocuments.ts
@@ -1,7 +1,8 @@
 import type { Doc } from "./_generated/dataModel";
-import type { DatabaseWriter } from "./_generated/server";
+import type { DatabaseReader, DatabaseWriter } from "./_generated/server";
 import { optionalField, safeHttpsUrl } from "./_publicFields";
 import { canReadProfile } from "./_profilePermissions";
+import { getProfileBySlug } from "./_profileSlugs";
 import { getProfileTrustLabel } from "./_profileStates";
 import {
   collectVocabularyKeys,
@@ -30,6 +31,9 @@ export type PublicSearchResult = {
 };
 
 type SearchDocumentInput = Omit<Doc<"searchDocuments">, "_id" | "_creationTime">;
+type WorldSearchDocumentOptions = {
+  hiddenProfileKeys?: Set<string>;
+};
 
 const ENTITY_TYPE_WEIGHT: Record<SearchEntityType, number> = {
   event: 18,
@@ -184,21 +188,74 @@ export function createProfileSearchDocument(profile: Doc<"profiles">): SearchDoc
   };
 }
 
-export function vocabularyForWorld(world: Doc<"worlds">): VocabularyCandidate[] {
+function worldAttributionKey(attribution: Doc<"worlds">["creatorAttributions"][number]): string | undefined {
+  if (!attribution.profileSlug || !attribution.profileType) {
+    return undefined;
+  }
+
+  return `${attribution.profileType}:${attribution.profileSlug}`;
+}
+
+function searchableWorldAttributions(
+  world: Doc<"worlds">,
+  options: WorldSearchDocumentOptions = {},
+): Doc<"worlds">["creatorAttributions"] {
+  return world.creatorAttributions.filter((attribution) => {
+    const key = worldAttributionKey(attribution);
+
+    if (key === undefined) {
+      return true;
+    }
+
+    return options.hiddenProfileKeys !== undefined && !options.hiddenProfileKeys.has(key);
+  });
+}
+
+export async function getHiddenWorldAttributionProfileKeys(db: DatabaseReader, world: Doc<"worlds">) {
+  const keys = new Set<string>();
+
+  await Promise.all(
+    world.creatorAttributions.map(async (attribution) => {
+      const key = worldAttributionKey(attribution);
+
+      if (key === undefined || attribution.profileSlug === undefined) {
+        return;
+      }
+
+      const profile = await getProfileBySlug(db, attribution.profileSlug);
+      if (profile === null || !canReadProfile("public", profile)) {
+        keys.add(key);
+      }
+    }),
+  );
+
+  return keys;
+}
+
+export function vocabularyForWorld(
+  world: Doc<"worlds">,
+  options: WorldSearchDocumentOptions = {},
+): VocabularyCandidate[] {
+  const attributions = searchableWorldAttributions(world, options);
+
   return [
     ...createVocabularyCandidates("world_tag", world.tags),
     ...createVocabularyCandidates(
       "world_creator_role",
-      world.creatorAttributions.map((attribution) => attribution.role),
+      attributions.map((attribution) => attribution.role),
     ),
   ];
 }
 
-export function createWorldSearchDocument(world: Doc<"worlds">): SearchDocumentInput {
+export function createWorldSearchDocument(
+  world: Doc<"worlds">,
+  options: WorldSearchDocumentOptions = {},
+): SearchDocumentInput {
   const source = world.sourceAttribution;
-  const creatorNames = world.creatorAttributions.map((attribution) => attribution.displayName);
-  const creatorRoles = world.creatorAttributions.map((attribution) => attribution.role);
-  const vocabulary = vocabularyForWorld(world);
+  const attributions = searchableWorldAttributions(world, options);
+  const creatorNames = attributions.map((attribution) => attribution.displayName);
+  const creatorRoles = attributions.map((attribution) => attribution.role);
+  const vocabulary = vocabularyForWorld(world, options);
 
   return {
     entityType: "world",
@@ -331,6 +388,28 @@ export function sortSearchResults(results: PublicSearchResult[]): PublicSearchRe
 }
 
 export async function upsertSearchDocument(db: DatabaseWriter, input: SearchDocumentInput) {
+  const existingById = input.profileId
+    ? await db
+        .query("searchDocuments")
+        .withIndex("by_profileId", (query) => query.eq("profileId", input.profileId))
+        .unique()
+    : input.worldId
+      ? await db
+          .query("searchDocuments")
+          .withIndex("by_worldId", (query) => query.eq("worldId", input.worldId))
+          .unique()
+      : input.eventId
+        ? await db
+            .query("searchDocuments")
+            .withIndex("by_eventId", (query) => query.eq("eventId", input.eventId))
+            .unique()
+        : null;
+
+  if (existingById) {
+    await db.patch(existingById._id, input);
+    return existingById._id;
+  }
+
   const existing = await db
     .query("searchDocuments")
     .withIndex("by_entityType_slug", (query) =>

--- a/convex/_searchDocuments.ts
+++ b/convex/_searchDocuments.ts
@@ -1,0 +1,347 @@
+import type { Doc } from "./_generated/dataModel";
+import type { DatabaseWriter } from "./_generated/server";
+import { optionalField, safeHttpsUrl } from "./_publicFields";
+import { canReadProfile } from "./_profilePermissions";
+import { getProfileTrustLabel } from "./_profileStates";
+import {
+  collectVocabularyKeys,
+  createVocabularyCandidates,
+  createVocabularyKey,
+  type VocabularyCandidate,
+} from "./_vocabulary";
+
+export type SearchEntityType = Doc<"searchDocuments">["entityType"];
+export type PublicSearchResult = {
+  entityType: SearchEntityType;
+  profileType?: "person" | "community";
+  slug: string;
+  routePath: string;
+  title: string;
+  subtitle?: string;
+  summary?: string;
+  imageUrl?: string;
+  trustLabel?: "community_submitted" | "unclaimed" | "claimed_unverified" | "claimed_verified";
+  source?: {
+    sourceType: Doc<"searchDocuments">["sourceType"];
+    label: string;
+  };
+  startsAt?: number;
+  score: number;
+};
+
+type SearchDocumentInput = Omit<Doc<"searchDocuments">, "_id" | "_creationTime">;
+
+const ENTITY_TYPE_WEIGHT: Record<SearchEntityType, number> = {
+  event: 18,
+  profile: 12,
+  world: 10,
+};
+
+function normalizeInlineText(input: string | undefined): string {
+  return (input ?? "").trim().replace(/\s+/g, " ");
+}
+
+export function normalizeSearchQuery(input: string): string {
+  return normalizeInlineText(input).slice(0, 120);
+}
+
+export function createSearchToken(input: string): string {
+  return createVocabularyKey(input).replace(/_/g, " ");
+}
+
+function compact<T>(values: Array<T | undefined>): T[] {
+  return values.filter((value): value is T => value !== undefined);
+}
+
+function weightedCorpus(groups: Array<{ values: Array<string | undefined>; weight: number }>): string {
+  const parts: string[] = [];
+
+  for (const group of groups) {
+    for (const value of group.values) {
+      const text = normalizeInlineText(value);
+      if (!text) {
+        continue;
+      }
+
+      for (let index = 0; index < group.weight; index += 1) {
+        parts.push(text);
+      }
+    }
+  }
+
+  return parts.join(" ").slice(0, 8_000);
+}
+
+function exactTokens(values: Array<string | undefined>): string[] {
+  const tokens = new Set<string>();
+
+  for (const value of values) {
+    const token = createSearchToken(value ?? "");
+    if (token) {
+      tokens.add(token);
+    }
+  }
+
+  return [...tokens].sort();
+}
+
+function trustRankForProfile(profile: Doc<"profiles">): number {
+  if (profile.claimState === "claimed_verified") {
+    return 40;
+  }
+
+  if (profile.claimState === "claimed_unverified") {
+    return 28;
+  }
+
+  if (profile.creationSource === "community") {
+    return 10;
+  }
+
+  return 8;
+}
+
+function publicStateForProfile(profile: Doc<"profiles">): Doc<"searchDocuments">["publicState"] {
+  return canReadProfile("public", profile) ? "public" : "hidden";
+}
+
+function sourceForProfile(profile: Doc<"profiles">): Pick<SearchDocumentInput, "sourceType" | "sourceLabel"> {
+  if (profile.creationSource === "community") {
+    return {
+      sourceType: "community",
+      sourceLabel: "Community submitted",
+    };
+  }
+
+  if (profile.creationSource === "import") {
+    return {
+      sourceType: "import",
+      sourceLabel: "Imported profile seed",
+    };
+  }
+
+  if (profile.creationSource === "moderator") {
+    return {
+      sourceType: "moderator",
+      sourceLabel: "Moderator curated",
+    };
+  }
+
+  return {
+    sourceType: "owner",
+    sourceLabel: "Owner-authored",
+  };
+}
+
+export function vocabularyForProfile(profile: Doc<"profiles">): VocabularyCandidate[] {
+  const shared = createVocabularyCandidates("profile_tag", profile.tags);
+
+  if (profile.profileType === "person") {
+    return [...shared, ...createVocabularyCandidates("person_role", profile.person.roleTags)];
+  }
+
+  return [
+    ...shared,
+    ...createVocabularyCandidates("community_subtype", [profile.community.subtype]),
+    ...createVocabularyCandidates("community_category", profile.community.categoryTags),
+  ];
+}
+
+export function createProfileSearchDocument(profile: Doc<"profiles">): SearchDocumentInput {
+  const typeLabel = profile.profileType === "person" ? "Person profile" : "Community profile";
+  const typeSpecific =
+    profile.profileType === "person"
+      ? profile.person.roleTags
+      : compact([profile.community.subtype, ...profile.community.categoryTags]);
+  const source = sourceForProfile(profile);
+  const vocabulary = vocabularyForProfile(profile);
+
+  return {
+    entityType: "profile",
+    publicState: publicStateForProfile(profile),
+    profileId: profile._id,
+    profileType: profile.profileType,
+    slug: profile.slug,
+    routePath: profile.profileType === "person" ? `/p/${profile.slug}` : `/c/${profile.slug}`,
+    title: profile.displayName,
+    subtitle: typeLabel,
+    ...optionalField("summary", profile.headline ?? profile.bio),
+    ...optionalField("imageUrl", safeHttpsUrl(profile.avatarImageUrl ?? profile.bannerImageUrl)),
+    searchText: weightedCorpus([
+      { values: [profile.displayName, profile.slug], weight: 8 },
+      { values: profile.aliases, weight: 5 },
+      { values: profile.tags, weight: 4 },
+      { values: typeSpecific, weight: 4 },
+      { values: [profile.headline, profile.bio, profile.region, profile.timezone, typeLabel], weight: 1 },
+    ]),
+    exactTokens: exactTokens([profile.displayName, profile.slug, ...profile.aliases, ...profile.tags, ...typeSpecific]),
+    vocabularyKeys: collectVocabularyKeys(vocabulary),
+    trustRank: trustRankForProfile(profile),
+    featuredRank: trustRankForProfile(profile),
+    sourceType: source.sourceType,
+    sourceLabel: source.sourceLabel,
+    updatedAt: profile.updatedAt,
+  };
+}
+
+export function vocabularyForWorld(world: Doc<"worlds">): VocabularyCandidate[] {
+  return [
+    ...createVocabularyCandidates("world_tag", world.tags),
+    ...createVocabularyCandidates(
+      "world_creator_role",
+      world.creatorAttributions.map((attribution) => attribution.role),
+    ),
+  ];
+}
+
+export function createWorldSearchDocument(world: Doc<"worlds">): SearchDocumentInput {
+  const source = world.sourceAttribution;
+  const creatorNames = world.creatorAttributions.map((attribution) => attribution.displayName);
+  const creatorRoles = world.creatorAttributions.map((attribution) => attribution.role);
+  const vocabulary = vocabularyForWorld(world);
+
+  return {
+    entityType: "world",
+    publicState: world.publicationState === "published" ? "public" : "hidden",
+    worldId: world._id,
+    slug: world.slug,
+    routePath: `/w/${world.slug}`,
+    title: world.displayName,
+    subtitle: "World",
+    ...optionalField("summary", world.summary ?? world.description),
+    ...optionalField("imageUrl", safeHttpsUrl(world.heroImageUrl ?? world.media[0]?.url)),
+    searchText: weightedCorpus([
+      { values: [world.displayName, world.slug, world.vrchatWorldId], weight: 8 },
+      { values: world.tags, weight: 5 },
+      { values: creatorNames, weight: 4 },
+      { values: creatorRoles, weight: 3 },
+      { values: [world.summary, world.description, world.visibilityStatus], weight: 1 },
+    ]),
+    exactTokens: exactTokens([world.displayName, world.slug, world.vrchatWorldId, ...world.tags, ...creatorNames]),
+    vocabularyKeys: collectVocabularyKeys(vocabulary),
+    trustRank: source?.sourceType === "owner" ? 34 : source?.sourceType === "partner" ? 24 : 14,
+    featuredRank: 20,
+    sourceType: source?.sourceType ?? "manual",
+    sourceLabel: source?.label ?? "VRDex world record",
+    updatedAt: world.updatedAt,
+  };
+}
+
+export function vocabularyForEvent(event: Doc<"events">, roleLabels: string[] = []): VocabularyCandidate[] {
+  const inferredTags = [event.communityName, event.timezone, event.startAt >= Date.now() ? "Upcoming" : undefined];
+
+  return [
+    ...createVocabularyCandidates("event_tag", inferredTags),
+    ...createVocabularyCandidates("event_participant_role", roleLabels),
+  ];
+}
+
+export function createEventSearchDocument(
+  event: Doc<"events">,
+  context: { community?: Doc<"profiles">; world?: Doc<"worlds">; roleLabels?: string[] } = {},
+): SearchDocumentInput {
+  const sourceUrl = safeHttpsUrl(event.sourceUrl);
+  const vocabulary = vocabularyForEvent(event, context.roleLabels ?? []);
+  const worldTerms = context.world ? [context.world.displayName, ...context.world.tags] : [];
+  const routePath = event.slug === undefined ? "/discover" : `/e/${event.slug}`;
+  const isUpcoming = event.startAt >= Date.now();
+
+  return {
+    entityType: "event",
+    publicState: event.publicationState === "published" && event.slug !== undefined ? "public" : "hidden",
+    eventId: event._id,
+    slug: event.slug ?? String(event._id),
+    routePath,
+    title: event.title,
+    subtitle: event.communityName ?? context.community?.displayName ?? "Event",
+    ...optionalField("summary", event.summary),
+    ...optionalField("imageUrl", safeHttpsUrl(event.posterImageUrl)),
+    searchText: weightedCorpus([
+      { values: [event.title, event.slug], weight: 8 },
+      { values: [event.communityName, context.community?.displayName], weight: 5 },
+      { values: worldTerms, weight: 4 },
+      { values: context.roleLabels ?? [], weight: 3 },
+      { values: [event.summary, event.notes, event.timezone, sourceUrl], weight: 1 },
+    ]),
+    exactTokens: exactTokens([
+      event.title,
+      event.slug,
+      event.communityName,
+      context.community?.displayName,
+      ...worldTerms,
+      ...(context.roleLabels ?? []),
+    ]),
+    vocabularyKeys: collectVocabularyKeys(vocabulary),
+    trustRank: event.sourceType === "manual" ? 30 : event.sourceType === "community" ? 20 : 16,
+    freshnessAt: event.startAt,
+    featuredRank: isUpcoming ? 42 : 8,
+    sourceType: event.sourceType,
+    sourceLabel: event.sourceLabel,
+    startsAt: event.startAt,
+    updatedAt: event.updatedAt,
+  };
+}
+
+export function toPublicSearchResult(
+  document: Doc<"searchDocuments">,
+  query: string | undefined,
+): PublicSearchResult {
+  const queryToken = createSearchToken(query ?? "");
+  const exactBoost = queryToken && document.exactTokens.includes(queryToken) ? 200 : 0;
+  const vocabularyBoost = queryToken
+    ? document.vocabularyKeys.some((key) => key.endsWith(`:${queryToken.replace(/\s+/g, "_")}`))
+      ? 80
+      : 0
+    : 0;
+  const freshnessBoost = document.startsAt && document.startsAt >= Date.now() ? 30 : 0;
+  const score =
+    exactBoost +
+    vocabularyBoost +
+    freshnessBoost +
+    document.trustRank +
+    document.featuredRank +
+    ENTITY_TYPE_WEIGHT[document.entityType];
+
+  return {
+    entityType: document.entityType,
+    ...optionalField("profileType", document.profileType),
+    slug: document.slug,
+    routePath: document.routePath,
+    title: document.title,
+    ...optionalField("subtitle", document.subtitle),
+    ...optionalField("summary", document.summary),
+    ...optionalField("imageUrl", document.imageUrl),
+    ...optionalField("startsAt", document.startsAt),
+    source:
+      document.sourceType && document.sourceLabel
+        ? { sourceType: document.sourceType, label: document.sourceLabel }
+        : undefined,
+    score,
+  };
+}
+
+export function sortSearchResults(results: PublicSearchResult[]): PublicSearchResult[] {
+  return [...results].sort((first, second) => {
+    if (second.score !== first.score) {
+      return second.score - first.score;
+    }
+
+    return first.title.localeCompare(second.title);
+  });
+}
+
+export async function upsertSearchDocument(db: DatabaseWriter, input: SearchDocumentInput) {
+  const existing = await db
+    .query("searchDocuments")
+    .withIndex("by_entityType_slug", (query) =>
+      query.eq("entityType", input.entityType).eq("slug", input.slug),
+    )
+    .unique();
+
+  if (existing) {
+    await db.patch(existing._id, input);
+    return existing._id;
+  }
+
+  return await db.insert("searchDocuments", input);
+}

--- a/convex/_searchDocuments.ts
+++ b/convex/_searchDocuments.ts
@@ -213,7 +213,7 @@ function searchableWorldAttributions(
       return true;
     }
 
-    return options.hiddenProfileKeys !== undefined && !options.hiddenProfileKeys.has(key);
+    return options.hiddenProfileKeys === undefined || !options.hiddenProfileKeys.has(key);
   });
 }
 

--- a/convex/_searchDocuments.ts
+++ b/convex/_searchDocuments.ts
@@ -3,7 +3,6 @@ import type { DatabaseReader, DatabaseWriter } from "./_generated/server";
 import { optionalField, safeHttpsUrl } from "./_publicFields";
 import { canReadProfile } from "./_profilePermissions";
 import { getProfileBySlug } from "./_profileSlugs";
-import { getProfileTrustLabel } from "./_profileStates";
 import {
   collectVocabularyKeys,
   createVocabularyCandidates,
@@ -21,7 +20,6 @@ export type PublicSearchResult = {
   subtitle?: string;
   summary?: string;
   imageUrl?: string;
-  trustLabel?: "community_submitted" | "unclaimed" | "claimed_unverified" | "claimed_verified";
   source?: {
     sourceType: Doc<"searchDocuments">["sourceType"];
     label: string;
@@ -107,6 +105,14 @@ function trustRankForProfile(profile: Doc<"profiles">): number {
 
 function publicStateForProfile(profile: Doc<"profiles">): Doc<"searchDocuments">["publicState"] {
   return canReadProfile("public", profile) ? "public" : "hidden";
+}
+
+function effectiveFeaturedRank(document: Doc<"searchDocuments">): number {
+  if (document.entityType === "event" && document.startsAt !== undefined && document.startsAt < Date.now()) {
+    return Math.min(document.featuredRank, 8);
+  }
+
+  return document.featuredRank;
 }
 
 function sourceForProfile(profile: Doc<"profiles">): Pick<SearchDocumentInput, "sourceType" | "sourceLabel"> {
@@ -356,7 +362,7 @@ export function toPublicSearchResult(
     vocabularyBoost +
     freshnessBoost +
     document.trustRank +
-    document.featuredRank +
+    effectiveFeaturedRank(document) +
     ENTITY_TYPE_WEIGHT[document.entityType];
 
   return {

--- a/convex/_vocabulary.ts
+++ b/convex/_vocabulary.ts
@@ -1,0 +1,123 @@
+import type { Doc } from "./_generated/dataModel";
+import type { DatabaseWriter } from "./_generated/server";
+
+export type VocabularyScope = Doc<"vocabularyTerms">["scope"];
+
+export type VocabularyCandidate = {
+  scope: VocabularyScope;
+  label: string | undefined;
+  source?: Doc<"vocabularyTerms">["source"];
+  rank?: number;
+};
+
+export const SEEDED_VOCABULARY_TERMS: Array<{
+  scope: VocabularyScope;
+  label: string;
+  aliases?: string[];
+  rank: number;
+}> = [
+  { scope: "person_role", label: "DJ", aliases: ["DJs", "Deejay"], rank: 100 },
+  { scope: "person_role", label: "VJ", aliases: ["Visuals", "Video jockey"], rank: 92 },
+  { scope: "person_role", label: "Host", aliases: ["MC"], rank: 86 },
+  { scope: "person_role", label: "Photographer", rank: 72 },
+  { scope: "community_subtype", label: "Club", aliases: ["Club night", "Venue"], rank: 100 },
+  { scope: "community_subtype", label: "Collective", aliases: ["Crew"], rank: 84 },
+  { scope: "community_subtype", label: "Festival", rank: 82 },
+  { scope: "community_category", label: "Music", rank: 100 },
+  { scope: "community_category", label: "Dance", aliases: ["Dancing"], rank: 90 },
+  { scope: "community_category", label: "Social", rank: 80 },
+  { scope: "profile_tag", label: "House", aliases: ["House music"], rank: 100 },
+  { scope: "profile_tag", label: "Trance", rank: 94 },
+  { scope: "profile_tag", label: "Techno", rank: 92 },
+  { scope: "event_participant_role", label: "Headliner", rank: 100 },
+  { scope: "event_participant_role", label: "Performer", aliases: ["Artist"], rank: 92 },
+  { scope: "event_participant_role", label: "Opener", rank: 80 },
+  { scope: "event_tag", label: "Tonight", rank: 100 },
+  { scope: "event_tag", label: "Festival", rank: 96 },
+  { scope: "world_tag", label: "Club world", aliases: ["Club", "Venue"], rank: 100 },
+  { scope: "world_tag", label: "Cyberpunk", rank: 80 },
+  { scope: "world_tag", label: "Dance floor", rank: 78 },
+  { scope: "discovery_facet", label: "Featured", aliases: ["Curated"], rank: 100 },
+  { scope: "discovery_facet", label: "Upcoming", aliases: ["Soon", "Tonight"], rank: 96 },
+];
+
+export function normalizeVocabularyLabel(input: string): string {
+  return input.trim().replace(/\s+/g, " ");
+}
+
+export function createVocabularyKey(input: string): string {
+  const normalized = normalizeVocabularyLabel(input)
+    .normalize("NFKD")
+    .replace(/[\u0300-\u036f]/g, "")
+    .toLowerCase()
+    .replace(/&/g, " and ")
+    .replace(/[^a-z0-9]+/g, " ")
+    .trim();
+
+  return normalized.replace(/\s+/g, "_");
+}
+
+export function createVocabularyCandidates(
+  scope: VocabularyScope,
+  labels: Array<string | undefined>,
+): VocabularyCandidate[] {
+  return labels.map((label) => ({ scope, label }));
+}
+
+export function collectVocabularyKeys(candidates: VocabularyCandidate[]): string[] {
+  const keys = new Set<string>();
+
+  for (const candidate of candidates) {
+    if (candidate.label === undefined) {
+      continue;
+    }
+
+    const key = createVocabularyKey(candidate.label);
+    if (key) {
+      keys.add(`${candidate.scope}:${key}`);
+    }
+  }
+
+  return [...keys].sort();
+}
+
+export async function recordVocabularyTerms(
+  db: DatabaseWriter,
+  candidates: VocabularyCandidate[],
+  now: number,
+) {
+  for (const candidate of candidates) {
+    const label = normalizeVocabularyLabel(candidate.label ?? "");
+    const key = createVocabularyKey(label);
+
+    if (!key) {
+      continue;
+    }
+
+    const existing = await db
+      .query("vocabularyTerms")
+      .withIndex("by_scope_key", (query) => query.eq("scope", candidate.scope).eq("key", key))
+      .unique();
+
+    if (existing) {
+      await db.patch(existing._id, {
+        label: existing.source === "seeded" ? existing.label : label,
+        usageCount: existing.usageCount + 1,
+        updatedAt: now,
+      });
+      continue;
+    }
+
+    await db.insert("vocabularyTerms", {
+      scope: candidate.scope,
+      key,
+      label,
+      aliases: [],
+      source: candidate.source ?? "user_created",
+      usageCount: 1,
+      rank: candidate.rank ?? 10,
+      createdAt: now,
+      updatedAt: now,
+    });
+  }
+}

--- a/convex/_worldPublic.ts
+++ b/convex/_worldPublic.ts
@@ -1,7 +1,10 @@
 import type { Doc } from "./_generated/dataModel";
 import { optionalField, safeHttpsUrl } from "./_publicFields";
 
-export function toPublicWorld(world: Doc<"worlds">) {
+export function toPublicWorld(
+  world: Doc<"worlds">,
+  options: { hiddenProfileKeys?: Set<string> } = {},
+) {
   const sourceUrl = safeHttpsUrl(world.sourceUrl);
   const heroImageUrl = safeHttpsUrl(world.heroImageUrl);
   const canonicalVrchatWorldUrl = safeHttpsUrl(world.canonicalVrchatWorldUrl);
@@ -30,13 +33,21 @@ export function toPublicWorld(world: Doc<"worlds">) {
 
       return [{ ...media, url: mediaUrl }];
     }),
-    creatorAttributions: world.creatorAttributions.map((attribution) => ({
-      role: attribution.role,
-      displayName: attribution.displayName,
-      ...optionalField("profileSlug", attribution.profileSlug),
-      ...optionalField("profileType", attribution.profileType),
-      ...optionalField("sourceLabel", attribution.sourceLabel),
-    })),
+    creatorAttributions: world.creatorAttributions
+      .filter((attribution) => {
+        if (!attribution.profileSlug || !attribution.profileType) {
+          return true;
+        }
+
+        return !options.hiddenProfileKeys?.has(`${attribution.profileType}:${attribution.profileSlug}`);
+      })
+      .map((attribution) => ({
+        role: attribution.role,
+        displayName: attribution.displayName,
+        ...optionalField("profileSlug", attribution.profileSlug),
+        ...optionalField("profileType", attribution.profileType),
+        ...optionalField("sourceLabel", attribution.sourceLabel),
+      })),
     outboundLinks: world.outboundLinks.flatMap((link) => {
       const linkUrl = safeHttpsUrl(link.url);
 

--- a/convex/events.ts
+++ b/convex/events.ts
@@ -11,7 +11,10 @@ import {
 import { sanitizeEventDraftInput } from "./_eventInputs";
 import { getPublicCommunityHostedEvents, getPublicEventBySlug } from "./_eventPublic";
 import { findAvailableEventSlug, getEventBySlug, validateEventSlug } from "./_eventSlugs";
+import { canReadProfile } from "./_profilePermissions";
 import { getProfileBySlug, validateProfileSlug } from "./_profileSlugs";
+import { createEventSearchDocument, upsertSearchDocument, vocabularyForEvent } from "./_searchDocuments";
+import { recordVocabularyTerms } from "./_vocabulary";
 import { getWorldBySlug, validateWorldSlug } from "./_worldSlugs";
 
 const eventMediaLinkType = v.union(
@@ -98,7 +101,7 @@ async function getPublishedCommunityBySlug(
     throw new Error("Community profile was not found.");
   }
 
-  if (profile.publicationState !== "published") {
+  if (!canReadProfile("public", profile)) {
     throw new Error("Community profile must be published before events can be linked.");
   }
 
@@ -139,7 +142,7 @@ async function getPublishedPersonBySlug(db: DatabaseReader, slug: string) {
     throw new Error(`Person profile "${slug}" was not found.`);
   }
 
-  if (profile.publicationState !== "published") {
+  if (!canReadProfile("public", profile)) {
     throw new Error(`Person profile "${slug}" must be published before event association.`);
   }
 
@@ -262,7 +265,7 @@ export const listHostedByCommunitySlug = query({
     if (
       community === null ||
       community.profileType !== "community" ||
-      community.publicationState !== "published"
+      !canReadProfile("public", community)
     ) {
       return [];
     }
@@ -309,6 +312,18 @@ export const createCommunityEvent = mutation({
 
     await replaceEventWorldLink(ctx.db, eventId, input.startAt, world, now);
     await replaceEventParticipants(ctx.db, eventId, input.startAt, input.participantLinks, now);
+
+    const event = await ctx.db.get(eventId);
+    if (event !== null) {
+      const roleLabels = input.participantLinks.map((participant) => participant.roleLabel);
+      await Promise.all([
+        upsertSearchDocument(
+          ctx.db,
+          createEventSearchDocument(event, { community, world, roleLabels }),
+        ),
+        recordVocabularyTerms(ctx.db, vocabularyForEvent(event, roleLabels), now),
+      ]);
+    }
 
     return {
       eventId,
@@ -382,6 +397,18 @@ export const updateCommunityEvent = mutation({
 
     await replaceEventWorldLink(ctx.db, event._id, input.startAt, world, now);
     await replaceEventParticipants(ctx.db, event._id, input.startAt, input.participantLinks, now);
+
+    const updatedEvent = await ctx.db.get(event._id);
+    if (updatedEvent !== null) {
+      const roleLabels = input.participantLinks.map((participant) => participant.roleLabel);
+      await Promise.all([
+        upsertSearchDocument(
+          ctx.db,
+          createEventSearchDocument(updatedEvent, { community, world, roleLabels }),
+        ),
+        recordVocabularyTerms(ctx.db, vocabularyForEvent(updatedEvent, roleLabels), now),
+      ]);
+    }
 
     return {
       eventId: event._id,

--- a/convex/migrations.ts
+++ b/convex/migrations.ts
@@ -1,0 +1,35 @@
+import type { Doc } from "./_generated/dataModel";
+import { internalMutation } from "./_generated/server";
+
+type LegacyProfile = Doc<"profiles"> & {
+  publicSurfacingState?: Doc<"profiles">["publicSurfacingState"];
+  publicSurfacingUpdatedAt?: number;
+};
+
+export const backfillProfilePublicSurfacingState = internalMutation({
+  args: {},
+  handler: async (ctx) => {
+    const now = Date.now();
+    const profiles = await ctx.db.query("profiles").collect();
+    let updated = 0;
+
+    for (const profile of profiles) {
+      const legacyProfile = profile as LegacyProfile;
+
+      if (
+        legacyProfile.publicSurfacingState !== undefined &&
+        legacyProfile.publicSurfacingUpdatedAt !== undefined
+      ) {
+        continue;
+      }
+
+      await ctx.db.patch(profile._id, {
+        publicSurfacingState: legacyProfile.publicSurfacingState ?? "public",
+        publicSurfacingUpdatedAt: legacyProfile.publicSurfacingUpdatedAt ?? now,
+      });
+      updated += 1;
+    }
+
+    return { scanned: profiles.length, updated };
+  },
+});

--- a/convex/profiles.ts
+++ b/convex/profiles.ts
@@ -7,6 +7,8 @@ import { toPublicProfile } from "./_profilePublic";
 import { findAvailableProfileSlug, getProfileBySlug, validateProfileSlug } from "./_profileSlugs";
 import { sanitizeCommunitySubmissionProfileInput } from "./_profileSubmissions";
 import { getPublicProfileWorldCredits } from "./_profileWorldCredits";
+import { createProfileSearchDocument, upsertSearchDocument, vocabularyForProfile } from "./_searchDocuments";
+import { recordVocabularyTerms } from "./_vocabulary";
 
 const profileType = v.union(v.literal("person"), v.literal("community"));
 
@@ -118,6 +120,8 @@ export const submitCommunityProfile = mutation({
       outboundLinks: [],
       claimState: "unclaimed" as const,
       publicationState: "published" as const,
+      publicSurfacingState: "public" as const,
+      publicSurfacingUpdatedAt: now,
       creationSource: "community" as const,
       publishedAt: now,
       updatedAt: now,
@@ -133,6 +137,22 @@ export const submitCommunityProfile = mutation({
         },
       });
 
+      const profile = await ctx.db.get(profileId);
+      if (profile !== null) {
+        await Promise.all([
+          upsertSearchDocument(ctx.db, createProfileSearchDocument(profile)),
+          recordVocabularyTerms(ctx.db, vocabularyForProfile(profile), now),
+          ctx.db.insert("profileAuditEvents", {
+            profileId,
+            action: "community_profile_submitted",
+            actor: sourceAttribution.submitter,
+            sourceType: "community",
+            note: "Community-submitted person profile created.",
+            createdAt: now,
+          }),
+        ]);
+      }
+
       return {
         profileId,
         profileType: "person" as const,
@@ -146,6 +166,22 @@ export const submitCommunityProfile = mutation({
       profileType: "community",
       community: input.community,
     });
+
+    const profile = await ctx.db.get(profileId);
+    if (profile !== null) {
+      await Promise.all([
+        upsertSearchDocument(ctx.db, createProfileSearchDocument(profile)),
+        recordVocabularyTerms(ctx.db, vocabularyForProfile(profile), now),
+        ctx.db.insert("profileAuditEvents", {
+          profileId,
+          action: "community_profile_submitted",
+          actor: sourceAttribution.submitter,
+          sourceType: "community",
+          note: "Community-submitted community profile created.",
+          createdAt: now,
+        }),
+      ]);
+    }
 
     return {
       profileId,

--- a/convex/schema.ts
+++ b/convex/schema.ts
@@ -12,6 +12,12 @@ const publicationState = v.union(
   v.literal("published"),
 );
 
+const publicSurfacingState = v.union(
+  v.literal("public"),
+  v.literal("opted_out"),
+  v.literal("suppressed"),
+);
+
 const creationSource = v.union(
   v.literal("self"),
   v.literal("community"),
@@ -89,6 +95,16 @@ const eventSourceType = v.union(
   v.literal("ai_suggested"),
 );
 
+const discoverySourceType = v.union(
+  v.literal("owner"),
+  v.literal("community"),
+  v.literal("partner"),
+  v.literal("moderator"),
+  v.literal("import"),
+  v.literal("manual"),
+  v.literal("ai_suggested"),
+);
+
 const eventMediaLinkType = v.union(
   v.literal("event_page"),
   v.literal("watch"),
@@ -123,6 +139,54 @@ const communityCapability = v.union(
 
 const communityAuthorityState = v.union(v.literal("active"), v.literal("revoked"));
 
+const suppressionRequestType = v.union(
+  v.literal("owner_opt_out"),
+  v.literal("pre_claim_safety"),
+);
+
+const suppressionRequestState = v.union(
+  v.literal("submitted"),
+  v.literal("under_review"),
+  v.literal("accepted"),
+  v.literal("rejected"),
+);
+
+const vocabularyScope = v.union(
+  v.literal("profile_tag"),
+  v.literal("person_role"),
+  v.literal("community_category"),
+  v.literal("community_subtype"),
+  v.literal("event_participant_role"),
+  v.literal("event_tag"),
+  v.literal("world_tag"),
+  v.literal("world_creator_role"),
+  v.literal("discovery_facet"),
+);
+
+const vocabularySource = v.union(
+  v.literal("seeded"),
+  v.literal("user_created"),
+  v.literal("reviewed"),
+  v.literal("imported"),
+);
+
+const searchEntityType = v.union(
+  v.literal("profile"),
+  v.literal("world"),
+  v.literal("event"),
+);
+
+const searchPublicState = v.union(v.literal("public"), v.literal("hidden"));
+
+const featuredPlacementSlot = v.union(
+  v.literal("home_hero"),
+  v.literal("home_event_wall"),
+  v.literal("discover_hero"),
+  v.literal("discover_rail"),
+);
+
+const featuredPlacementState = v.union(v.literal("active"), v.literal("inactive"));
+
 const authSubject = v.object({
   tokenIdentifier: v.string(),
   issuer: v.string(),
@@ -155,6 +219,9 @@ const sharedProfileFields = {
   timezone: v.optional(v.string()),
   claimState,
   publicationState,
+  publicSurfacingState,
+  publicSurfacingUpdatedAt: v.optional(v.number()),
+  publicSurfacingReason: v.optional(v.string()),
   creationSource,
   sourceAttribution: v.optional(
     v.object({
@@ -198,6 +265,10 @@ export default defineSchema({
     .index("by_slug", ["slug"])
     .index("by_profileType_publicationState", ["profileType", "publicationState"])
     .index("by_publicationState_claimState", ["publicationState", "claimState"])
+    .index("by_publicSurfacingState_publicationState", [
+      "publicSurfacingState",
+      "publicationState",
+    ])
     .index("by_claimState_profileType", ["claimState", "profileType"])
     .index("by_creationSource_claimState", ["creationSource", "claimState"])
     .index("by_profileType_sortName", ["profileType", "sortName"]),
@@ -358,4 +429,120 @@ export default defineSchema({
       "state",
       "communityProfileId",
     ]),
+  profileSuppressionRequests: defineTable({
+    profileId: v.optional(v.id("profiles")),
+    profileSlug: v.optional(v.string()),
+    profileType: v.optional(profileType),
+    displayName: v.optional(v.string()),
+    requestType: suppressionRequestType,
+    state: suppressionRequestState,
+    requester: v.optional(authSubject),
+    requesterContact: v.optional(v.string()),
+    requesterNote: v.optional(v.string()),
+    resolutionNote: v.optional(v.string()),
+    createdAt: v.number(),
+    updatedAt: v.number(),
+  })
+    .index("by_state_createdAt", ["state", "createdAt"])
+    .index("by_profileId_state", ["profileId", "state"])
+    .index("by_profileSlug_state", ["profileSlug", "state"]),
+  profileAuditEvents: defineTable({
+    profileId: v.id("profiles"),
+    action: v.string(),
+    actor: v.optional(authSubject),
+    sourceType,
+    note: v.optional(v.string()),
+    createdAt: v.number(),
+  })
+    .index("by_profileId_createdAt", ["profileId", "createdAt"])
+    .index("by_action_createdAt", ["action", "createdAt"]),
+  vocabularyTerms: defineTable({
+    scope: vocabularyScope,
+    key: v.string(),
+    label: v.string(),
+    aliases: v.array(v.string()),
+    source: vocabularySource,
+    usageCount: v.number(),
+    rank: v.number(),
+    createdAt: v.number(),
+    updatedAt: v.number(),
+  })
+    .index("by_scope_key", ["scope", "key"])
+    .index("by_scope_rank", ["scope", "rank"])
+    .searchIndex("search_label", {
+      searchField: "label",
+      filterFields: ["scope"],
+    }),
+  searchDocuments: defineTable({
+    entityType: searchEntityType,
+    publicState: searchPublicState,
+    profileId: v.optional(v.id("profiles")),
+    worldId: v.optional(v.id("worlds")),
+    eventId: v.optional(v.id("events")),
+    profileType: v.optional(profileType),
+    slug: v.string(),
+    routePath: v.string(),
+    title: v.string(),
+    subtitle: v.optional(v.string()),
+    summary: v.optional(v.string()),
+    imageUrl: v.optional(v.string()),
+    searchText: v.string(),
+    exactTokens: v.array(v.string()),
+    vocabularyKeys: v.array(v.string()),
+    trustRank: v.number(),
+    freshnessAt: v.optional(v.number()),
+    featuredRank: v.number(),
+    sourceType: v.optional(discoverySourceType),
+    sourceLabel: v.optional(v.string()),
+    startsAt: v.optional(v.number()),
+    updatedAt: v.number(),
+  })
+    .index("by_entityType_slug", ["entityType", "slug"])
+    .index("by_profileId", ["profileId"])
+    .index("by_worldId", ["worldId"])
+    .index("by_eventId", ["eventId"])
+    .index("by_publicState_entityType_featuredRank", [
+      "publicState",
+      "entityType",
+      "featuredRank",
+    ])
+    .index("by_publicState_startsAt", ["publicState", "startsAt"])
+    .searchIndex("search_text", {
+      searchField: "searchText",
+      filterFields: ["publicState", "entityType"],
+    }),
+  searchEmbeddings: defineTable({
+    searchDocumentId: v.id("searchDocuments"),
+    entityType: searchEntityType,
+    publicState: searchPublicState,
+    embedding: v.array(v.float64()),
+    model: v.string(),
+    dimensions: v.number(),
+    updatedAt: v.number(),
+  })
+    .index("by_searchDocumentId", ["searchDocumentId"])
+    .vectorIndex("by_embedding", {
+      vectorField: "embedding",
+      dimensions: 1536,
+      filterFields: ["publicState", "entityType"],
+    }),
+  featuredPlacements: defineTable({
+    slot: featuredPlacementSlot,
+    state: featuredPlacementState,
+    targetEntityType: searchEntityType,
+    targetProfileId: v.optional(v.id("profiles")),
+    targetWorldId: v.optional(v.id("worlds")),
+    targetEventId: v.optional(v.id("events")),
+    label: v.string(),
+    reason: v.string(),
+    weight: v.number(),
+    startsAt: v.optional(v.number()),
+    endsAt: v.optional(v.number()),
+    sourceType: discoverySourceType,
+    sourceLabel: v.string(),
+    createdAt: v.number(),
+    updatedAt: v.number(),
+  })
+    .index("by_slot_state_weight", ["slot", "state", "weight"])
+    .index("by_state_startsAt", ["state", "startsAt"]),
 });

--- a/convex/search.ts
+++ b/convex/search.ts
@@ -1,0 +1,124 @@
+import { v } from "convex/values";
+
+import { mutation, query, type QueryCtx } from "./_generated/server";
+import {
+  normalizeSearchQuery,
+  sortSearchResults,
+  toPublicSearchResult,
+  type SearchEntityType,
+} from "./_searchDocuments";
+import { SEEDED_VOCABULARY_TERMS, recordVocabularyTerms } from "./_vocabulary";
+
+const SEARCH_RESULT_LIMIT = 24;
+const DISCOVERY_SECTION_LIMIT = 8;
+
+const searchEntityType = v.union(
+  v.literal("profile"),
+  v.literal("world"),
+  v.literal("event"),
+);
+
+function boundedLimit(value: number | undefined, fallback: number, max: number): number {
+  return Math.max(1, Math.min(value ?? fallback, max));
+}
+
+export const searchUniversal = query({
+  args: {
+    query: v.string(),
+    entityType: v.optional(searchEntityType),
+    limit: v.optional(v.number()),
+  },
+  handler: async (ctx, args) => {
+    const searchText = normalizeSearchQuery(args.query);
+    const limit = boundedLimit(args.limit, SEARCH_RESULT_LIMIT, 50);
+
+    if (!searchText) {
+      return [];
+    }
+
+    const documents = await ctx.db
+      .query("searchDocuments")
+      .withSearchIndex("search_text", (search) => {
+        const filtered = search.search("searchText", searchText).eq("publicState", "public");
+
+        return args.entityType === undefined ? filtered : filtered.eq("entityType", args.entityType);
+      })
+      .take(limit * 2);
+
+    return sortSearchResults(documents.map((document) => toPublicSearchResult(document, searchText))).slice(
+      0,
+      limit,
+    );
+  },
+});
+
+async function listDocumentsByType(ctx: QueryCtx, entityType: SearchEntityType) {
+  return await ctx.db
+    .query("searchDocuments")
+    .withIndex("by_publicState_entityType_featuredRank", (index) =>
+      index.eq("publicState", "public").eq("entityType", entityType),
+    )
+    .take(40);
+}
+
+export const listDiscovery = query({
+  args: {
+    now: v.optional(v.number()),
+  },
+  handler: async (ctx, args) => {
+    const now = args.now ?? Date.now();
+    const [profiles, worlds, events, vocabulary] = await Promise.all([
+      listDocumentsByType(ctx, "profile"),
+      listDocumentsByType(ctx, "world"),
+      listDocumentsByType(ctx, "event"),
+      ctx.db.query("vocabularyTerms").take(60),
+    ]);
+    const profileResults = sortSearchResults(
+      profiles.map((document) => toPublicSearchResult(document, undefined)),
+    );
+    const worldResults = sortSearchResults(worlds.map((document) => toPublicSearchResult(document, undefined)));
+    const eventResults = sortSearchResults(events.map((document) => toPublicSearchResult(document, undefined)));
+    const upcomingEvents = eventResults
+      .filter((event) => event.startsAt !== undefined && event.startsAt >= now)
+      .slice(0, DISCOVERY_SECTION_LIMIT);
+
+    return {
+      featured: sortSearchResults([...eventResults, ...profileResults, ...worldResults]).slice(0, 5),
+      upcomingEvents,
+      people: profileResults.filter((result) => result.profileType === "person").slice(0, DISCOVERY_SECTION_LIMIT),
+      communities: profileResults
+        .filter((result) => result.profileType === "community")
+        .slice(0, DISCOVERY_SECTION_LIMIT),
+      worlds: worldResults.slice(0, DISCOVERY_SECTION_LIMIT),
+      terms: vocabulary
+        .sort((first, second) => second.rank - first.rank || first.label.localeCompare(second.label))
+        .slice(0, 18)
+        .map((term) => ({
+          scope: term.scope,
+          key: term.key,
+          label: term.label,
+          usageCount: term.usageCount,
+        })),
+    };
+  },
+});
+
+export const seedVocabulary = mutation({
+  args: {},
+  handler: async (ctx) => {
+    const now = Date.now();
+
+    await recordVocabularyTerms(
+      ctx.db,
+      SEEDED_VOCABULARY_TERMS.map((term) => ({
+        scope: term.scope,
+        label: term.label,
+        source: "seeded",
+        rank: term.rank,
+      })),
+      now,
+    );
+
+    return { seeded: SEEDED_VOCABULARY_TERMS.length };
+  },
+});

--- a/convex/search.ts
+++ b/convex/search.ts
@@ -1,11 +1,15 @@
 import { v } from "convex/values";
 
-import { mutation, query, type QueryCtx } from "./_generated/server";
+import { internalMutation, query, type QueryCtx } from "./_generated/server";
 import {
+  createWorldSearchDocument,
+  getHiddenWorldAttributionProfileKeys,
   normalizeSearchQuery,
   sortSearchResults,
   toPublicSearchResult,
   type SearchEntityType,
+  upsertSearchDocument,
+  vocabularyForWorld,
 } from "./_searchDocuments";
 import { SEEDED_VOCABULARY_TERMS, recordVocabularyTerms } from "./_vocabulary";
 
@@ -58,6 +62,7 @@ async function listDocumentsByType(ctx: QueryCtx, entityType: SearchEntityType) 
     .withIndex("by_publicState_entityType_featuredRank", (index) =>
       index.eq("publicState", "public").eq("entityType", entityType),
     )
+    .order("desc")
     .take(40);
 }
 
@@ -103,7 +108,7 @@ export const listDiscovery = query({
   },
 });
 
-export const seedVocabulary = mutation({
+export const seedVocabulary = internalMutation({
   args: {},
   handler: async (ctx) => {
     const now = Date.now();
@@ -120,5 +125,23 @@ export const seedVocabulary = mutation({
     );
 
     return { seeded: SEEDED_VOCABULARY_TERMS.length };
+  },
+});
+
+export const rebuildWorldSearchDocuments = internalMutation({
+  args: {},
+  handler: async (ctx) => {
+    const now = Date.now();
+    const worlds = await ctx.db.query("worlds").collect();
+
+    for (const world of worlds) {
+      const hiddenProfileKeys = await getHiddenWorldAttributionProfileKeys(ctx.db, world);
+      await Promise.all([
+        upsertSearchDocument(ctx.db, createWorldSearchDocument(world, { hiddenProfileKeys })),
+        recordVocabularyTerms(ctx.db, vocabularyForWorld(world, { hiddenProfileKeys }), now),
+      ]);
+    }
+
+    return { indexed: worlds.length };
   },
 });

--- a/convex/search.ts
+++ b/convex/search.ts
@@ -66,23 +66,39 @@ async function listDocumentsByType(ctx: QueryCtx, entityType: SearchEntityType) 
     .take(40);
 }
 
+async function listUpcomingEventDocuments(ctx: QueryCtx, now: number) {
+  return await ctx.db
+    .query("searchDocuments")
+    .withIndex("by_publicState_startsAt", (index) => index.eq("publicState", "public").gte("startsAt", now))
+    .filter((query) => query.eq(query.field("entityType"), "event"))
+    .order("asc")
+    .take(40);
+}
+
 export const listDiscovery = query({
   args: {
     now: v.optional(v.number()),
   },
   handler: async (ctx, args) => {
     const now = args.now ?? Date.now();
-    const [profiles, worlds, events, vocabulary] = await Promise.all([
+    const [profiles, worlds, events, upcomingEventDocuments, vocabulary] = await Promise.all([
       listDocumentsByType(ctx, "profile"),
       listDocumentsByType(ctx, "world"),
       listDocumentsByType(ctx, "event"),
+      listUpcomingEventDocuments(ctx, now),
       ctx.db.query("vocabularyTerms").take(60),
     ]);
     const profileResults = sortSearchResults(
       profiles.map((document) => toPublicSearchResult(document, undefined)),
     );
     const worldResults = sortSearchResults(worlds.map((document) => toPublicSearchResult(document, undefined)));
-    const eventResults = sortSearchResults(events.map((document) => toPublicSearchResult(document, undefined)));
+    const eventDocuments = new Map(events.map((document) => [document._id, document]));
+    for (const document of upcomingEventDocuments) {
+      eventDocuments.set(document._id, document);
+    }
+    const eventResults = sortSearchResults(
+      [...eventDocuments.values()].map((document) => toPublicSearchResult(document, undefined)),
+    );
     const upcomingEvents = eventResults
       .filter((event) => event.startsAt !== undefined && event.startsAt >= now)
       .slice(0, DISCOVERY_SECTION_LIMIT);

--- a/convex/suppressions.ts
+++ b/convex/suppressions.ts
@@ -1,0 +1,91 @@
+import { v } from "convex/values";
+
+import { mutation } from "./_generated/server";
+import { toAuthSubject } from "./_communityAuthority";
+import { getProfileBySlug, validateProfileSlug } from "./_profileSlugs";
+import { normalizeProfileInlineText } from "./_profileSubmissions";
+
+const profileType = v.union(v.literal("person"), v.literal("community"));
+const suppressionRequestType = v.union(
+  v.literal("owner_opt_out"),
+  v.literal("pre_claim_safety"),
+);
+
+function optionalValue<T>(key: string, value: T | undefined): Record<string, T> {
+  return value === undefined ? {} : { [key]: value };
+}
+
+function optionalText(value: string | undefined, maxLength: number): string | undefined {
+  const normalized = normalizeProfileInlineText(value ?? "");
+
+  if (!normalized) {
+    return undefined;
+  }
+
+  return normalized.slice(0, maxLength);
+}
+
+export const requestProfileSuppression = mutation({
+  args: {
+    requestType: suppressionRequestType,
+    profileSlug: v.optional(v.string()),
+    profileType: v.optional(profileType),
+    displayName: v.optional(v.string()),
+    requesterContact: v.optional(v.string()),
+    requesterNote: v.optional(v.string()),
+  },
+  handler: async (ctx, args) => {
+    const now = Date.now();
+    const identity = await ctx.auth.getUserIdentity();
+    const requester = identity
+      ? toAuthSubject({
+          tokenIdentifier: identity.tokenIdentifier,
+          issuer: identity.issuer,
+          subject: identity.subject,
+          name: identity.name,
+        })
+      : undefined;
+    const slugValidation = args.profileSlug ? validateProfileSlug(args.profileSlug) : undefined;
+
+    if (slugValidation && !slugValidation.ok) {
+      throw new Error("Profile slug is invalid.");
+    }
+
+    const profile = slugValidation ? await getProfileBySlug(ctx.db, slugValidation.slug) : null;
+    const displayName = optionalText(args.displayName ?? profile?.displayName, 120);
+
+    if (profile === null && displayName === undefined) {
+      throw new Error("Suppression requests need a profile slug or display name.");
+    }
+
+    const requestId = await ctx.db.insert("profileSuppressionRequests", {
+      ...optionalValue("profileId", profile?._id),
+      ...optionalValue("profileSlug", profile?.slug ?? slugValidation?.slug),
+      ...optionalValue("profileType", profile?.profileType ?? args.profileType),
+      ...optionalValue("displayName", displayName),
+      requestType: args.requestType,
+      state: "submitted",
+      ...optionalValue("requester", requester),
+      ...optionalValue("requesterContact", optionalText(args.requesterContact, 160)),
+      ...optionalValue("requesterNote", optionalText(args.requesterNote, 1_000)),
+      createdAt: now,
+      updatedAt: now,
+    });
+
+    if (profile) {
+      await ctx.db.insert("profileAuditEvents", {
+        profileId: profile._id,
+        action: "suppression_requested",
+        ...optionalValue("actor", requester),
+        sourceType: "community",
+        note:
+          args.requestType === "owner_opt_out"
+            ? "Owner opt-out request submitted."
+            : "Pre-claim safety suppression request submitted.",
+        createdAt: now,
+      });
+    }
+
+    return { requestId };
+  },
+});

--- a/convex/worlds.ts
+++ b/convex/worlds.ts
@@ -1,9 +1,34 @@
 import { v } from "convex/values";
 
-import { query } from "./_generated/server";
+import { query, type QueryCtx } from "./_generated/server";
+import { canReadProfile } from "./_profilePermissions";
+import { getProfileBySlug } from "./_profileSlugs";
 import { getPublicActiveWorlds, getPublicWorldEventContext } from "./_worldEvents";
 import { toPublicWorld } from "./_worldPublic";
 import { getWorldBySlug, validateWorldSlug } from "./_worldSlugs";
+
+async function getHiddenProfileKeys(ctx: QueryCtx, world: Awaited<ReturnType<typeof getWorldBySlug>>) {
+  const keys = new Set<string>();
+
+  if (world === null) {
+    return keys;
+  }
+
+  await Promise.all(
+    world.creatorAttributions.map(async (attribution) => {
+      if (!attribution.profileSlug || !attribution.profileType) {
+        return;
+      }
+
+      const profile = await getProfileBySlug(ctx.db, attribution.profileSlug);
+      if (profile === null || !canReadProfile("public", profile)) {
+        keys.add(`${attribution.profileType}:${attribution.profileSlug}`);
+      }
+    }),
+  );
+
+  return keys;
+}
 
 export const getPublicBySlug = query({
   args: {
@@ -23,8 +48,10 @@ export const getPublicBySlug = query({
       return null;
     }
 
+    const hiddenProfileKeys = await getHiddenProfileKeys(ctx, world);
+
     return {
-      ...toPublicWorld(world),
+      ...toPublicWorld(world, { hiddenProfileKeys }),
       eventContext: await getPublicWorldEventContext(ctx.db, world._id, args.now),
     };
   },

--- a/convex/worlds.ts
+++ b/convex/worlds.ts
@@ -1,34 +1,10 @@
 import { v } from "convex/values";
 
-import { query, type QueryCtx } from "./_generated/server";
-import { canReadProfile } from "./_profilePermissions";
-import { getProfileBySlug } from "./_profileSlugs";
+import { query } from "./_generated/server";
+import { getHiddenWorldAttributionProfileKeys } from "./_searchDocuments";
 import { getPublicActiveWorlds, getPublicWorldEventContext } from "./_worldEvents";
 import { toPublicWorld } from "./_worldPublic";
 import { getWorldBySlug, validateWorldSlug } from "./_worldSlugs";
-
-async function getHiddenProfileKeys(ctx: QueryCtx, world: Awaited<ReturnType<typeof getWorldBySlug>>) {
-  const keys = new Set<string>();
-
-  if (world === null) {
-    return keys;
-  }
-
-  await Promise.all(
-    world.creatorAttributions.map(async (attribution) => {
-      if (!attribution.profileSlug || !attribution.profileType) {
-        return;
-      }
-
-      const profile = await getProfileBySlug(ctx.db, attribution.profileSlug);
-      if (profile === null || !canReadProfile("public", profile)) {
-        keys.add(`${attribution.profileType}:${attribution.profileSlug}`);
-      }
-    }),
-  );
-
-  return keys;
-}
 
 export const getPublicBySlug = query({
   args: {
@@ -48,7 +24,7 @@ export const getPublicBySlug = query({
       return null;
     }
 
-    const hiddenProfileKeys = await getHiddenProfileKeys(ctx, world);
+    const hiddenProfileKeys = await getHiddenWorldAttributionProfileKeys(ctx.db, world);
 
     return {
       ...toPublicWorld(world, { hiddenProfileKeys }),

--- a/docs/agentic/product-analytics-and-feature-flags.md
+++ b/docs/agentic/product-analytics-and-feature-flags.md
@@ -123,6 +123,20 @@ Examples:
 - add a reusable implementation helper layer so contributors do not hand-roll flag or event calls inconsistently
 - define environment defaults such as local-dev behavior, preview behavior, and production-safe fallbacks once the app exists
 
+## First Discovery Event Taxonomy
+
+Current discovery instrumentation uses PostHog when `NEXT_PUBLIC_POSTHOG_KEY` is configured and otherwise no-ops safely.
+
+Initial events:
+
+- `search_submitted`
+- `search_result_clicked`
+- `discovery_filter_selected`
+- `event_card_clicked`
+- `featured_card_clicked`
+
+Discovery events should avoid private profile fields, raw authentication identifiers, and unsupported popularity claims. Search terms are intentionally captured as product-learning data when PostHog is enabled; revisit retention and privacy copy before broad public launch.
+
 ## Interview later
 
 - whether public marketing pages eventually justify a separate `Google Analytics` installation

--- a/docs/backend/community-submissions.md
+++ b/docs/backend/community-submissions.md
@@ -12,6 +12,7 @@ This doc captures the first community-submitted profile flow for `#23`, plus the
 - profile slugs are generated server-side from the submitted display name
 - submitters cannot provide custom slugs, claim state, publication state, owner fields, freeform bios, about sections, image URLs, private contact details, or trust labels
 - source attribution is stored inline for later moderation and display decisions without creating an account table yet
+- community-submitted records start with `publicSurfacingState: "public"` unless later opt-out or moderation suppression changes that state
 
 ## Public Routes
 
@@ -21,7 +22,9 @@ This doc captures the first community-submitted profile flow for `#23`, plus the
 
 The `/submit` UI currently shows a sign-in-required state until Convex auth is wired into the web app. The backend mutation is already auth-gated and can only write for callers with a Convex identity.
 
-Both public profile routes read through `profiles:getPublicBySlug`, require `publicationState: "published"`, verify the requested route type matches the stored `profileType`, and return a public projection that omits source-attribution identifiers.
+Both public profile routes read through `profiles:getPublicBySlug`, require `publicationState: "published"` plus `publicSurfacingState: "public"`, verify the requested route type matches the stored `profileType`, and return a public projection that omits source-attribution identifiers.
+
+Public source display is sanitized to labels such as `Community submitted` and submitted date. Submitter token identifiers, issuer, subject, and display name are not exposed publicly in this slice.
 
 ## Allowed Submission Fields
 
@@ -55,6 +58,12 @@ Ordinary community submissions do not set those fields in this slice. Future own
 ## Follow-On Boundaries
 
 - `#25` should make community-submitted and unverified labels consistent across cards and pages
-- `#26` should expand attribution into a rollback-capable moderation trail
-- `#29` should add pre-claim suppression workflow state
-- `#31` and `#33` should add search and browse surfaces over published profiles
+- `#26` expands attribution into a first rollback-capable moderation trail
+- `#29` adds pre-claim suppression workflow state
+- `#30` enforces accepted opt-out and suppression state across public surfaces
+- `#31` and `#33` add search and browse surfaces over published, publicly surfacing profiles
+
+See also:
+
+- `docs/backend/search-discovery.md`
+- `docs/backend/vocabulary-model.md`

--- a/docs/backend/profile-schema.md
+++ b/docs/backend/profile-schema.md
@@ -2,7 +2,7 @@
 
 ## Status Note
 
-This doc captures the durable profile schema foundation started in `#9` and extended through `#10`, `#11`, `#12`, `#13`, `#22`, `#23`, and `#82`.
+This doc captures the durable profile schema foundation started in `#9` and extended through `#10`, `#11`, `#12`, `#13`, `#22`, `#23`, `#25`, `#26`, `#30`, `#31`, `#32`, `#33`, `#82`, and `#90`.
 
 The schema is intentionally narrow. It establishes one shared `profiles` table for people and communities without introducing account tables, full claim flows, normalized link tables, asset tables, or advanced moderation workflows.
 
@@ -13,6 +13,7 @@ The schema is intentionally narrow. It establishes one shared `profiles` table f
 - every profile has a canonical `slug` that is globally unique across people and communities
 - claim state, publication state, and creation provenance are separate fields
 - community-submitted unclaimed records are represented by `creationSource: "community"` plus `claimState: "unclaimed"`
+- public surfacing state is separate from ordinary publication state so valid opt-out and suppression can hide otherwise-published profiles
 - account/user references are deferred until auth and claim issues define the account model
 - most public write mutations are deferred until auth and permissions are wired; `profiles:submitCommunityProfile` is the current auth-gated exception
 - the community submission mutation requires a Convex authenticated identity before writing
@@ -47,6 +48,9 @@ State fields:
 - `claimState`: `"unclaimed" | "claimed_unverified" | "claimed_verified"`
 - `publicationState`: `"draft_private" | "published"`
 - `creationSource`: `"self" | "community" | "concierge" | "import" | "moderator"`
+- `publicSurfacingState`: `"public" | "opted_out" | "suppressed"`
+- `publicSurfacingUpdatedAt`: optional timestamp for the latest public-surfacing state change
+- `publicSurfacingReason`: optional short reason for opt-out or suppression state
 - `claimedAt`: optional claim timestamp, present only after claim authority is established
 - `publishedAt`: optional publication timestamp, present once a profile has been published
 - `updatedAt`: application-maintained update timestamp that every profile mutation must refresh
@@ -74,6 +78,12 @@ Convex automatically provides `_id` and `_creationTime`; those are not duplicate
 - `draft_private`: not public and not searchable
 - `published`: eligible for public profile pages and later discovery flows, subject to permission, trust, and opt-out rules
 
+`publicSurfacingState` describes whether an otherwise-published profile is allowed to appear on ordinary public surfaces:
+
+- `public`: profile can appear on profile pages, search, discovery, event participant references, and linked attribution surfaces
+- `opted_out`: valid owner opt-out; hide from ordinary public surfaces
+- `suppressed`: moderation/safety suppression; hide from ordinary public surfaces
+
 `creationSource` describes how the record entered the system. It is not an authority marker by itself; authority comes from `claimState` and later claim records.
 
 ## Mutation Contracts
@@ -91,6 +101,7 @@ The first write path is `profiles:submitCommunityProfile`. It requires `ctx.auth
 - `by_slug`: canonical profile lookup and mutation-enforced slug uniqueness
 - `by_profileType_publicationState`: public page/discovery entry points split by person vs community
 - `by_publicationState_claimState`: public/trust filtering for later profile lists
+- `by_publicSurfacingState_publicationState`: public suppression and opt-out enforcement
 - `by_claimState_profileType`: moderation and claim-review flows by claim state, with optional type splitting
 - `by_creationSource_claimState`: moderation and community-submitted/unclaimed review flows
 - `by_profileType_sortName`: deterministic profile listing by type
@@ -103,6 +114,10 @@ The first write path is `profiles:submitCommunityProfile`. It requires `ctx.auth
 - `#13` defines claim-state transitions and trust labeling behavior
 - `#22` added presentation fields and public-page rendering for avatar/banner, short bio, and longer about content
 - `#23` added the authenticated community submission mutation and source attribution details
+- `#25` and `#26` add public trust/source labeling and the first audit trail
+- `#30` adds public surfacing suppression enforcement
+- `#31`, `#32`, and `#33` add universal public search/discovery surfaces
 - `#82` added inline typed external links for first-slice creator commerce/profile links, with public `https` filtering
+- `#90` adds scoped vocabulary normalization for tags, roles, categories, and discovery facets
 - `#27` adds field-level visibility controls
 - `#31` adds public search behavior and any search-specific indexing

--- a/docs/backend/profile-schema.md
+++ b/docs/backend/profile-schema.md
@@ -96,6 +96,8 @@ Convex schema validation cannot enforce conditional timestamp invariants, so pro
 
 The first write path is `profiles:submitCommunityProfile`. It requires `ctx.auth.getUserIdentity()` to return a signed-in identity, generates the slug server-side, publishes the profile as `creationSource: "community"` plus `claimState: "unclaimed"`, and stores narrow source attribution for later moderation and display decisions.
 
+The `migrations:backfillProfilePublicSurfacingState` internal mutation sets missing legacy `publicSurfacingState` values to `"public"` and fills `publicSurfacingUpdatedAt` so previously-written profiles keep their existing publication behavior after the surfacing-state schema addition.
+
 ## Initial Indexes
 
 - `by_slug`: canonical profile lookup and mutation-enforced slug uniqueness

--- a/docs/backend/search-discovery.md
+++ b/docs/backend/search-discovery.md
@@ -30,6 +30,8 @@ Each document stores:
 
 The first live implementation uses Convex full-text search. Convex supports relevance ordering and prefix/typeahead behavior. Fuzzy typo matching should not be reimplemented with ad hoc regex piles or one-off Levenshtein hacks in app code.
 
+Profile and event mutations update their own search documents. Worlds do not yet have a public write mutation, so `search.rebuildWorldSearchDocuments` is an internal backfill hook for keeping world search documents populated until that write path exists.
+
 ## Semantic And Vector Search Seam
 
 `searchEmbeddings` is a provider-neutral vector seam keyed to `searchDocuments`.
@@ -78,7 +80,7 @@ Profiles carry `publicSurfacingState`:
 - `opted_out`: valid owner opt-out, hidden from ordinary public surfaces
 - `suppressed`: moderation/safety suppression, hidden from ordinary public surfaces
 
-Public profile reads, search documents, event participants, and linked world attributions must respect this state.
+Public profile reads, search documents, event participants, and linked world attributions must respect this state. World search documents must not index linked profile attribution names unless the linked profile is publicly readable.
 
 ## Analytics Events
 

--- a/docs/backend/search-discovery.md
+++ b/docs/backend/search-discovery.md
@@ -1,0 +1,101 @@
+# Search And Discovery
+
+## Status Note
+
+Current recommendation and first implementation for the expanded public discovery engine bundle covering `#25`, `#30`, `#31`, `#32`, `#33`, `#95`, `#96`, and `#97`.
+
+## Locked Decisions
+
+- public discovery starts from explicit VRDex records, not scraped popularity or private presence
+- search is a first-class product surface, not a secondary directory page
+- search and discovery must enforce `publicationState` and `publicSurfacingState`
+- community-submitted and unverified records can be discoverable only with visible trust and source labels
+- events, worlds, people, and communities participate in universal search through search documents
+- PostHog is the first-pass analytics target for discovery instrumentation when configured
+
+## Search Documents
+
+`searchDocuments` is the universal search surface.
+
+Each document stores:
+
+- `entityType`: `profile`, `world`, or `event`
+- target id fields for the source record
+- public route, title, subtitle, summary, and image URL
+- `searchText`: weighted keyword corpus used by Convex full-text search
+- `exactTokens`: normalized exact-match terms for deterministic reranking
+- `vocabularyKeys`: scoped normalized tags and role/category terms
+- trust, freshness, and featured ranking signals
+- sanitized source label
+
+The first live implementation uses Convex full-text search. Convex supports relevance ordering and prefix/typeahead behavior. Fuzzy typo matching should not be reimplemented with ad hoc regex piles or one-off Levenshtein hacks in app code.
+
+## Semantic And Vector Search Seam
+
+`searchEmbeddings` is a provider-neutral vector seam keyed to `searchDocuments`.
+
+Current recommendation:
+
+- use Convex full-text search for the first production keyword/typeahead path
+- keep embeddings optional until a provider is selected
+- evaluate Convex vector search, Weaviate, Pinecone, Typesense, Meilisearch, and Algolia before committing to a separate service
+- prefer provider choice based on real query quality, operations burden, self-hosting posture, and privacy boundaries
+
+The schema uses 1536 dimensions as the first embedding-seam default because that matches common embedding models and Convex's vector-index range.
+
+## Ranking Model
+
+Initial ranking combines:
+
+- Convex full-text relevance
+- exact title/slug/alias token boost
+- vocabulary term match boost
+- trust weight for claimed and verified profiles
+- upcoming-event freshness
+- featured-placement weight
+- entity-type weight so events can surface strongly for tonight/soon discovery
+
+This is intentionally transparent and deterministic. Personalization and analytics-derived ranking are later layers.
+
+## Featured Placements
+
+`featuredPlacements` models curated discovery positions such as home hero, event poster wall, discover hero, and discovery rail.
+
+Featured labels must stay honest:
+
+- `Featured`
+- `Curated`
+- `Upcoming`
+- `Partner-provided`
+
+Avoid unsupported labels such as global popularity, live now, most attended, or trending unless backed by safe documented data.
+
+## Public Surfacing Enforcement
+
+Profiles carry `publicSurfacingState`:
+
+- `public`: normal public discovery and profile access
+- `opted_out`: valid owner opt-out, hidden from ordinary public surfaces
+- `suppressed`: moderation/safety suppression, hidden from ordinary public surfaces
+
+Public profile reads, search documents, event participants, and linked world attributions must respect this state.
+
+## Analytics Events
+
+Optional PostHog instrumentation emits:
+
+- `search_submitted`
+- `search_result_clicked`
+- `discovery_filter_selected`
+- `event_card_clicked`
+- `featured_card_clicked`
+
+Missing PostHog configuration must not break local, preview, self-hosted, or production reads.
+
+## Follow-On Work
+
+- choose the long-term semantic/vector provider after real query testing
+- add personalized ranking once auth, consent, and analytics history exist
+- create PostHog dashboards and quality reports
+- add richer moderation dashboard for suppression requests
+- add paid or partner placement policy only after explicit product review

--- a/docs/backend/vocabulary-model.md
+++ b/docs/backend/vocabulary-model.md
@@ -1,0 +1,68 @@
+# Vocabulary Model
+
+## Status Note
+
+Current recommendation and first implementation for `#90`.
+
+## Purpose
+
+VRDex needs flexible scene language without forcing everyone into one rigid taxonomy. The vocabulary model normalizes and remembers terms that appear in profiles, worlds, events, and discovery facets.
+
+## Scopes
+
+Initial scopes:
+
+- `profile_tag`
+- `person_role`
+- `community_category`
+- `community_subtype`
+- `event_participant_role`
+- `event_tag`
+- `world_tag`
+- `world_creator_role`
+- `discovery_facet`
+
+## Normalization
+
+Terms keep a user-facing `label` and a normalized `key`.
+
+Examples:
+
+- `Melodic House` -> `melodic_house`
+- ` club night ` -> `club_night`
+- `World Author` -> `world_author`
+
+The model deduplicates obvious case and whitespace variants. It does not try to infer arbitrary semantic equivalence in deterministic code.
+
+## Sources
+
+Term source values:
+
+- `seeded`: built-in starter vocabulary
+- `user_created`: learned from submitted or authored records
+- `reviewed`: promoted or curated by maintainers/moderators
+- `imported`: created from reviewed import flows
+
+## Ranking Use
+
+Vocabulary terms feed:
+
+- search facets
+- weighted search document fields
+- browse chips on discovery surfaces
+- future typeahead suggestions
+- future moderation/merge workflows
+
+## Non-Goals
+
+- fully automated taxonomy inference
+- forcing all communities into one fixed role list
+- broad ad hoc language-to-intent mappings in code
+- moderation dashboard for vocabulary abuse in the first slice
+
+## Follow-On Work
+
+- reviewed aliases and merges
+- admin curation UI
+- usage analytics for term quality
+- personalized recommendation facets

--- a/docs/planning/architecture.md
+++ b/docs/planning/architecture.md
@@ -474,6 +474,9 @@ Recommended search behavior:
 - community-submitted profiles are searchable and discoverable
 - claimed and verified profiles get higher ranking weight
 - unclaimed profiles must carry clear trust labels in search cards and profile headers
+- universal search uses `searchDocuments` across profiles, worlds, and events rather than scanning source tables directly
+- deterministic reranking starts with exact, alias, tag, trust, freshness, and featured-placement signals
+- `searchEmbeddings` creates a provider-neutral seam for later semantic/vector search provider evaluation
 
 This prevents public seed data from feeling identical to owner-endorsed identity.
 

--- a/docs/planning/product-spec.md
+++ b/docs/planning/product-spec.md
@@ -277,6 +277,15 @@ Search and browse should also support:
 - worlds hosting upcoming events
 - curated or event-derived active venues
 
+Implementation status for the first discovery engine slice:
+
+- home is moving toward search-first discovery instead of treating search as a secondary directory link
+- universal search is backed by `searchDocuments` for profiles, worlds, and events
+- search ranking starts with deterministic exact, alias, tag, trust, freshness, and featured signals
+- `searchEmbeddings` is a provider-neutral seam for later semantic/vector search
+- featured placements can front event posters, festivals, worlds, communities, and profiles without unsupported global popularity claims
+- PostHog discovery events are optional and no-op when analytics config is absent
+
 ### 6. Discord bot integration
 
 First commands should be simple:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -34,7 +34,10 @@ importers:
         version: 1.32.0(react@19.2.3)
       next:
         specifier: 16.1.6
-        version: 16.1.6(@babel/core@7.29.0)(@playwright/test@1.60.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
+        version: 16.1.6(@babel/core@7.29.0)(@opentelemetry/api@1.9.1)(@playwright/test@1.60.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
+      posthog-js:
+        specifier: ^1.376.2
+        version: 1.376.2
       react:
         specifier: 19.2.3
         version: 19.2.3
@@ -744,10 +747,118 @@ packages:
     resolution: {integrity: sha512-nn5ozdjYQpUCZlWGuxcJY/KpxkWQs4DcbMCmKojjyrYDEAGy4Ce19NN4v5MduafTwJlbKc99UA8YhSVqq9yPZA==}
     engines: {node: '>=12.4.0'}
 
+  '@opentelemetry/api-logs@0.208.0':
+    resolution: {integrity: sha512-CjruKY9V6NMssL/T1kAFgzosF1v9o6oeN+aX5JB/C/xPNtmgIJqcXHG7fA82Ou1zCpWGl4lROQUKwUNE1pMCyg==}
+    engines: {node: '>=8.0.0'}
+
+  '@opentelemetry/api@1.9.1':
+    resolution: {integrity: sha512-gLyJlPHPZYdAk1JENA9LeHejZe1Ti77/pTeFm/nMXmQH/HFZlcS/O2XJB+L8fkbrNSqhdtlvjBVjxwUYanNH5Q==}
+    engines: {node: '>=8.0.0'}
+
+  '@opentelemetry/core@2.2.0':
+    resolution: {integrity: sha512-FuabnnUm8LflnieVxs6eP7Z383hgQU4W1e3KJS6aOG3RxWxcHyBxH8fDMHNgu/gFx/M2jvTOW/4/PHhLz6bjWw==}
+    engines: {node: ^18.19.0 || >=20.6.0}
+    peerDependencies:
+      '@opentelemetry/api': '>=1.0.0 <1.10.0'
+
+  '@opentelemetry/core@2.7.1':
+    resolution: {integrity: sha512-QAqIj32AtK6+pEVNG7EOVxHdE06RP+FM5qpiEJ4RtDcFIqKUZHYhl7/7UY5efhwmwNAg7j8QbJVBLxMerc0+gw==}
+    engines: {node: ^18.19.0 || >=20.6.0}
+    peerDependencies:
+      '@opentelemetry/api': '>=1.0.0 <1.10.0'
+
+  '@opentelemetry/exporter-logs-otlp-http@0.208.0':
+    resolution: {integrity: sha512-jOv40Bs9jy9bZVLo/i8FwUiuCvbjWDI+ZW13wimJm4LjnlwJxGgB+N/VWOZUTpM+ah/awXeQqKdNlpLf2EjvYg==}
+    engines: {node: ^18.19.0 || >=20.6.0}
+    peerDependencies:
+      '@opentelemetry/api': ^1.3.0
+
+  '@opentelemetry/otlp-exporter-base@0.208.0':
+    resolution: {integrity: sha512-gMd39gIfVb2OgxldxUtOwGJYSH8P1kVFFlJLuut32L6KgUC4gl1dMhn+YC2mGn0bDOiQYSk/uHOdSjuKp58vvA==}
+    engines: {node: ^18.19.0 || >=20.6.0}
+    peerDependencies:
+      '@opentelemetry/api': ^1.3.0
+
+  '@opentelemetry/otlp-transformer@0.208.0':
+    resolution: {integrity: sha512-DCFPY8C6lAQHUNkzcNT9R+qYExvsk6C5Bto2pbNxgicpcSWbe2WHShLxkOxIdNcBiYPdVHv/e7vH7K6TI+C+fQ==}
+    engines: {node: ^18.19.0 || >=20.6.0}
+    peerDependencies:
+      '@opentelemetry/api': ^1.3.0
+
+  '@opentelemetry/resources@2.2.0':
+    resolution: {integrity: sha512-1pNQf/JazQTMA0BiO5NINUzH0cbLbbl7mntLa4aJNmCCXSj0q03T5ZXXL0zw4G55TjdL9Tz32cznGClf+8zr5A==}
+    engines: {node: ^18.19.0 || >=20.6.0}
+    peerDependencies:
+      '@opentelemetry/api': '>=1.3.0 <1.10.0'
+
+  '@opentelemetry/resources@2.7.1':
+    resolution: {integrity: sha512-DeT6KKolmC4e/dRQvMQ/RwlnzhaqeiFOXY5ngoOPJ07GgVVKxZOg9EcrNZb5aTzUn+iCrJldAgOfQm1O/QfPAQ==}
+    engines: {node: ^18.19.0 || >=20.6.0}
+    peerDependencies:
+      '@opentelemetry/api': '>=1.3.0 <1.10.0'
+
+  '@opentelemetry/sdk-logs@0.208.0':
+    resolution: {integrity: sha512-QlAyL1jRpOeaqx7/leG1vJMp84g0xKP6gJmfELBpnI4O/9xPX+Hu5m1POk9Kl+veNkyth5t19hRlN6tNY1sjbA==}
+    engines: {node: ^18.19.0 || >=20.6.0}
+    peerDependencies:
+      '@opentelemetry/api': '>=1.4.0 <1.10.0'
+
+  '@opentelemetry/sdk-metrics@2.2.0':
+    resolution: {integrity: sha512-G5KYP6+VJMZzpGipQw7Giif48h6SGQ2PFKEYCybeXJsOCB4fp8azqMAAzE5lnnHK3ZVwYQrgmFbsUJO/zOnwGw==}
+    engines: {node: ^18.19.0 || >=20.6.0}
+    peerDependencies:
+      '@opentelemetry/api': '>=1.9.0 <1.10.0'
+
+  '@opentelemetry/sdk-trace-base@2.2.0':
+    resolution: {integrity: sha512-xWQgL0Bmctsalg6PaXExmzdedSp3gyKV8mQBwK/j9VGdCDu2fmXIb2gAehBKbkXCpJ4HPkgv3QfoJWRT4dHWbw==}
+    engines: {node: ^18.19.0 || >=20.6.0}
+    peerDependencies:
+      '@opentelemetry/api': '>=1.3.0 <1.10.0'
+
+  '@opentelemetry/semantic-conventions@1.41.1':
+    resolution: {integrity: sha512-/UhIkaZgPutTFmQ7RnIJGgDXZmtEJ7Dvi86xNTFWcnRxVRNk/aotsqDJYeEvDP+FSMB2SdW+pQzNMcWP0rwuNA==}
+    engines: {node: '>=14'}
+
   '@playwright/test@1.60.0':
     resolution: {integrity: sha512-O71yZIbAh/PxDMNGns37GHBIfrVkEVyn+AXyIa5dOTfb4/xNvRWV+Vv/NMbNCtODB/pO7vLlF2OTmMVLhmr7Ag==}
     engines: {node: '>=18'}
     hasBin: true
+
+  '@posthog/core@1.29.11':
+    resolution: {integrity: sha512-/4EF7oxAFSWJgaXxppT8bdYp7MGAnWFnKz994+MetTz/T6CKbYpjqIXHCofQXtcOXjEclTYj91igA+IkVFKiSg==}
+
+  '@posthog/types@1.376.2':
+    resolution: {integrity: sha512-Y3ROpAxNqgcy2G0w6JoG5Gt+P6WNY2lkHTPMPzWqexRwemYbFegDi5AifDyD9/tstKTlOYKTTExtaJ5EBcghyQ==}
+
+  '@protobufjs/aspromise@1.1.2':
+    resolution: {integrity: sha512-j+gKExEuLmKwvz3OgROXtrJ2UG2x8Ch2YZUxahh+s1F2HZ+wAceUNLkvy6zKCPVRkU++ZWQrdxsUeQXmcg4uoQ==}
+
+  '@protobufjs/base64@1.1.2':
+    resolution: {integrity: sha512-AZkcAA5vnN/v4PDqKyMR5lx7hZttPDgClv83E//FMNhR2TMcLUhfRUBHCmSl0oi9zMgDDqRUJkSxO3wm85+XLg==}
+
+  '@protobufjs/codegen@2.0.5':
+    resolution: {integrity: sha512-zgXFLzW3Ap33e6d0Wlj4MGIm6Ce8O89n/apUaGNB/jx+hw+ruWEp7EwGUshdLKVRCxZW12fp9r40E1mQrf/34g==}
+
+  '@protobufjs/eventemitter@1.1.1':
+    resolution: {integrity: sha512-vW1GmwMZNnL+gMRaovlh9yZX74kc+TTU3FObkkurpMaRtBfLP3ldjS9KQWlwZgraRE0+dheEEoAxdzcJQ8eXZg==}
+
+  '@protobufjs/fetch@1.1.1':
+    resolution: {integrity: sha512-GpptLrs57adMSuHi3VNj0mAF8dwh36LMaYF6XyJ6JMWlVsc+t42tm1HSEDmOs3A8fC9yyeisgLhsTVQokOZ0zw==}
+
+  '@protobufjs/float@1.0.2':
+    resolution: {integrity: sha512-Ddb+kVXlXst9d+R9PfTIxh1EdNkgoRe5tOX6t01f1lYWOvJnSPDBlG241QLzcyPdoNTsblLUdujGSE4RzrTZGQ==}
+
+  '@protobufjs/inquire@1.1.2':
+    resolution: {integrity: sha512-pa0vFRuws4wkvaXKK1uXZMAwAX4/t8ANaJo45iw/oQHNQ9q5xUzwgFmVJGXiga2BeN+zpX7Vf9vmsiIa2J+MUw==}
+
+  '@protobufjs/path@1.1.2':
+    resolution: {integrity: sha512-6JOcJ5Tm08dOHAbdR3GrvP+yUUfkjG5ePsHYczMFLq3ZmMkAD98cDgcT2iA1lJ9NVwFd4tH/iSSoe44YWkltEA==}
+
+  '@protobufjs/pool@1.1.0':
+    resolution: {integrity: sha512-0kELaGSIDBKvcgS4zkjz1PeddatrjYcmMWOlAuAPwAeccUrPHdUqo/J6LiymHHEiJT5NrF1UVwxY14f+fy4WQw==}
+
+  '@protobufjs/utf8@1.1.1':
+    resolution: {integrity: sha512-oOAWABowe8EAbMyWKM0tYDKi8Yaox52D+HWZhAIJqQXbqe0xI/GV7FhLWqlEKreMkfDjshR5FKgi3mnle0h6Eg==}
 
   '@rtsao/scc@1.1.0':
     resolution: {integrity: sha512-zt6OdqaDoOnJ1ZYsCYGt9YmWzDXl4vQdKTyJev62gFhRGKdx7mcT54V9KIjg+d2wi9EXsPvAPKe7i7WjfVWB8g==}
@@ -865,6 +976,9 @@ packages:
 
   '@types/react@19.2.14':
     resolution: {integrity: sha512-ilcTH/UniCkMdtexkoCN0bI7pMcJDvmQFPvuPvmEaYA/NSfFTAgdUSLAoVjaRJm7+6PvcM+q1zYOwS4wTYMF9w==}
+
+  '@types/trusted-types@2.0.7':
+    resolution: {integrity: sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw==}
 
   '@typescript-eslint/eslint-plugin@8.57.0':
     resolution: {integrity: sha512-qeu4rTHR3/IaFORbD16gmjq9+rEs9fGKdX0kF6BKSfi+gCuG3RCKLlSBYzn/bGsY9Tj7KE/DAQStbp8AHJGHEQ==}
@@ -1205,6 +1319,9 @@ packages:
       react:
         optional: true
 
+  core-js@3.49.0:
+    resolution: {integrity: sha512-es1U2+YTtzpwkxVLwAFdSpaIMyQaq0PBgm3YD1W3Qpsn1NAmO3KSgZfu+oGSWVu6NvLHoHCV/aYcsE5wiB7ALg==}
+
   cross-spawn@7.0.6:
     resolution: {integrity: sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==}
     engines: {node: '>= 8'}
@@ -1262,6 +1379,9 @@ packages:
   doctrine@2.1.0:
     resolution: {integrity: sha512-35mSku4ZXK0vfCuHEDAwt55dg2jNajHZ1odvF+8SSr82EsZY4QmXfuWso8oEd8zRhVObSN18aM0CjSdoBX7zIw==}
     engines: {node: '>=0.10.0'}
+
+  dompurify@3.4.6:
+    resolution: {integrity: sha512-+7gzEI8trIIQkVCvQ3ucGtNfH3nOmDgVTzc62rAAOlMxLth78pwpPoZCPc7CyRzAQF89MqcfPdEWkDwnjgqktg==}
 
   dunder-proto@1.0.1:
     resolution: {integrity: sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==}
@@ -1481,6 +1601,9 @@ packages:
     peerDependenciesMeta:
       picomatch:
         optional: true
+
+  fflate@0.4.8:
+    resolution: {integrity: sha512-FJqqoDBR00Mdj9ppamLa/Y7vxm+PRmNWA67N846RvsoYVMKB4q3y/de5PA7gUmRMYK/8CMz2GDZQmCRN1wBcWA==}
 
   file-entry-cache@8.0.0:
     resolution: {integrity: sha512-XXTUwCvisa5oacNGRP9SfNtYBNAMi+RPwBFmblZEF7N7swHYQS6/Zfk7SRwx4D5j3CH211YNRco1DEMNVfZCnQ==}
@@ -1896,6 +2019,9 @@ packages:
     resolution: {integrity: sha512-9ie8ItPR6tjY5uYJh8K/Zrv/RMZ5VOlOWvtZdEHYSTFKZfIBPQa9tOAEeAWhd+AnIneLJ22w5fjOYtoutpWq5w==}
     engines: {node: '>=18'}
 
+  long@5.3.2:
+    resolution: {integrity: sha512-mNAgZ1GmyNhD7AuqnTG3/VQ26o760+ZYBPKjPvugO8+nLbYfX6TVpJPseBvopbdY+qpZ/lKUnmEc1LeZYS3QAA==}
+
   loose-envify@1.4.0:
     resolution: {integrity: sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==}
     hasBin: true
@@ -2076,6 +2202,12 @@ packages:
     resolution: {integrity: sha512-OW/rX8O/jXnm82Ey1k44pObPtdblfiuWnrd8X7GJ7emImCOstunGbXUpp7HdBrFQX6rJzn3sPT397Wp5aCwCHg==}
     engines: {node: ^10 || ^12 || >=14}
 
+  posthog-js@1.376.2:
+    resolution: {integrity: sha512-Anz2pCp7dcNbammTExiZpcKC08dxfrHYaJgaXH6rq5x3Zcfj/4FkcMJF2cGCrdQXel5Y4vftiVSseZda0HAQTQ==}
+
+  preact@10.29.2:
+    resolution: {integrity: sha512-7tNmwg/7mzzAoB/8kSg6Hl37JraAZw3Z3A0JSY7VXlZwo82Xn0G7wKbNNs2qoF4ZEEsQGTwDAroNdqKs1ofJxQ==}
+
   prelude-ls@1.2.1:
     resolution: {integrity: sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g==}
     engines: {node: '>= 0.8.0'}
@@ -2088,9 +2220,16 @@ packages:
   prop-types@15.8.1:
     resolution: {integrity: sha512-oj87CgZICdulUohogVAR7AjlC0327U4el4L6eAvOqCeudMDVU0NThNaV+b9Df4dXgSP1gXMTnPdhfe/2qDH5cg==}
 
+  protobufjs@7.6.1:
+    resolution: {integrity: sha512-4K0myLaWL5EteuSAro91EGFgcfVgxb64Jx+7oDAY6GOkXD4M69yuSEljNcInGVCA5sOPxmZ/EqDLj2x0Q0+Ygg==}
+    engines: {node: '>=12.0.0'}
+
   punycode@2.3.1:
     resolution: {integrity: sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==}
     engines: {node: '>=6'}
+
+  query-selector-shadow-dom@1.0.1:
+    resolution: {integrity: sha512-lT5yCqEBgfoMYpf3F2xQRK7zEr1rhIIZuceDK6+xRkJQ4NMbHTwXqk4NkwDwQMNqXgG9r9fyHnzwNVs6zV5KRw==}
 
   queue-microtask@1.2.3:
     resolution: {integrity: sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==}
@@ -2387,6 +2526,9 @@ packages:
 
   uri-js@4.4.1:
     resolution: {integrity: sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==}
+
+  web-vitals@5.2.0:
+    resolution: {integrity: sha512-i2z98bEmaCqSDiHEDu+gHl/dmR4Q+TxFmG3/13KkMO+o8UxQzCqWaDRCiLgEa41nlO4VpXSI0ASa1xWmO9sBlA==}
 
   which-boxed-primitive@1.1.1:
     resolution: {integrity: sha512-TbX3mj8n0odCBFVlY8AxkqcHASw3L60jIuF8jFP78az3C2YhmGvqbHBpAjTRH2/xqYunrJ9g1jSyjCjpoWzIAA==}
@@ -2950,9 +3092,113 @@ snapshots:
 
   '@nolyfill/is-core-module@1.0.39': {}
 
+  '@opentelemetry/api-logs@0.208.0':
+    dependencies:
+      '@opentelemetry/api': 1.9.1
+
+  '@opentelemetry/api@1.9.1': {}
+
+  '@opentelemetry/core@2.2.0(@opentelemetry/api@1.9.1)':
+    dependencies:
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/semantic-conventions': 1.41.1
+
+  '@opentelemetry/core@2.7.1(@opentelemetry/api@1.9.1)':
+    dependencies:
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/semantic-conventions': 1.41.1
+
+  '@opentelemetry/exporter-logs-otlp-http@0.208.0(@opentelemetry/api@1.9.1)':
+    dependencies:
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/api-logs': 0.208.0
+      '@opentelemetry/core': 2.2.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/otlp-exporter-base': 0.208.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/otlp-transformer': 0.208.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/sdk-logs': 0.208.0(@opentelemetry/api@1.9.1)
+
+  '@opentelemetry/otlp-exporter-base@0.208.0(@opentelemetry/api@1.9.1)':
+    dependencies:
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/core': 2.2.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/otlp-transformer': 0.208.0(@opentelemetry/api@1.9.1)
+
+  '@opentelemetry/otlp-transformer@0.208.0(@opentelemetry/api@1.9.1)':
+    dependencies:
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/api-logs': 0.208.0
+      '@opentelemetry/core': 2.2.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/resources': 2.2.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/sdk-logs': 0.208.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/sdk-metrics': 2.2.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/sdk-trace-base': 2.2.0(@opentelemetry/api@1.9.1)
+      protobufjs: 7.6.1
+
+  '@opentelemetry/resources@2.2.0(@opentelemetry/api@1.9.1)':
+    dependencies:
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/core': 2.2.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/semantic-conventions': 1.41.1
+
+  '@opentelemetry/resources@2.7.1(@opentelemetry/api@1.9.1)':
+    dependencies:
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/core': 2.7.1(@opentelemetry/api@1.9.1)
+      '@opentelemetry/semantic-conventions': 1.41.1
+
+  '@opentelemetry/sdk-logs@0.208.0(@opentelemetry/api@1.9.1)':
+    dependencies:
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/api-logs': 0.208.0
+      '@opentelemetry/core': 2.2.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/resources': 2.2.0(@opentelemetry/api@1.9.1)
+
+  '@opentelemetry/sdk-metrics@2.2.0(@opentelemetry/api@1.9.1)':
+    dependencies:
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/core': 2.2.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/resources': 2.2.0(@opentelemetry/api@1.9.1)
+
+  '@opentelemetry/sdk-trace-base@2.2.0(@opentelemetry/api@1.9.1)':
+    dependencies:
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/core': 2.2.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/resources': 2.2.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/semantic-conventions': 1.41.1
+
+  '@opentelemetry/semantic-conventions@1.41.1': {}
+
   '@playwright/test@1.60.0':
     dependencies:
       playwright: 1.60.0
+
+  '@posthog/core@1.29.11':
+    dependencies:
+      '@posthog/types': 1.376.2
+
+  '@posthog/types@1.376.2': {}
+
+  '@protobufjs/aspromise@1.1.2': {}
+
+  '@protobufjs/base64@1.1.2': {}
+
+  '@protobufjs/codegen@2.0.5': {}
+
+  '@protobufjs/eventemitter@1.1.1': {}
+
+  '@protobufjs/fetch@1.1.1':
+    dependencies:
+      '@protobufjs/aspromise': 1.1.2
+
+  '@protobufjs/float@1.0.2': {}
+
+  '@protobufjs/inquire@1.1.2': {}
+
+  '@protobufjs/path@1.1.2': {}
+
+  '@protobufjs/pool@1.1.0': {}
+
+  '@protobufjs/utf8@1.1.1': {}
 
   '@rtsao/scc@1.1.0': {}
 
@@ -3051,6 +3297,9 @@ snapshots:
   '@types/react@19.2.14':
     dependencies:
       csstype: 3.2.3
+
+  '@types/trusted-types@2.0.7':
+    optional: true
 
   '@typescript-eslint/eslint-plugin@8.57.0(@typescript-eslint/parser@8.57.0(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3))(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3)':
     dependencies:
@@ -3399,6 +3648,8 @@ snapshots:
       - bufferutil
       - utf-8-validate
 
+  core-js@3.49.0: {}
+
   cross-spawn@7.0.6:
     dependencies:
       path-key: 3.1.1
@@ -3454,6 +3705,10 @@ snapshots:
   doctrine@2.1.0:
     dependencies:
       esutils: 2.0.3
+
+  dompurify@3.4.6:
+    optionalDependencies:
+      '@types/trusted-types': 2.0.7
 
   dunder-proto@1.0.1:
     dependencies:
@@ -3866,6 +4121,8 @@ snapshots:
     optionalDependencies:
       picomatch: 4.0.3
 
+  fflate@0.4.8: {}
+
   file-entry-cache@8.0.0:
     dependencies:
       flat-cache: 4.0.1
@@ -4265,6 +4522,8 @@ snapshots:
       strip-ansi: 7.2.0
       wrap-ansi: 9.0.2
 
+  long@5.3.2: {}
+
   loose-envify@1.4.0:
     dependencies:
       js-tokens: 4.0.0
@@ -4306,7 +4565,7 @@ snapshots:
 
   natural-compare@1.4.0: {}
 
-  next@16.1.6(@babel/core@7.29.0)(@playwright/test@1.60.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3):
+  next@16.1.6(@babel/core@7.29.0)(@opentelemetry/api@1.9.1)(@playwright/test@1.60.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3):
     dependencies:
       '@next/env': 16.1.6
       '@swc/helpers': 0.5.15
@@ -4325,6 +4584,7 @@ snapshots:
       '@next/swc-linux-x64-musl': 16.1.6
       '@next/swc-win32-arm64-msvc': 16.1.6
       '@next/swc-win32-x64-msvc': 16.1.6
+      '@opentelemetry/api': 1.9.1
       '@playwright/test': 1.60.0
       sharp: 0.34.5
     transitivePeerDependencies:
@@ -4447,6 +4707,24 @@ snapshots:
       picocolors: 1.1.1
       source-map-js: 1.2.1
 
+  posthog-js@1.376.2:
+    dependencies:
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/api-logs': 0.208.0
+      '@opentelemetry/exporter-logs-otlp-http': 0.208.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/resources': 2.7.1(@opentelemetry/api@1.9.1)
+      '@opentelemetry/sdk-logs': 0.208.0(@opentelemetry/api@1.9.1)
+      '@posthog/core': 1.29.11
+      '@posthog/types': 1.376.2
+      core-js: 3.49.0
+      dompurify: 3.4.6
+      fflate: 0.4.8
+      preact: 10.29.2
+      query-selector-shadow-dom: 1.0.1
+      web-vitals: 5.2.0
+
+  preact@10.29.2: {}
+
   prelude-ls@1.2.1: {}
 
   prettier@3.8.1: {}
@@ -4457,7 +4735,24 @@ snapshots:
       object-assign: 4.1.1
       react-is: 16.13.1
 
+  protobufjs@7.6.1:
+    dependencies:
+      '@protobufjs/aspromise': 1.1.2
+      '@protobufjs/base64': 1.1.2
+      '@protobufjs/codegen': 2.0.5
+      '@protobufjs/eventemitter': 1.1.1
+      '@protobufjs/fetch': 1.1.1
+      '@protobufjs/float': 1.0.2
+      '@protobufjs/inquire': 1.1.2
+      '@protobufjs/path': 1.1.2
+      '@protobufjs/pool': 1.1.0
+      '@protobufjs/utf8': 1.1.1
+      '@types/node': 22.19.15
+      long: 5.3.2
+
   punycode@2.3.1: {}
+
+  query-selector-shadow-dom@1.0.1: {}
 
   queue-microtask@1.2.3: {}
 
@@ -4866,6 +5161,8 @@ snapshots:
   uri-js@4.4.1:
     dependencies:
       punycode: 2.3.1
+
+  web-vitals@5.2.0: {}
 
   which-boxed-primitive@1.1.1:
     dependencies:

--- a/tests/backend/event-foundation.test.ts
+++ b/tests/backend/event-foundation.test.ts
@@ -188,6 +188,7 @@ describe("public event projection", () => {
       tags: [],
       claimState: "unclaimed",
       publicationState: "published",
+      publicSurfacingState: "public",
       creationSource: "community",
       updatedAt: now,
       profileType: "person",

--- a/tests/backend/profile-foundation.test.ts
+++ b/tests/backend/profile-foundation.test.ts
@@ -82,6 +82,7 @@ describe("profile permission helpers", () => {
     claimState: "unclaimed",
     profileType: "person",
     publicationState: "published",
+    publicSurfacingState: "public",
   } as const;
 
   const privateUnclaimedPerson = {
@@ -247,6 +248,7 @@ describe("public profile projection", () => {
       ],
       claimState: "unclaimed",
       publicationState: "published",
+      publicSurfacingState: "public",
       creationSource: "community",
       publishedAt: 1,
       updatedAt: 1,
@@ -268,6 +270,7 @@ describe("public profile projection", () => {
 
     assert.equal("sourceAttribution" in publicProfile, false);
     assert.equal("creationSource" in publicProfile, false);
+    assert.equal(publicProfile.source?.label, "Community submitted");
     assert.equal(publicProfile.trustLabel, "community_submitted");
     assert.equal(publicProfile.outboundLinks.length, 1);
     assert.equal(publicProfile.outboundLinks[0]?.url, "https://example.invalid/dj-celine-kofi");
@@ -288,6 +291,7 @@ describe("public profile world credits", () => {
       creatorAttributions: [],
       outboundLinks: [],
       publicationState: "published",
+      publicSurfacingState: "public",
       creationSource: "self",
       updatedAt: 1,
     } as Doc<"worlds">;
@@ -296,6 +300,7 @@ describe("public profile world credits", () => {
       slug: "draft-world",
       displayName: "Draft World",
       publicationState: "draft_private",
+      publicSurfacingState: "public",
     } as Doc<"worlds">;
     const worldAuthorCredit = {
       worldId: "world123",

--- a/tests/backend/search-discovery.test.ts
+++ b/tests/backend/search-discovery.test.ts
@@ -1,0 +1,144 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+
+import type { Doc } from "../../convex/_generated/dataModel";
+import {
+  createEventSearchDocument,
+  createProfileSearchDocument,
+  createWorldSearchDocument,
+  sortSearchResults,
+  toPublicSearchResult,
+} from "../../convex/_searchDocuments";
+import { createVocabularyKey, collectVocabularyKeys } from "../../convex/_vocabulary";
+
+describe("vocabulary normalization", () => {
+  it("normalizes obvious duplicate terms into stable keys", () => {
+    assert.equal(createVocabularyKey("  Melodic   House  "), "melodic_house");
+    assert.equal(createVocabularyKey("DJs"), "djs");
+    assert.deepEqual(
+      collectVocabularyKeys([
+        { scope: "profile_tag", label: "House" },
+        { scope: "profile_tag", label: " house " },
+        { scope: "person_role", label: "DJ" },
+      ]),
+      ["person_role:dj", "profile_tag:house"],
+    );
+  });
+});
+
+describe("search document projection", () => {
+  it("builds weighted profile documents and hides suppressed profiles", () => {
+    const profile = {
+      _id: "profile123",
+      slug: "dj-aurora",
+      displayName: "DJ Aurora",
+      sortName: "dj aurora",
+      aliases: ["Auralight"],
+      tags: ["Melodic House"],
+      headline: "Late-night VRChat floors.",
+      claimState: "claimed_verified",
+      publicationState: "published",
+      publicSurfacingState: "suppressed",
+      creationSource: "community",
+      updatedAt: 1,
+      profileType: "person",
+      person: {
+        roleTags: ["DJ"],
+      },
+    } as unknown as Doc<"profiles">;
+
+    const document = createProfileSearchDocument(profile);
+
+    assert.equal(document.publicState, "hidden");
+    assert.equal(document.routePath, "/p/dj-aurora");
+    assert.equal(document.trustRank, 40);
+    assert.ok(document.searchText.includes("DJ Aurora"));
+    assert.deepEqual(document.vocabularyKeys, ["person_role:dj", "profile_tag:melodic_house"]);
+  });
+
+  it("builds world and event documents for universal search", () => {
+    const world = {
+      _id: "world123",
+      slug: "neon-harbor",
+      displayName: "Neon Harbor",
+      sortName: "neon harbor",
+      tags: ["Club world"],
+      summary: "A VRChat venue.",
+      visibilityStatus: "public",
+      platformCompatibility: ["pc"],
+      media: [],
+      creatorAttributions: [
+        {
+          role: "world_author",
+          displayName: "Afterglow Social",
+          profileSlug: "afterglow-social",
+          profileType: "community",
+        },
+      ],
+      outboundLinks: [],
+      publicationState: "published",
+      creationSource: "self",
+      updatedAt: 1,
+    } as unknown as Doc<"worlds">;
+    const event = {
+      _id: "event123",
+      slug: "afterglow-harbor-sessions",
+      title: "Afterglow Harbor Sessions",
+      sortTitle: "afterglow harbor sessions",
+      startAt: Date.now() + 86_400_000,
+      communityName: "Afterglow Social",
+      summary: "A poster-forward fixture event.",
+      sourceType: "manual",
+      sourceLabel: "Fixture event listing",
+      publicationState: "published",
+      updatedAt: 1,
+    } as unknown as Doc<"events">;
+
+    const worldDocument = createWorldSearchDocument(world);
+    const eventDocument = createEventSearchDocument(event, { world, roleLabels: ["Headliner"] });
+
+    assert.equal(worldDocument.entityType, "world");
+    assert.equal(eventDocument.entityType, "event");
+    assert.equal(eventDocument.publicState, "public");
+    assert.ok(eventDocument.searchText.includes("Neon Harbor"));
+    assert.deepEqual(eventDocument.vocabularyKeys, [
+      "event_participant_role:headliner",
+      "event_tag:afterglow_social",
+      "event_tag:upcoming",
+    ]);
+  });
+
+  it("reranks exact and event results above weaker matches", () => {
+    const weak = {
+      entityType: "profile",
+      slug: "random-profile",
+      routePath: "/p/random-profile",
+      title: "Random Profile",
+      searchText: "House",
+      exactTokens: ["random profile"],
+      vocabularyKeys: ["profile_tag:house"],
+      trustRank: 10,
+      featuredRank: 0,
+      publicState: "public",
+      updatedAt: 1,
+    } as unknown as Doc<"searchDocuments">;
+    const strong = {
+      ...weak,
+      entityType: "event",
+      slug: "house-night",
+      routePath: "/e/house-night",
+      title: "House Night",
+      exactTokens: ["house"],
+      trustRank: 30,
+      featuredRank: 40,
+      startsAt: Date.now() + 3_600_000,
+    } as unknown as Doc<"searchDocuments">;
+
+    const results = sortSearchResults([
+      toPublicSearchResult(weak, "House"),
+      toPublicSearchResult(strong, "House"),
+    ]);
+
+    assert.equal(results[0]?.slug, "house-night");
+  });
+});

--- a/tests/backend/search-discovery.test.ts
+++ b/tests/backend/search-discovery.test.ts
@@ -94,7 +94,7 @@ describe("search document projection", () => {
       updatedAt: 1,
     } as unknown as Doc<"events">;
 
-    const worldDocument = createWorldSearchDocument(world, { hiddenProfileKeys: new Set() });
+    const worldDocument = createWorldSearchDocument(world);
     const eventDocument = createEventSearchDocument(event, { world, roleLabels: ["Headliner"] });
 
     assert.equal(worldDocument.entityType, "world");

--- a/tests/backend/search-discovery.test.ts
+++ b/tests/backend/search-discovery.test.ts
@@ -94,10 +94,11 @@ describe("search document projection", () => {
       updatedAt: 1,
     } as unknown as Doc<"events">;
 
-    const worldDocument = createWorldSearchDocument(world);
+    const worldDocument = createWorldSearchDocument(world, { hiddenProfileKeys: new Set() });
     const eventDocument = createEventSearchDocument(event, { world, roleLabels: ["Headliner"] });
 
     assert.equal(worldDocument.entityType, "world");
+    assert.ok(worldDocument.searchText.includes("Afterglow Social"));
     assert.equal(eventDocument.entityType, "event");
     assert.equal(eventDocument.publicState, "public");
     assert.ok(eventDocument.searchText.includes("Neon Harbor"));
@@ -106,6 +107,44 @@ describe("search document projection", () => {
       "event_tag:afterglow_social",
       "event_tag:upcoming",
     ]);
+  });
+
+  it("omits hidden linked profile attribution names from world search documents", () => {
+    const world = {
+      _id: "world123",
+      slug: "neon-harbor",
+      displayName: "Neon Harbor",
+      sortName: "neon harbor",
+      tags: ["Club world"],
+      summary: "A VRChat venue.",
+      visibilityStatus: "public",
+      platformCompatibility: ["pc"],
+      media: [],
+      creatorAttributions: [
+        {
+          role: "world_author",
+          displayName: "Suppressed Creator",
+          profileSlug: "suppressed-creator",
+          profileType: "person",
+        },
+        {
+          role: "builder",
+          displayName: "Unlinked Builder",
+        },
+      ],
+      outboundLinks: [],
+      publicationState: "published",
+      creationSource: "self",
+      updatedAt: 1,
+    } as unknown as Doc<"worlds">;
+
+    const document = createWorldSearchDocument(world, {
+      hiddenProfileKeys: new Set(["person:suppressed-creator"]),
+    });
+
+    assert.equal(document.searchText.includes("Suppressed Creator"), false);
+    assert.equal(document.exactTokens.includes("suppressed creator"), false);
+    assert.ok(document.searchText.includes("Unlinked Builder"));
   });
 
   it("reranks exact and event results above weaker matches", () => {

--- a/tests/backend/search-discovery.test.ts
+++ b/tests/backend/search-discovery.test.ts
@@ -180,4 +180,35 @@ describe("search document projection", () => {
 
     assert.equal(results[0]?.slug, "house-night");
   });
+
+  it("caps stale event featured rank after an event has passed", () => {
+    const pastEvent = {
+      entityType: "event",
+      slug: "past-house-night",
+      routePath: "/e/past-house-night",
+      title: "Past House Night",
+      searchText: "House",
+      exactTokens: ["house"],
+      vocabularyKeys: ["event_tag:house"],
+      trustRank: 30,
+      featuredRank: 42,
+      startsAt: Date.now() - 3_600_000,
+      publicState: "public",
+      updatedAt: 1,
+    } as unknown as Doc<"searchDocuments">;
+    const upcomingEvent = {
+      ...pastEvent,
+      slug: "upcoming-house-night",
+      routePath: "/e/upcoming-house-night",
+      title: "Upcoming House Night",
+      startsAt: Date.now() + 3_600_000,
+    } as unknown as Doc<"searchDocuments">;
+
+    const results = sortSearchResults([
+      toPublicSearchResult(pastEvent, "House"),
+      toPublicSearchResult(upcomingEvent, "House"),
+    ]);
+
+    assert.equal(results[0]?.slug, "upcoming-house-night");
+  });
 });


### PR DESCRIPTION
## Summary
- Adds the public discovery/search foundation across profiles, worlds, and events with universal search documents, vocabulary terms, featured placements, and suppression/opt-out state.
- Adds `/discover`, `/search`, and `/privacy/suppression` web surfaces plus a search-first home hero and optional PostHog analytics hooks.
- Documents search, vocabulary, surfacing, suppression, and analytics contracts with backend tests and Playwright fixture coverage.

## Testing
- `pnpm verify`
- `pnpm test:e2e`
- `pnpm test:e2e:visual`

## Risk Notes
- PostHog is no-op unless `NEXT_PUBLIC_POSTHOG_KEY` is configured.
- Vector search provider remains behind the provider-neutral `searchEmbeddings` seam.
- Suppression intake is request-only until full auth/claim review workflows exist.

Closes #25
Closes #26
Closes #28
Closes #29
Closes #30
Closes #31
Closes #32
Closes #33
Closes #90
Closes #95
Closes #96
Closes #97