### PR TITLE
Add auth claims and profile privacy foundation

### DIFF
--- a/.github/workflows/baseline-checks.yml
+++ b/.github/workflows/baseline-checks.yml
@@ -155,13 +155,13 @@ jobs:
       - name: Check Convex deploy key
         id: gate
         env:
-          CONVEX_DEPLOY_KEY: ${{ secrets.CONVEX_DEPLOY_KEY }}
+          CONVEX_DEPLOY_KEY: ${{ secrets.CONVEX_DEPLOY_KEY_PROD }}
         run: |
           if [ -z "$CONVEX_DEPLOY_KEY" ]; then
             echo "enabled=false" >> "$GITHUB_OUTPUT"
             {
               echo "## Convex production deploy"
-              echo "Skipped because CONVEX_DEPLOY_KEY is not configured."
+              echo "Skipped because CONVEX_DEPLOY_KEY_PROD is not configured."
             } >> "$GITHUB_STEP_SUMMARY"
             exit 0
           fi
@@ -186,13 +186,13 @@ jobs:
       - name: Deploy Convex functions and schema
         if: steps.gate.outputs.enabled == 'true'
         env:
-          CONVEX_DEPLOY_KEY: ${{ secrets.CONVEX_DEPLOY_KEY }}
+          CONVEX_DEPLOY_KEY: ${{ secrets.CONVEX_DEPLOY_KEY_PROD }}
         run: pnpm exec convex deploy --yes --typecheck=enable
 
       - name: Run deploy-time migrations
         if: steps.gate.outputs.enabled == 'true'
         env:
-          CONVEX_DEPLOY_KEY: ${{ secrets.CONVEX_DEPLOY_KEY }}
+          CONVEX_DEPLOY_KEY: ${{ secrets.CONVEX_DEPLOY_KEY_PROD }}
         run: pnpm exec convex run migrations:runAll --prod
 
   playwright-public-preview:

--- a/.github/workflows/baseline-checks.yml
+++ b/.github/workflows/baseline-checks.yml
@@ -141,6 +141,60 @@ jobs:
       - name: Run build
         run: pnpm build:web
 
+  deploy-convex-production:
+    name: Deploy Convex Production
+    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+    needs: [build-web]
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Check Convex deploy key
+        id: gate
+        env:
+          CONVEX_DEPLOY_KEY: ${{ secrets.CONVEX_DEPLOY_KEY }}
+        run: |
+          if [ -z "$CONVEX_DEPLOY_KEY" ]; then
+            echo "enabled=false" >> "$GITHUB_OUTPUT"
+            {
+              echo "## Convex production deploy"
+              echo "Skipped because CONVEX_DEPLOY_KEY is not configured."
+            } >> "$GITHUB_STEP_SUMMARY"
+            exit 0
+          fi
+
+          echo "enabled=true" >> "$GITHUB_OUTPUT"
+
+      - name: Setup pnpm
+        if: steps.gate.outputs.enabled == 'true'
+        uses: pnpm/action-setup@v4
+
+      - name: Setup Node.js
+        if: steps.gate.outputs.enabled == 'true'
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: pnpm
+
+      - name: Install dependencies
+        if: steps.gate.outputs.enabled == 'true'
+        run: pnpm install --frozen-lockfile
+
+      - name: Deploy Convex functions and schema
+        if: steps.gate.outputs.enabled == 'true'
+        env:
+          CONVEX_DEPLOY_KEY: ${{ secrets.CONVEX_DEPLOY_KEY }}
+        run: pnpm exec convex deploy --yes --typecheck=enable
+
+      - name: Run deploy-time migrations
+        if: steps.gate.outputs.enabled == 'true'
+        env:
+          CONVEX_DEPLOY_KEY: ${{ secrets.CONVEX_DEPLOY_KEY }}
+        run: pnpm exec convex run migrations:runAll --prod
+
   playwright-public-preview:
     name: Playwright Public Preview
     if: github.event_name == 'pull_request'

--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,10 @@ apps/web/test-results/
 apps/web/.vercel/
 .env
 .env.local
+.terraform/
+*.tfstate
+*.tfstate.*
+terraform.tfvars
+terraform.tfvars.json
+tfplan
+tfplan.*

--- a/apps/web/.env.example
+++ b/apps/web/.env.example
@@ -1,8 +1,30 @@
 # Optional for shell-only previews. Set to a Convex deployment URL for live backend reads.
 NEXT_PUBLIC_CONVEX_URL=
 
-# Keep false until web auth is implemented.
-NEXT_PUBLIC_VRDEX_SUBMISSIONS_AUTH_READY=false
-
 # Set true in Vercel if previews must fail when NEXT_PUBLIC_CONVEX_URL is missing.
 VRDEX_REQUIRE_CONVEX_URL=false
+
+# Optional PostHog analytics. Missing values keep analytics disabled.
+NEXT_PUBLIC_POSTHOG_KEY=
+NEXT_PUBLIC_POSTHOG_HOST=
+
+# Convex Auth OAuth providers.
+AUTH_DISCORD_ID=
+AUTH_DISCORD_SECRET=
+AUTH_GOOGLE_ID=
+AUTH_GOOGLE_SECRET=
+
+# SES sender used by Convex Auth password/email verification.
+AWS_SES_REGION=
+AWS_SES_FROM_EMAIL=
+AWS_ACCESS_KEY_ID=
+AWS_SECRET_ACCESS_KEY=
+
+# Discord community claim adapter. The bot must be in claimed guilds and able to read members and roles.
+DISCORD_BOT_TOKEN=
+DISCORD_API_BASE_URL=https://discord.com/api/v10
+
+# VRChat and VRCLinking proof-code adapters. The services receive POST JSON and return { verified, evidenceSource, evidenceSummary }.
+VRCHAT_PROOF_ADAPTER_URL=
+VRCLINKING_PROOF_ADAPTER_URL=
+VRCHAT_PROOF_ADAPTER_BEARER_TOKEN=

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -17,6 +17,7 @@
     "typecheck": "next typegen && node ./scripts/ensure-next-type-stubs.mjs && tsc --noEmit --incremental false"
   },
   "dependencies": {
+    "@convex-dev/auth": "^0.0.92",
     "convex": "^1.32.0",
     "next": "16.1.6",
     "posthog-js": "^1.376.2",

--- a/apps/web/src/app/ConvexClientProvider.tsx
+++ b/apps/web/src/app/ConvexClientProvider.tsx
@@ -1,6 +1,7 @@
 "use client";
 
-import { ConvexProvider, ConvexReactClient } from "convex/react";
+import { ConvexAuthNextjsProvider } from "@convex-dev/auth/nextjs";
+import { ConvexReactClient } from "convex/react";
 import type { ReactNode } from "react";
 
 const convexUrl = process.env.NEXT_PUBLIC_CONVEX_URL;
@@ -11,5 +12,5 @@ export function ConvexClientProvider({ children }: { children: ReactNode }) {
     return children;
   }
 
-  return <ConvexProvider client={convex}>{children}</ConvexProvider>;
+  return <ConvexAuthNextjsProvider client={convex}>{children}</ConvexAuthNextjsProvider>;
 }

--- a/apps/web/src/app/account/account-panel.tsx
+++ b/apps/web/src/app/account/account-panel.tsx
@@ -1,0 +1,300 @@
+"use client";
+
+import { useAuthActions } from "@convex-dev/auth/react";
+import { useMutation, useQuery } from "convex/react";
+import Link from "next/link";
+import { FormEvent, useState, useTransition } from "react";
+
+import { api } from "@convex-generated-api";
+
+const convexUrl = process.env.NEXT_PUBLIC_CONVEX_URL;
+
+type ClaimStatus =
+  | { kind: "idle" }
+  | { kind: "submitting"; label: string }
+  | { kind: "success"; message: string; href?: string; proofCode?: string; expiresAt?: number }
+  | { kind: "error"; message: string };
+
+const claimErrorPatterns = [
+  /A verified email address is required before claim-level actions\./,
+  /A linked Discord account is required for this claim method\./,
+  /A valid profile slug is required\./,
+  /Profile not found\./,
+  /This claim method requires a (?:person|community) profile\./,
+  /This profile already has an active owner\./,
+  /VRChat user proof requires a person profile\./,
+  /VRChat group proof requires a community profile\./,
+  /A VRChat or VRCLinking target id is required\./,
+];
+
+function stringField(value: FormDataEntryValue | null): string {
+  return typeof value === "string" ? value.trim() : "";
+}
+
+function claimErrorMessage(error: unknown): string {
+  const message = error instanceof Error ? error.message : String(error);
+
+  for (const pattern of claimErrorPatterns) {
+    const match = message.match(pattern);
+
+    if (match) {
+      return match[0];
+    }
+  }
+
+  return "Claim request failed. Check the profile slug and try again.";
+}
+
+function ClaimActions({ emailVerified, hasDiscord }: { emailVerified: boolean; hasDiscord: boolean }) {
+  const claimPerson = useMutation(api.profileClaims.claimExistingPersonWithDiscord);
+  const requestCommunityClaim = useMutation(api.profileClaims.requestCommunityDiscordAdminClaim);
+  const startVrchatProof = useMutation(api.profileClaims.startVrchatProof);
+  const [status, setStatus] = useState<ClaimStatus>({ kind: "idle" });
+  const [, startTransition] = useTransition();
+
+  async function submitDiscordPersonClaim(event: FormEvent<HTMLFormElement>) {
+    event.preventDefault();
+    const formData = new FormData(event.currentTarget);
+
+    setStatus({ kind: "submitting", label: "Claiming person profile..." });
+
+    try {
+      const result = await claimPerson({ profileSlug: stringField(formData.get("profileSlug")) });
+      startTransition(() =>
+        setStatus({
+          kind: "success",
+          message: `Person profile claimed as ${result.claimState.replace(/_/g, " ")}.`,
+          href: result.profilePath,
+        }),
+      );
+      event.currentTarget.reset();
+    } catch (error) {
+      startTransition(() => setStatus({ kind: "error", message: claimErrorMessage(error) }));
+    }
+  }
+
+  async function submitCommunityDiscordClaim(event: FormEvent<HTMLFormElement>) {
+    event.preventDefault();
+    const formData = new FormData(event.currentTarget);
+
+    setStatus({ kind: "submitting", label: "Requesting community claim..." });
+
+    try {
+      const result = await requestCommunityClaim({
+        profileSlug: stringField(formData.get("profileSlug")),
+        discordGuildId: stringField(formData.get("discordGuildId")),
+        discordGuildName: stringField(formData.get("discordGuildName")) || undefined,
+      });
+      startTransition(() =>
+        setStatus({
+          kind: "success",
+          message:
+            result.state === "already_owned"
+              ? "You already own this community profile."
+              : "Community claim request created. Administrator verification still needs the Discord adapter.",
+          href: result.profilePath,
+        }),
+      );
+      event.currentTarget.reset();
+    } catch (error) {
+      startTransition(() => setStatus({ kind: "error", message: claimErrorMessage(error) }));
+    }
+  }
+
+  async function submitVrchatProof(event: FormEvent<HTMLFormElement>) {
+    event.preventDefault();
+    const formData = new FormData(event.currentTarget);
+
+    setStatus({ kind: "submitting", label: "Creating proof code..." });
+
+    try {
+      const result = await startVrchatProof({
+        profileSlug: stringField(formData.get("profileSlug")),
+        targetType: stringField(formData.get("targetType")) as "vrchat_user" | "vrchat_group" | "vrclinking",
+        targetExternalId: stringField(formData.get("targetExternalId")),
+      });
+      startTransition(() =>
+        setStatus({
+          kind: "success",
+          message: "Proof code created. Put this code where the configured adapter can read it.",
+          proofCode: result.proofCode,
+          expiresAt: result.expiresAt,
+        }),
+      );
+      event.currentTarget.reset();
+    } catch (error) {
+      startTransition(() => setStatus({ kind: "error", message: claimErrorMessage(error) }));
+    }
+  }
+
+  const disabled = !emailVerified;
+
+  return (
+    <div className="rounded-[1.5rem] border border-border bg-white/45 px-5 py-5 lg:col-span-2">
+      <p className="font-mono text-xs uppercase tracking-[0.22em] text-muted">Profile claims</p>
+      <div className="mt-3 rounded-[1rem] border border-border bg-surface-strong px-4 py-3 text-sm leading-6 text-muted">
+        Claim actions require a verified email. Discord community ownership is recorded as a pending request until the Discord Administrator adapter verifies full Administrator permission.
+      </div>
+
+      <div className="mt-5 grid gap-5 lg:grid-cols-3">
+        <form className="grid gap-3 rounded-[1.25rem] border border-border bg-surface-strong px-4 py-4" onSubmit={submitDiscordPersonClaim}>
+          <h3 className="font-semibold tracking-[-0.02em]">Discord person claim</h3>
+          <label className="grid gap-2 text-sm font-medium">
+            Person slug
+            <input className="rounded-2xl border border-border bg-surface px-4 py-3 font-normal outline-none focus:border-accent" name="profileSlug" placeholder="dj-celine" required />
+          </label>
+          <button className="rounded-full bg-accent px-4 py-3 text-sm font-medium text-white disabled:cursor-not-allowed disabled:opacity-60" disabled={disabled || !hasDiscord} type="submit">
+            Claim with Discord
+          </button>
+          {!hasDiscord ? <p className="text-xs leading-5 text-muted">Link Discord before using this method.</p> : null}
+        </form>
+
+        <form className="grid gap-3 rounded-[1.25rem] border border-border bg-surface-strong px-4 py-4" onSubmit={submitCommunityDiscordClaim}>
+          <h3 className="font-semibold tracking-[-0.02em]">Discord community claim</h3>
+          <label className="grid gap-2 text-sm font-medium">
+            Community slug
+            <input className="rounded-2xl border border-border bg-surface px-4 py-3 font-normal outline-none focus:border-accent" name="profileSlug" placeholder="afterglow-social" required />
+          </label>
+          <label className="grid gap-2 text-sm font-medium">
+            Discord guild ID
+            <input className="rounded-2xl border border-border bg-surface px-4 py-3 font-normal outline-none focus:border-accent" name="discordGuildId" required />
+          </label>
+          <label className="grid gap-2 text-sm font-medium">
+            Guild name
+            <input className="rounded-2xl border border-border bg-surface px-4 py-3 font-normal outline-none focus:border-accent" name="discordGuildName" placeholder="Optional" />
+          </label>
+          <button className="rounded-full bg-accent px-4 py-3 text-sm font-medium text-white disabled:cursor-not-allowed disabled:opacity-60" disabled={disabled || !hasDiscord} type="submit">
+            Request admin claim
+          </button>
+        </form>
+
+        <form className="grid gap-3 rounded-[1.25rem] border border-border bg-surface-strong px-4 py-4" onSubmit={submitVrchatProof}>
+          <h3 className="font-semibold tracking-[-0.02em]">VRChat proof code</h3>
+          <label className="grid gap-2 text-sm font-medium">
+            Profile slug
+            <input className="rounded-2xl border border-border bg-surface px-4 py-3 font-normal outline-none focus:border-accent" name="profileSlug" placeholder="dj-celine" required />
+          </label>
+          <label className="grid gap-2 text-sm font-medium">
+            Target type
+            <select className="rounded-2xl border border-border bg-surface px-4 py-3 font-normal outline-none focus:border-accent" name="targetType" required>
+              <option value="vrchat_user">VRChat user</option>
+              <option value="vrchat_group">VRChat group</option>
+              <option value="vrclinking">VRCLinking</option>
+            </select>
+          </label>
+          <label className="grid gap-2 text-sm font-medium">
+            Target ID
+            <input className="rounded-2xl border border-border bg-surface px-4 py-3 font-normal outline-none focus:border-accent" name="targetExternalId" required />
+          </label>
+          <button className="rounded-full bg-accent px-4 py-3 text-sm font-medium text-white disabled:cursor-not-allowed disabled:opacity-60" disabled={disabled} type="submit">
+            Create proof code
+          </button>
+        </form>
+      </div>
+
+      {status.kind === "submitting" ? <p className="mt-4 text-sm text-muted">{status.label}</p> : null}
+      {status.kind === "error" ? (
+        <p className="mt-4 rounded-[1rem] border border-accent/35 bg-accent/10 px-4 py-3 text-sm leading-6 text-accent-strong">{status.message}</p>
+      ) : null}
+      {status.kind === "success" ? (
+        <div className="mt-4 rounded-[1rem] border border-border bg-surface-strong px-4 py-3 text-sm leading-6 text-muted">
+          <p>{status.message}</p>
+          {status.proofCode ? <p className="mt-2 font-mono text-base text-foreground">{status.proofCode}</p> : null}
+          {status.expiresAt ? <p className="mt-1 text-xs">Expires {new Date(status.expiresAt).toLocaleString()}</p> : null}
+          {status.href ? (
+            <Link className="mt-3 inline-flex rounded-full border border-border bg-surface px-4 py-2 text-sm font-medium text-foreground" href={status.href}>
+              View profile
+            </Link>
+          ) : null}
+        </div>
+      ) : null}
+    </div>
+  );
+}
+
+export function AccountPanel() {
+  const viewer = useQuery(api.accounts.viewer);
+  const { signOut } = useAuthActions();
+
+  if (!convexUrl) {
+    return (
+      <div className="rounded-[1.5rem] border border-dashed border-border bg-surface-strong px-5 py-5 text-sm leading-7 text-muted">
+        Convex is not configured in this environment, so account state is unavailable.
+      </div>
+    );
+  }
+
+  if (viewer === undefined) {
+    return <p className="text-sm text-muted">Loading account...</p>;
+  }
+
+  if (viewer === null) {
+    return (
+      <div className="rounded-[1.5rem] border border-border bg-surface-strong px-5 py-5">
+        <h2 className="text-2xl font-semibold tracking-[-0.03em]">Not signed in</h2>
+        <p className="mt-3 text-sm leading-7 text-muted">
+          Sign in before submitting profiles, claiming ownership, or changing field privacy.
+        </p>
+        <Link
+          className="mt-5 inline-flex rounded-full bg-accent px-5 py-3 text-sm font-medium text-white"
+          href="/sign-in"
+        >
+          Sign in
+        </Link>
+      </div>
+    );
+  }
+
+  return (
+    <div className="grid gap-5 lg:grid-cols-[1fr_0.8fr]">
+      <div className="rounded-[1.5rem] border border-border bg-surface-strong px-5 py-5">
+        <h2 className="text-2xl font-semibold tracking-[-0.03em]">
+          {viewer.user.name ?? viewer.user.email ?? "Signed-in account"}
+        </h2>
+        <dl className="mt-5 grid gap-3 text-sm">
+          <div>
+            <dt className="font-mono text-xs uppercase tracking-[0.22em] text-muted">Email</dt>
+            <dd className="mt-1">{viewer.user.email ?? "Not provided"}</dd>
+          </div>
+          <div>
+            <dt className="font-mono text-xs uppercase tracking-[0.22em] text-muted">Email status</dt>
+            <dd className="mt-1">{viewer.user.emailVerified ? "Verified" : "Not verified"}</dd>
+          </div>
+        </dl>
+        <button
+          className="mt-5 rounded-full border border-border bg-surface px-5 py-3 text-sm font-medium"
+          type="button"
+          onClick={() => void signOut()}
+        >
+          Sign out
+        </button>
+      </div>
+
+      <div className="rounded-[1.5rem] border border-border bg-white/45 px-5 py-5">
+        <p className="font-mono text-xs uppercase tracking-[0.22em] text-muted">Linked providers</p>
+        <div className="mt-4 grid gap-3">
+          {viewer.linkedProviders.length === 0 ? (
+            <p className="text-sm text-muted">No providers linked yet.</p>
+          ) : (
+            viewer.linkedProviders.map((account) => (
+              <div
+                className="rounded-2xl border border-border bg-surface-strong px-4 py-3 text-sm"
+                key={`${account.provider}:${account.providerAccountId}`}
+              >
+                <span className="font-medium capitalize">{account.provider}</span>
+                <span className="ml-2 text-muted">
+                  {account.emailVerified ? "email verified" : "linked"}
+                </span>
+              </div>
+            ))
+          )}
+        </div>
+      </div>
+
+      <ClaimActions
+        emailVerified={viewer.user.emailVerified}
+        hasDiscord={viewer.linkedProviders.some((account) => account.provider === "discord")}
+      />
+    </div>
+  );
+}

--- a/apps/web/src/app/account/account-panel.tsx
+++ b/apps/web/src/app/account/account-panel.tsx
@@ -78,7 +78,10 @@ function ClaimActions({ emailVerified, hasDiscord }: { emailVerified: boolean; h
       startTransition(() =>
         setStatus({
           kind: "success",
-          message: `Person profile claimed as ${result.claimState.replace(/_/g, " ")}.`,
+          message:
+            "state" in result && result.state === "already_owned"
+              ? "You already own this person profile."
+              : `Person profile claimed as ${result.claimState.replace(/_/g, " ")}.`,
           href: result.profilePath,
         }),
       );

--- a/apps/web/src/app/account/account-panel.tsx
+++ b/apps/web/src/app/account/account-panel.tsx
@@ -1,18 +1,27 @@
 "use client";
 
 import { useAuthActions } from "@convex-dev/auth/react";
-import { useMutation, useQuery } from "convex/react";
+import { useAction, useMutation, useQuery } from "convex/react";
 import Link from "next/link";
 import { FormEvent, useState, useTransition } from "react";
 
 import { api } from "@convex-generated-api";
+import type { Id } from "../../../../../convex/_generated/dataModel";
 
 const convexUrl = process.env.NEXT_PUBLIC_CONVEX_URL;
 
 type ClaimStatus =
   | { kind: "idle" }
   | { kind: "submitting"; label: string }
-  | { kind: "success"; message: string; href?: string; proofCode?: string; expiresAt?: number }
+  | {
+      kind: "success";
+      message: string;
+      href?: string;
+      proofCode?: string;
+      expiresAt?: number;
+      claimRequestId?: Id<"profileClaimRequests">;
+      attemptId?: Id<"profileVerificationAttempts">;
+    }
   | { kind: "error"; message: string };
 
 const claimErrorPatterns = [
@@ -25,6 +34,10 @@ const claimErrorPatterns = [
   /VRChat user proof requires a person profile\./,
   /VRChat group proof requires a community profile\./,
   /A VRChat or VRCLinking target id is required\./,
+  /DISCORD_BOT_TOKEN is not configured\./,
+  /Discord API returned HTTP \d+\./,
+  /VRCHAT_PROOF_ADAPTER_URL is not configured\./,
+  /VRCLINKING_PROOF_ADAPTER_URL is not configured\./,
 ];
 
 function stringField(value: FormDataEntryValue | null): string {
@@ -46,6 +59,8 @@ function claimErrorMessage(error: unknown): string {
 }
 
 function ClaimActions({ emailVerified, hasDiscord }: { emailVerified: boolean; hasDiscord: boolean }) {
+  const verifyDiscordAdmin = useAction(api.profileClaims.verifyDiscordCommunityAdminClaim);
+  const verifyVrchatProof = useAction(api.profileClaims.verifyVrchatProofViaAdapter);
   const claimPerson = useMutation(api.profileClaims.claimExistingPersonWithDiscord);
   const requestCommunityClaim = useMutation(api.profileClaims.requestCommunityDiscordAdminClaim);
   const startVrchatProof = useMutation(api.profileClaims.startVrchatProof);
@@ -93,6 +108,7 @@ function ClaimActions({ emailVerified, hasDiscord }: { emailVerified: boolean; h
               ? "You already own this community profile."
               : "Community claim request created. Administrator verification still needs the Discord adapter.",
           href: result.profilePath,
+          ...("claimRequestId" in result ? { claimRequestId: result.claimRequestId } : {}),
         }),
       );
       event.currentTarget.reset();
@@ -119,9 +135,48 @@ function ClaimActions({ emailVerified, hasDiscord }: { emailVerified: boolean; h
           message: "Proof code created. Put this code where the configured adapter can read it.",
           proofCode: result.proofCode,
           expiresAt: result.expiresAt,
+          attemptId: result.attemptId,
         }),
       );
       event.currentTarget.reset();
+    } catch (error) {
+      startTransition(() => setStatus({ kind: "error", message: claimErrorMessage(error) }));
+    }
+  }
+
+  async function verifyPendingDiscordAdminClaim(claimRequestId: Id<"profileClaimRequests">) {
+    setStatus({ kind: "submitting", label: "Checking Discord Administrator permission..." });
+
+    try {
+      const result = await verifyDiscordAdmin({ claimRequestId });
+      startTransition(() =>
+        setStatus({
+          kind: "success",
+          message:
+            "claimState" in result
+              ? `Community claim verified as ${result.claimState.replace(/_/g, " ")}.`
+              : "Discord Administrator permission was not verified.",
+        }),
+      );
+    } catch (error) {
+      startTransition(() => setStatus({ kind: "error", message: claimErrorMessage(error) }));
+    }
+  }
+
+  async function verifyPendingVrchatProof(attemptId: Id<"profileVerificationAttempts">) {
+    setStatus({ kind: "submitting", label: "Checking proof code..." });
+
+    try {
+      const result = await verifyVrchatProof({ attemptId });
+      startTransition(() =>
+        setStatus({
+          kind: "success",
+          message:
+            "claimState" in result
+              ? `Proof verified as ${result.claimState.replace(/_/g, " ")}.`
+              : `Proof check finished with state ${result.state}.`,
+        }),
+      );
     } catch (error) {
       startTransition(() => setStatus({ kind: "error", message: claimErrorMessage(error) }));
     }
@@ -201,6 +256,24 @@ function ClaimActions({ emailVerified, hasDiscord }: { emailVerified: boolean; h
           <p>{status.message}</p>
           {status.proofCode ? <p className="mt-2 font-mono text-base text-foreground">{status.proofCode}</p> : null}
           {status.expiresAt ? <p className="mt-1 text-xs">Expires {new Date(status.expiresAt).toLocaleString()}</p> : null}
+          {status.claimRequestId ? (
+            <button
+              className="mt-3 mr-3 inline-flex rounded-full border border-border bg-surface px-4 py-2 text-sm font-medium text-foreground"
+              type="button"
+              onClick={() => void verifyPendingDiscordAdminClaim(status.claimRequestId!)}
+            >
+              Check Discord admin
+            </button>
+          ) : null}
+          {status.attemptId ? (
+            <button
+              className="mt-3 mr-3 inline-flex rounded-full border border-border bg-surface px-4 py-2 text-sm font-medium text-foreground"
+              type="button"
+              onClick={() => void verifyPendingVrchatProof(status.attemptId!)}
+            >
+              Check proof now
+            </button>
+          ) : null}
           {status.href ? (
             <Link className="mt-3 inline-flex rounded-full border border-border bg-surface px-4 py-2 text-sm font-medium text-foreground" href={status.href}>
               View profile
@@ -212,17 +285,9 @@ function ClaimActions({ emailVerified, hasDiscord }: { emailVerified: boolean; h
   );
 }
 
-export function AccountPanel() {
+function ConnectedAccountPanel() {
   const viewer = useQuery(api.accounts.viewer);
   const { signOut } = useAuthActions();
-
-  if (!convexUrl) {
-    return (
-      <div className="rounded-[1.5rem] border border-dashed border-border bg-surface-strong px-5 py-5 text-sm leading-7 text-muted">
-        Convex is not configured in this environment, so account state is unavailable.
-      </div>
-    );
-  }
 
   if (viewer === undefined) {
     return <p className="text-sm text-muted">Loading account...</p>;
@@ -297,4 +362,16 @@ export function AccountPanel() {
       />
     </div>
   );
+}
+
+export function AccountPanel() {
+  if (!convexUrl) {
+    return (
+      <div className="rounded-[1.5rem] border border-dashed border-border bg-surface-strong px-5 py-5 text-sm leading-7 text-muted">
+        Convex is not configured in this environment, so account state is unavailable.
+      </div>
+    );
+  }
+
+  return <ConnectedAccountPanel />;
 }

--- a/apps/web/src/app/account/account-panel.tsx
+++ b/apps/web/src/app/account/account-panel.tsx
@@ -3,7 +3,7 @@
 import { useAuthActions } from "@convex-dev/auth/react";
 import { useAction, useMutation, useQuery } from "convex/react";
 import Link from "next/link";
-import { FormEvent, useState, useTransition } from "react";
+import { Component, FormEvent, ReactNode, useState, useTransition } from "react";
 
 import { api } from "@convex-generated-api";
 import type { Id } from "../../../../../convex/_generated/dataModel";
@@ -364,6 +364,29 @@ function ConnectedAccountPanel() {
   );
 }
 
+class AccountPanelErrorBoundary extends Component<
+  { children: ReactNode },
+  { hasError: boolean }
+> {
+  state = { hasError: false };
+
+  static getDerivedStateFromError() {
+    return { hasError: true };
+  }
+
+  render() {
+    if (this.state.hasError) {
+      return (
+        <div className="rounded-[1.5rem] border border-dashed border-border bg-surface-strong px-5 py-5 text-sm leading-7 text-muted">
+          Account state is temporarily unavailable because the backend query failed. Try again after the Convex deployment finishes.
+        </div>
+      );
+    }
+
+    return this.props.children;
+  }
+}
+
 export function AccountPanel() {
   if (!convexUrl) {
     return (
@@ -373,5 +396,9 @@ export function AccountPanel() {
     );
   }
 
-  return <ConnectedAccountPanel />;
+  return (
+    <AccountPanelErrorBoundary>
+      <ConnectedAccountPanel />
+    </AccountPanelErrorBoundary>
+  );
 }

--- a/apps/web/src/app/account/page.tsx
+++ b/apps/web/src/app/account/page.tsx
@@ -1,0 +1,32 @@
+import Link from "next/link";
+
+import { AccountPanel } from "./account-panel";
+
+export default function AccountPage() {
+  return (
+    <main className="min-h-screen px-6 py-10 text-foreground sm:px-10 lg:px-16">
+      <div className="mx-auto flex w-full max-w-5xl flex-col gap-6">
+        <nav className="flex flex-wrap items-center justify-between gap-3 text-sm">
+          <Link className="font-mono uppercase tracking-[0.28em] text-muted" href="/">
+            VRDex
+          </Link>
+          <Link className="rounded-full border border-border bg-surface px-4 py-2 font-medium" href="/sign-in">
+            Sign in
+          </Link>
+        </nav>
+
+        <section className="rounded-[2rem] border border-border bg-surface px-6 py-8 shadow-[0_24px_80px_rgba(64,40,24,0.12)] sm:px-8 lg:px-10">
+          <p className="font-mono text-xs uppercase tracking-[0.28em] text-muted">
+            Account
+          </p>
+          <h1 className="mt-5 text-4xl leading-none font-semibold tracking-[-0.04em] sm:text-6xl">
+            Your VRDex account and claim readiness.
+          </h1>
+          <div className="mt-8">
+            <AccountPanel />
+          </div>
+        </section>
+      </div>
+    </main>
+  );
+}

--- a/apps/web/src/app/layout.tsx
+++ b/apps/web/src/app/layout.tsx
@@ -1,4 +1,5 @@
 import type { Metadata } from "next";
+import { ConvexAuthNextjsServerProvider } from "@convex-dev/auth/nextjs/server";
 import { IBM_Plex_Mono, Space_Grotesk } from "next/font/google";
 import { ConvexClientProvider } from "./ConvexClientProvider";
 import { PostHogProvider } from "./PostHogProvider";
@@ -25,7 +26,7 @@ export default function RootLayout({
 }: Readonly<{
   children: React.ReactNode;
 }>) {
-  return (
+  const shell = (
     <html lang="en">
       <body
         className={`${spaceGrotesk.variable} ${ibmPlexMono.variable} antialiased`}
@@ -36,4 +37,10 @@ export default function RootLayout({
       </body>
     </html>
   );
+
+  if (!process.env.NEXT_PUBLIC_CONVEX_URL) {
+    return shell;
+  }
+
+  return <ConvexAuthNextjsServerProvider>{shell}</ConvexAuthNextjsServerProvider>;
 }

--- a/apps/web/src/app/sign-in/page.tsx
+++ b/apps/web/src/app/sign-in/page.tsx
@@ -1,0 +1,40 @@
+import Link from "next/link";
+
+import { SignInForm } from "./sign-in-form";
+
+export default function SignInPage() {
+  return (
+    <main className="min-h-screen px-6 py-10 text-foreground sm:px-10 lg:px-16">
+      <div className="mx-auto flex w-full max-w-4xl flex-col gap-6">
+        <nav className="flex flex-wrap items-center justify-between gap-3 text-sm">
+          <Link className="font-mono uppercase tracking-[0.28em] text-muted" href="/">
+            VRDex
+          </Link>
+          <Link className="rounded-full border border-border bg-surface px-4 py-2 font-medium" href="/account">
+            Account
+          </Link>
+        </nav>
+
+        <section className="overflow-hidden rounded-[2rem] border border-border bg-surface shadow-[0_24px_80px_rgba(64,40,24,0.12)] backdrop-blur">
+          <div className="grid gap-8 px-6 py-8 sm:px-8 lg:grid-cols-[0.9fr_1.1fr] lg:px-10 lg:py-10">
+            <div>
+              <p className="font-mono text-xs uppercase tracking-[0.28em] text-muted">
+                Account access
+              </p>
+              <h1 className="mt-5 text-4xl leading-none font-semibold tracking-[-0.04em] sm:text-6xl">
+                Sign in to claim and manage profiles.
+              </h1>
+              <p className="mt-5 max-w-xl text-base leading-7 text-muted sm:text-lg">
+                Use Discord, Google, or verified email/password. Claims and owner controls stay separate from the login provider so VRDex can accept multiple proof sources over time.
+              </p>
+            </div>
+
+            <div className="rounded-[1.5rem] border border-border bg-white/45 px-5 py-6 sm:px-6">
+              <SignInForm />
+            </div>
+          </div>
+        </section>
+      </div>
+    </main>
+  );
+}

--- a/apps/web/src/app/sign-in/sign-in-form.tsx
+++ b/apps/web/src/app/sign-in/sign-in-form.tsx
@@ -1,0 +1,187 @@
+"use client";
+
+import { useAuthActions } from "@convex-dev/auth/react";
+import { FormEvent, useState, useTransition } from "react";
+
+type PasswordMode = "signIn" | "signUp" | "email-verification";
+
+type AuthStatus =
+  | { kind: "idle" }
+  | { kind: "submitting" }
+  | { kind: "verify-email"; email: string }
+  | { kind: "error"; message: string };
+
+const convexUrl = process.env.NEXT_PUBLIC_CONVEX_URL;
+
+function authErrorMessage(error: unknown) {
+  const message = error instanceof Error ? error.message : String(error);
+
+  if (/Password must be at least \d+ characters\./.test(message)) {
+    return message.match(/Password must be at least \d+ characters\./)?.[0] ?? message;
+  }
+
+  if (/Invalid credentials/.test(message)) {
+    return "Email or password did not match.";
+  }
+
+  if (/Email is required\./.test(message)) {
+    return "Email is required.";
+  }
+
+  return "Sign-in failed. Check your details and try again.";
+}
+
+function stringField(value: FormDataEntryValue | null): string {
+  return typeof value === "string" ? value.trim() : "";
+}
+
+export function SignInForm() {
+  const { signIn } = useAuthActions();
+  const [mode, setMode] = useState<PasswordMode>("signIn");
+  const [status, setStatus] = useState<AuthStatus>({ kind: "idle" });
+  const [, startTransition] = useTransition();
+
+  if (!convexUrl) {
+    return (
+      <div className="rounded-[1.25rem] border border-dashed border-border bg-surface px-4 py-5 text-sm leading-7 text-muted">
+        Convex is not configured in this environment, so sign-in is disabled.
+      </div>
+    );
+  }
+
+  async function submitPassword(event: FormEvent<HTMLFormElement>) {
+    event.preventDefault();
+    const form = event.currentTarget;
+    const formData = new FormData(form);
+    const email = stringField(formData.get("email")).toLowerCase();
+
+    setStatus({ kind: "submitting" });
+
+    try {
+      if (mode === "email-verification") {
+        await signIn("password", {
+          email,
+          code: stringField(formData.get("code")),
+          flow: "email-verification",
+        });
+        return;
+      }
+
+      await signIn("password", {
+        email,
+        password: stringField(formData.get("password")),
+        flow: mode,
+      });
+
+      startTransition(() => setStatus({ kind: "verify-email", email }));
+      setMode("email-verification");
+    } catch (error) {
+      startTransition(() => setStatus({ kind: "error", message: authErrorMessage(error) }));
+    }
+  }
+
+  const isSubmitting = status.kind === "submitting";
+
+  return (
+    <div className="grid gap-5">
+      <div className="grid gap-3 sm:grid-cols-2">
+        <button
+          className="rounded-full bg-[#5865f2] px-5 py-3 text-sm font-medium text-white transition hover:brightness-95"
+          type="button"
+          onClick={() => void signIn("discord", { redirectTo: "/account" })}
+        >
+          Continue with Discord
+        </button>
+        <button
+          className="rounded-full border border-border bg-surface-strong px-5 py-3 text-sm font-medium transition hover:border-accent"
+          type="button"
+          onClick={() => void signIn("google", { redirectTo: "/account" })}
+        >
+          Continue with Google
+        </button>
+      </div>
+
+      <div className="flex items-center gap-3 text-xs font-mono uppercase tracking-[0.22em] text-muted">
+        <span className="h-px flex-1 bg-border" />
+        Email password
+        <span className="h-px flex-1 bg-border" />
+      </div>
+
+      <form className="grid gap-4" onSubmit={submitPassword}>
+        <input name="flow" type="hidden" value={mode} />
+        <label className="grid gap-2 text-sm font-medium">
+          Email
+          <input
+            className="rounded-2xl border border-border bg-surface-strong px-4 py-3 font-normal outline-none transition placeholder:text-muted/65 focus:border-accent"
+            name="email"
+            placeholder="you@example.com"
+            required
+            type="email"
+            defaultValue={status.kind === "verify-email" ? status.email : undefined}
+          />
+        </label>
+
+        {mode === "email-verification" ? (
+          <label className="grid gap-2 text-sm font-medium">
+            Verification code
+            <input
+              className="rounded-2xl border border-border bg-surface-strong px-4 py-3 font-normal outline-none transition placeholder:text-muted/65 focus:border-accent"
+              name="code"
+              placeholder="12345678"
+              required
+            />
+          </label>
+        ) : (
+          <label className="grid gap-2 text-sm font-medium">
+            Password
+            <input
+              className="rounded-2xl border border-border bg-surface-strong px-4 py-3 font-normal outline-none transition placeholder:text-muted/65 focus:border-accent"
+              name="password"
+              minLength={12}
+              required
+              type="password"
+            />
+          </label>
+        )}
+
+        <div className="flex flex-col gap-3 sm:flex-row sm:items-center">
+          <button
+            className="inline-flex items-center justify-center rounded-full bg-accent px-5 py-3 text-sm font-medium text-white transition hover:bg-accent-strong disabled:cursor-not-allowed disabled:opacity-60"
+            disabled={isSubmitting}
+            type="submit"
+          >
+            {isSubmitting
+              ? "Working..."
+              : mode === "signUp"
+                ? "Create account"
+                : mode === "email-verification"
+                  ? "Verify email"
+                  : "Sign in"}
+          </button>
+          <button
+            className="rounded-full border border-border bg-surface-strong px-5 py-3 text-sm font-medium"
+            type="button"
+            onClick={() => {
+              setStatus({ kind: "idle" });
+              setMode(mode === "signIn" ? "signUp" : "signIn");
+            }}
+          >
+            {mode === "signIn" ? "Create account" : "Use existing account"}
+          </button>
+        </div>
+
+        {status.kind === "verify-email" ? (
+          <p className="rounded-[1rem] border border-border bg-surface-strong px-4 py-3 text-sm leading-6 text-muted">
+            Check {status.email} for a verification code before claim-level actions.
+          </p>
+        ) : null}
+
+        {status.kind === "error" ? (
+          <p className="rounded-[1rem] border border-accent/35 bg-accent/10 px-4 py-3 text-sm leading-6 text-accent-strong">
+            {status.message}
+          </p>
+        ) : null}
+      </form>
+    </div>
+  );
+}

--- a/apps/web/src/app/sign-in/sign-in-form.tsx
+++ b/apps/web/src/app/sign-in/sign-in-form.tsx
@@ -35,19 +35,11 @@ function stringField(value: FormDataEntryValue | null): string {
   return typeof value === "string" ? value.trim() : "";
 }
 
-export function SignInForm() {
+function ConnectedSignInForm() {
   const { signIn } = useAuthActions();
   const [mode, setMode] = useState<PasswordMode>("signIn");
   const [status, setStatus] = useState<AuthStatus>({ kind: "idle" });
   const [, startTransition] = useTransition();
-
-  if (!convexUrl) {
-    return (
-      <div className="rounded-[1.25rem] border border-dashed border-border bg-surface px-4 py-5 text-sm leading-7 text-muted">
-        Convex is not configured in this environment, so sign-in is disabled.
-      </div>
-    );
-  }
 
   async function submitPassword(event: FormEvent<HTMLFormElement>) {
     event.preventDefault();
@@ -184,4 +176,16 @@ export function SignInForm() {
       </form>
     </div>
   );
+}
+
+export function SignInForm() {
+  if (!convexUrl) {
+    return (
+      <div className="rounded-[1.25rem] border border-dashed border-border bg-surface px-4 py-5 text-sm leading-7 text-muted">
+        Convex is not configured in this environment, so sign-in is disabled.
+      </div>
+    );
+  }
+
+  return <ConnectedSignInForm />;
 }

--- a/apps/web/src/app/submit/profile-submission-form.tsx
+++ b/apps/web/src/app/submit/profile-submission-form.tsx
@@ -257,12 +257,8 @@ function ConnectedSubmissionForm() {
   );
 }
 
-export function ProfileSubmissionForm() {
+function AuthenticatedProfileSubmissionForm() {
   const { isAuthenticated, isLoading } = useConvexAuth();
-
-  if (!convexUrl) {
-    return <DisabledSubmissionPanel />;
-  }
 
   if (isLoading) {
     return <p className="text-sm text-muted">Loading sign-in state...</p>;
@@ -273,4 +269,12 @@ export function ProfileSubmissionForm() {
   }
 
   return <ConnectedSubmissionForm />;
+}
+
+export function ProfileSubmissionForm() {
+  if (!convexUrl) {
+    return <DisabledSubmissionPanel />;
+  }
+
+  return <AuthenticatedProfileSubmissionForm />;
 }

--- a/apps/web/src/app/submit/profile-submission-form.tsx
+++ b/apps/web/src/app/submit/profile-submission-form.tsx
@@ -2,11 +2,10 @@
 
 import Link from "next/link";
 import { FormEvent, useState, useTransition } from "react";
-import { useMutation } from "convex/react";
+import { useConvexAuth, useMutation } from "convex/react";
 import { api } from "@convex-generated-api";
 
 const convexUrl = process.env.NEXT_PUBLIC_CONVEX_URL;
-const submissionsAuthReady = process.env.NEXT_PUBLIC_VRDEX_SUBMISSIONS_AUTH_READY === "true";
 
 type ProfileType = "person" | "community";
 
@@ -88,8 +87,11 @@ function SignInRequiredSubmissionPanel() {
         Sign-in required
       </h2>
       <p className="mt-3 text-sm leading-7 text-muted">
-        The backend submission mutation is ready, but the public form stays locked until Convex auth is wired into the web app. This avoids exposing a form that can only fail for anonymous visitors.
+        Sign in before submitting profile records. Community submissions create unclaimed profiles with narrow source attribution and safe public fields.
       </p>
+      <Link className="mt-5 inline-flex rounded-full bg-accent px-5 py-3 text-sm font-medium text-white" href="/sign-in">
+        Sign in
+      </Link>
     </div>
   );
 }
@@ -256,11 +258,17 @@ function ConnectedSubmissionForm() {
 }
 
 export function ProfileSubmissionForm() {
+  const { isAuthenticated, isLoading } = useConvexAuth();
+
   if (!convexUrl) {
     return <DisabledSubmissionPanel />;
   }
 
-  if (!submissionsAuthReady) {
+  if (isLoading) {
+    return <p className="text-sm text-muted">Loading sign-in state...</p>;
+  }
+
+  if (!isAuthenticated) {
     return <SignInRequiredSubmissionPanel />;
   }
 

--- a/apps/web/src/middleware.ts
+++ b/apps/web/src/middleware.ts
@@ -1,0 +1,12 @@
+import { convexAuthNextjsMiddleware } from "@convex-dev/auth/nextjs/server";
+import { NextResponse } from "next/server";
+
+export default process.env.NEXT_PUBLIC_CONVEX_URL
+  ? convexAuthNextjsMiddleware()
+  : function middleware() {
+      return NextResponse.next();
+    };
+
+export const config = {
+  matcher: ["/((?!.*\\..*|_next).*)", "/", "/(api|trpc)(.*)"],
+};

--- a/convex/README.md
+++ b/convex/README.md
@@ -4,11 +4,16 @@ This directory holds the initial Convex backend slice for `VRDex`.
 
 - `health.ts` exposes the placeholder public query `health:status`
 - `schema.ts` defines the base `profiles` table for people/communities and the first `worlds` table
+- `auth.ts` and `http.ts` configure Convex Auth providers and HTTP routes
+- `accounts.ts` exposes current viewer and linked-provider helpers
 - `_profileSlugs.ts` contains pure profile slug validation, generation, and lookup helpers
 - `_profileStates.ts` contains pure claim-state and trust-label helpers
 - `_profilePermissions.ts` contains pure profile read/write permission baseline helpers
+- `_profileFieldVisibility.ts` contains public, unlisted, and private field visibility helpers
+- `_profileOwnership.ts` contains profile owner singleton and claim approval helpers
 - `_profilePublic.ts` contains public profile projection helpers
 - `_profileSubmissions.ts` contains community submission sanitization helpers
+- `profileClaims.ts` exposes claim request, Discord, and VRChat proof-code flows
 - `profiles.ts` exposes public profile reads and authenticated community submission mutations
 - `_worldIds.ts` contains VRChat world id and canonical URL helpers
 - `_worldSlugs.ts` contains pure world slug validation, generation, and lookup helpers
@@ -16,7 +21,7 @@ This directory holds the initial Convex backend slice for `VRDex`.
 - `worlds.ts` exposes public world reads
 - `_eventSlugs.ts`, `_eventInputs.ts`, and `_eventPublic.ts` contain event slug, input, and public projection helpers
 - `events.ts` exposes public event reads and authenticated event editor mutations
-- `migrations.ts` contains internal one-off data backfills for schema additions
+- `migrations.ts` contains deploy-time data backfills for schema additions
 - `_searchDocuments.ts`, `_vocabulary.ts`, `search.ts`, and `suppressions.ts` contain public discovery, vocabulary, and suppression helpers
 - `_generated/` contains committed Convex codegen output and should not be edited by hand
 - `tsconfig.json` is the Convex-managed TypeScript config for backend functions

--- a/convex/_generated/api.d.ts
+++ b/convex/_generated/api.d.ts
@@ -12,6 +12,8 @@ import type * as _communityAuthority from "../_communityAuthority.js";
 import type * as _eventInputs from "../_eventInputs.js";
 import type * as _eventPublic from "../_eventPublic.js";
 import type * as _eventSlugs from "../_eventSlugs.js";
+import type * as _profileFieldVisibility from "../_profileFieldVisibility.js";
+import type * as _profileOwnership from "../_profileOwnership.js";
 import type * as _profilePermissions from "../_profilePermissions.js";
 import type * as _profilePublic from "../_profilePublic.js";
 import type * as _profileSlugs from "../_profileSlugs.js";
@@ -25,9 +27,13 @@ import type * as _worldEvents from "../_worldEvents.js";
 import type * as _worldIds from "../_worldIds.js";
 import type * as _worldPublic from "../_worldPublic.js";
 import type * as _worldSlugs from "../_worldSlugs.js";
+import type * as accounts from "../accounts.js";
+import type * as auth from "../auth.js";
 import type * as events from "../events.js";
 import type * as health from "../health.js";
+import type * as http from "../http.js";
 import type * as migrations from "../migrations.js";
+import type * as profileClaims from "../profileClaims.js";
 import type * as profiles from "../profiles.js";
 import type * as search from "../search.js";
 import type * as suppressions from "../suppressions.js";
@@ -44,6 +50,8 @@ declare const fullApi: ApiFromModules<{
   _eventInputs: typeof _eventInputs;
   _eventPublic: typeof _eventPublic;
   _eventSlugs: typeof _eventSlugs;
+  _profileFieldVisibility: typeof _profileFieldVisibility;
+  _profileOwnership: typeof _profileOwnership;
   _profilePermissions: typeof _profilePermissions;
   _profilePublic: typeof _profilePublic;
   _profileSlugs: typeof _profileSlugs;
@@ -57,9 +65,13 @@ declare const fullApi: ApiFromModules<{
   _worldIds: typeof _worldIds;
   _worldPublic: typeof _worldPublic;
   _worldSlugs: typeof _worldSlugs;
+  accounts: typeof accounts;
+  auth: typeof auth;
   events: typeof events;
   health: typeof health;
+  http: typeof http;
   migrations: typeof migrations;
+  profileClaims: typeof profileClaims;
   profiles: typeof profiles;
   search: typeof search;
   suppressions: typeof suppressions;
@@ -92,4 +104,92 @@ export declare const internal: FilterApi<
   FunctionReference<any, "internal">
 >;
 
-export declare const components: {};
+export declare const components: {
+  migrations: {
+    lib: {
+      cancel: FunctionReference<
+        "mutation",
+        "internal",
+        { name: string },
+        {
+          batchSize?: number;
+          cursor?: string | null;
+          error?: string;
+          isDone: boolean;
+          latestEnd?: number;
+          latestStart: number;
+          name: string;
+          next?: Array<string>;
+          processed: number;
+          state: "inProgress" | "success" | "failed" | "canceled" | "unknown";
+        }
+      >;
+      cancelAll: FunctionReference<
+        "mutation",
+        "internal",
+        { sinceTs?: number },
+        Array<{
+          batchSize?: number;
+          cursor?: string | null;
+          error?: string;
+          isDone: boolean;
+          latestEnd?: number;
+          latestStart: number;
+          name: string;
+          next?: Array<string>;
+          processed: number;
+          state: "inProgress" | "success" | "failed" | "canceled" | "unknown";
+        }>
+      >;
+      clearAll: FunctionReference<
+        "mutation",
+        "internal",
+        { before?: number },
+        null
+      >;
+      getStatus: FunctionReference<
+        "query",
+        "internal",
+        { limit?: number; names?: Array<string> },
+        Array<{
+          batchSize?: number;
+          cursor?: string | null;
+          error?: string;
+          isDone: boolean;
+          latestEnd?: number;
+          latestStart: number;
+          name: string;
+          next?: Array<string>;
+          processed: number;
+          state: "inProgress" | "success" | "failed" | "canceled" | "unknown";
+        }>
+      >;
+      migrate: FunctionReference<
+        "mutation",
+        "internal",
+        {
+          batchSize?: number;
+          cursor?: string | null;
+          dryRun: boolean;
+          fnHandle: string;
+          name: string;
+          next?: Array<{ fnHandle: string; name: string }>;
+          oneBatchOnly?: boolean;
+          reset?: boolean;
+        },
+        {
+          batchSize?: number;
+          cursor?: string | null;
+          error?: string;
+          isDone: boolean;
+          latestEnd?: number;
+          latestStart: number;
+          name: string;
+          next?: Array<string>;
+          processed: number;
+          state: "inProgress" | "success" | "failed" | "canceled" | "unknown";
+        }
+      >;
+    };
+  };
+};

--- a/convex/_profileFieldVisibility.ts
+++ b/convex/_profileFieldVisibility.ts
@@ -1,0 +1,61 @@
+import type { Doc } from "./_generated/dataModel";
+
+export type ProfileFieldVisibilityKey =
+  | "aliases"
+  | "tags"
+  | "headline"
+  | "bio"
+  | "about"
+  | "avatarImageUrl"
+  | "bannerImageUrl"
+  | "outboundLinks"
+  | "region"
+  | "timezone"
+  | "personPronouns"
+  | "personRoleTags"
+  | "communitySubtype"
+  | "communityCategoryTags";
+
+export type ProfileVisibilitySurface = "profile_page" | "discovery";
+export type ProfileFieldVisibilityState = "public" | "unlisted" | "private";
+
+type ProfileVisibilitySource = Pick<Doc<"profiles">, "fieldVisibility">;
+
+export function getProfileFieldVisibility(
+  profile: ProfileVisibilitySource,
+  key: ProfileFieldVisibilityKey,
+): ProfileFieldVisibilityState {
+  return profile.fieldVisibility?.[key] ?? "public";
+}
+
+export function isProfileFieldVisible(
+  profile: ProfileVisibilitySource,
+  key: ProfileFieldVisibilityKey,
+  surface: ProfileVisibilitySurface,
+): boolean {
+  const visibility = getProfileFieldVisibility(profile, key);
+
+  if (visibility === "private") {
+    return false;
+  }
+
+  return surface === "profile_page" || visibility === "public";
+}
+
+export function visibleProfileField<T>(
+  profile: ProfileVisibilitySource,
+  key: ProfileFieldVisibilityKey,
+  value: T | undefined,
+  surface: ProfileVisibilitySurface,
+): T | undefined {
+  return isProfileFieldVisible(profile, key, surface) ? value : undefined;
+}
+
+export function visibleProfileList<T>(
+  profile: ProfileVisibilitySource,
+  key: ProfileFieldVisibilityKey,
+  values: T[],
+  surface: ProfileVisibilitySurface,
+): T[] {
+  return isProfileFieldVisible(profile, key, surface) ? values : [];
+}

--- a/convex/_profileOwnership.ts
+++ b/convex/_profileOwnership.ts
@@ -1,0 +1,108 @@
+import type { Doc, Id } from "./_generated/dataModel";
+import type { DatabaseReader, DatabaseWriter } from "./_generated/server";
+import type { AuthSubject } from "./_communityAuthority";
+import { requireProfileClaimStateTransition } from "./_profileStates";
+
+type GrantProfileOwnerOptions = {
+  profileId: Id<"profiles">;
+  userId: Id<"users">;
+  grantedByClaimRequestId?: Id<"profileClaimRequests">;
+  now: number;
+};
+
+type ApproveProfileClaimOptions = GrantProfileOwnerOptions & {
+  profile: Doc<"profiles">;
+  verified: boolean;
+  actor?: AuthSubject;
+  note?: string;
+};
+
+export async function getActiveProfileOwner(db: DatabaseReader, profileId: Id<"profiles">) {
+  const owners = await db
+    .query("profileOwners")
+    .withIndex("by_profileId_roleKey_state", (query) =>
+      query.eq("profileId", profileId).eq("roleKey", "owner").eq("state", "active"),
+    )
+    .take(1);
+
+  return owners[0] ?? null;
+}
+
+export async function getActiveProfileOwnerForUser(
+  db: DatabaseReader,
+  profileId: Id<"profiles">,
+  userId: Id<"users">,
+) {
+  const owners = await db
+    .query("profileOwners")
+    .withIndex("by_userId_state", (query) => query.eq("userId", userId).eq("state", "active"))
+    .filter((query) => query.eq(query.field("profileId"), profileId))
+    .take(1);
+
+  return owners[0] ?? null;
+}
+
+export async function userOwnsProfile(
+  db: DatabaseReader,
+  profileId: Id<"profiles">,
+  userId: Id<"users">,
+): Promise<boolean> {
+  return (await getActiveProfileOwnerForUser(db, profileId, userId)) !== null;
+}
+
+export async function grantProfileOwner(db: DatabaseWriter, options: GrantProfileOwnerOptions) {
+  const existingOwner = await getActiveProfileOwner(db, options.profileId);
+
+  if (existingOwner !== null) {
+    if (existingOwner.userId === options.userId) {
+      return existingOwner._id;
+    }
+
+    throw new Error("This profile already has an active owner.");
+  }
+
+  return await db.insert("profileOwners", {
+    profileId: options.profileId,
+    userId: options.userId,
+    roleKey: "owner",
+    state: "active",
+    ...(options.grantedByClaimRequestId !== undefined
+      ? { grantedByClaimRequestId: options.grantedByClaimRequestId }
+      : {}),
+    grantedAt: options.now,
+    updatedAt: options.now,
+  });
+}
+
+export async function approveProfileClaimForUser(
+  db: DatabaseWriter,
+  options: ApproveProfileClaimOptions,
+) {
+  const targetClaimState =
+    options.profile.claimState === "claimed_verified"
+      ? "claimed_verified"
+      : options.verified
+        ? "claimed_verified"
+        : "claimed_unverified";
+
+  await grantProfileOwner(db, options);
+
+  if (options.profile.claimState !== targetClaimState) {
+    requireProfileClaimStateTransition(options.profile.claimState, targetClaimState);
+
+    await db.patch(options.profileId, {
+      claimState: targetClaimState,
+      claimedAt: options.profile.claimedAt ?? options.now,
+      updatedAt: options.now,
+    });
+  }
+
+  await db.insert("profileAuditEvents", {
+    profileId: options.profileId,
+    action: targetClaimState === "claimed_verified" ? "profile_claim_verified" : "profile_claim_approved_unverified",
+    ...(options.actor !== undefined ? { actor: options.actor } : {}),
+    sourceType: "owner",
+    ...(options.note !== undefined ? { note: options.note } : {}),
+    createdAt: options.now,
+  });
+}

--- a/convex/_profilePublic.ts
+++ b/convex/_profilePublic.ts
@@ -1,6 +1,14 @@
 import type { Doc } from "./_generated/dataModel";
+import { visibleProfileField, visibleProfileList } from "./_profileFieldVisibility";
 import { optionalField, safeHttpsUrl } from "./_publicFields";
 import { getProfileTrustLabel } from "./_profileStates";
+
+function visibleHttpsProfileImage(
+  profile: Doc<"profiles">,
+  key: "avatarImageUrl" | "bannerImageUrl",
+): string | undefined {
+  return safeHttpsUrl(visibleProfileField(profile, key, profile[key], "profile_page"));
+}
 
 export function toPublicProfile(profile: Doc<"profiles">) {
   const source = profile.sourceAttribution
@@ -14,11 +22,16 @@ export function toPublicProfile(profile: Doc<"profiles">) {
     profileType: profile.profileType,
     slug: profile.slug,
     displayName: profile.displayName,
-    aliases: profile.aliases,
-    tags: profile.tags,
+    aliases: visibleProfileList(profile, "aliases", profile.aliases, "profile_page"),
+    tags: visibleProfileList(profile, "tags", profile.tags, "profile_page"),
     trustLabel: getProfileTrustLabel(profile.claimState, profile.creationSource),
     ...optionalField("source", source),
-    outboundLinks: (profile.outboundLinks ?? []).flatMap((link) => {
+    outboundLinks: visibleProfileList(
+      profile,
+      "outboundLinks",
+      profile.outboundLinks ?? [],
+      "profile_page",
+    ).flatMap((link) => {
       const linkUrl = safeHttpsUrl(link.url);
 
       if (linkUrl === undefined) {
@@ -27,13 +40,16 @@ export function toPublicProfile(profile: Doc<"profiles">) {
 
       return [{ ...link, url: linkUrl }];
     }),
-    ...optionalField("headline", profile.headline),
-    ...optionalField("bio", profile.bio),
-    ...optionalField("about", profile.about),
-    ...optionalField("avatarImageUrl", profile.avatarImageUrl),
-    ...optionalField("bannerImageUrl", profile.bannerImageUrl),
-    ...optionalField("region", profile.region),
-    ...optionalField("timezone", profile.timezone),
+    ...optionalField(
+      "headline",
+      visibleProfileField(profile, "headline", profile.headline, "profile_page"),
+    ),
+    ...optionalField("bio", visibleProfileField(profile, "bio", profile.bio, "profile_page")),
+    ...optionalField("about", visibleProfileField(profile, "about", profile.about, "profile_page")),
+    ...optionalField("avatarImageUrl", visibleHttpsProfileImage(profile, "avatarImageUrl")),
+    ...optionalField("bannerImageUrl", visibleHttpsProfileImage(profile, "bannerImageUrl")),
+    ...optionalField("region", visibleProfileField(profile, "region", profile.region, "profile_page")),
+    ...optionalField("timezone", visibleProfileField(profile, "timezone", profile.timezone, "profile_page")),
   };
 
   if (profile.profileType === "person") {
@@ -41,8 +57,11 @@ export function toPublicProfile(profile: Doc<"profiles">) {
       ...shared,
       profileType: "person" as const,
       person: {
-        ...optionalField("pronouns", profile.person.pronouns),
-        roleTags: profile.person.roleTags,
+        ...optionalField(
+          "pronouns",
+          visibleProfileField(profile, "personPronouns", profile.person.pronouns, "profile_page"),
+        ),
+        roleTags: visibleProfileList(profile, "personRoleTags", profile.person.roleTags, "profile_page"),
       },
     };
   }
@@ -51,8 +70,16 @@ export function toPublicProfile(profile: Doc<"profiles">) {
     ...shared,
     profileType: "community" as const,
     community: {
-      ...optionalField("subtype", profile.community.subtype),
-      categoryTags: profile.community.categoryTags,
+      ...optionalField(
+        "subtype",
+        visibleProfileField(profile, "communitySubtype", profile.community.subtype, "profile_page"),
+      ),
+      categoryTags: visibleProfileList(
+        profile,
+        "communityCategoryTags",
+        profile.community.categoryTags,
+        "profile_page",
+      ),
     },
   };
 }

--- a/convex/_searchDocuments.ts
+++ b/convex/_searchDocuments.ts
@@ -1,5 +1,6 @@
 import type { Doc } from "./_generated/dataModel";
 import type { DatabaseReader, DatabaseWriter } from "./_generated/server";
+import { visibleProfileField, visibleProfileList } from "./_profileFieldVisibility";
 import { optionalField, safeHttpsUrl } from "./_publicFields";
 import { canReadProfile } from "./_profilePermissions";
 import { getProfileBySlug } from "./_profileSlugs";
@@ -107,6 +108,13 @@ function publicStateForProfile(profile: Doc<"profiles">): Doc<"searchDocuments">
   return canReadProfile("public", profile) ? "public" : "hidden";
 }
 
+function publicProfileImageUrl(profile: Doc<"profiles">): string | undefined {
+  return (
+    safeHttpsUrl(visibleProfileField(profile, "avatarImageUrl", profile.avatarImageUrl, "discovery")) ??
+    safeHttpsUrl(visibleProfileField(profile, "bannerImageUrl", profile.bannerImageUrl, "discovery"))
+  );
+}
+
 function effectiveFeaturedRank(document: Doc<"searchDocuments">): number {
   if (document.entityType === "event" && document.startsAt !== undefined && document.startsAt < Date.now()) {
     return Math.min(document.featuredRank, 8);
@@ -144,25 +152,53 @@ function sourceForProfile(profile: Doc<"profiles">): Pick<SearchDocumentInput, "
 }
 
 export function vocabularyForProfile(profile: Doc<"profiles">): VocabularyCandidate[] {
-  const shared = createVocabularyCandidates("profile_tag", profile.tags);
+  const shared = createVocabularyCandidates(
+    "profile_tag",
+    visibleProfileList(profile, "tags", profile.tags, "discovery"),
+  );
 
   if (profile.profileType === "person") {
-    return [...shared, ...createVocabularyCandidates("person_role", profile.person.roleTags)];
+    return [
+      ...shared,
+      ...createVocabularyCandidates(
+        "person_role",
+        visibleProfileList(profile, "personRoleTags", profile.person.roleTags, "discovery"),
+      ),
+    ];
   }
 
   return [
     ...shared,
-    ...createVocabularyCandidates("community_subtype", [profile.community.subtype]),
-    ...createVocabularyCandidates("community_category", profile.community.categoryTags),
+    ...createVocabularyCandidates("community_subtype", [
+      visibleProfileField(profile, "communitySubtype", profile.community.subtype, "discovery"),
+    ]),
+    ...createVocabularyCandidates(
+      "community_category",
+      visibleProfileList(profile, "communityCategoryTags", profile.community.categoryTags, "discovery"),
+    ),
   ];
 }
 
 export function createProfileSearchDocument(profile: Doc<"profiles">): SearchDocumentInput {
   const typeLabel = profile.profileType === "person" ? "Person profile" : "Community profile";
+  const aliases = visibleProfileList(profile, "aliases", profile.aliases, "discovery");
+  const tags = visibleProfileList(profile, "tags", profile.tags, "discovery");
+  const headline = visibleProfileField(profile, "headline", profile.headline, "discovery");
+  const bio = visibleProfileField(profile, "bio", profile.bio, "discovery");
+  const region = visibleProfileField(profile, "region", profile.region, "discovery");
+  const timezone = visibleProfileField(profile, "timezone", profile.timezone, "discovery");
   const typeSpecific =
     profile.profileType === "person"
-      ? profile.person.roleTags
-      : compact([profile.community.subtype, ...profile.community.categoryTags]);
+      ? visibleProfileList(profile, "personRoleTags", profile.person.roleTags, "discovery")
+      : compact([
+          visibleProfileField(profile, "communitySubtype", profile.community.subtype, "discovery"),
+          ...visibleProfileList(
+            profile,
+            "communityCategoryTags",
+            profile.community.categoryTags,
+            "discovery",
+          ),
+        ]);
   const source = sourceForProfile(profile);
   const vocabulary = vocabularyForProfile(profile);
 
@@ -175,16 +211,16 @@ export function createProfileSearchDocument(profile: Doc<"profiles">): SearchDoc
     routePath: profile.profileType === "person" ? `/p/${profile.slug}` : `/c/${profile.slug}`,
     title: profile.displayName,
     subtitle: typeLabel,
-    ...optionalField("summary", profile.headline ?? profile.bio),
-    ...optionalField("imageUrl", safeHttpsUrl(profile.avatarImageUrl ?? profile.bannerImageUrl)),
+    ...optionalField("summary", headline ?? bio),
+    ...optionalField("imageUrl", publicProfileImageUrl(profile)),
     searchText: weightedCorpus([
       { values: [profile.displayName, profile.slug], weight: 8 },
-      { values: profile.aliases, weight: 5 },
-      { values: profile.tags, weight: 4 },
+      { values: aliases, weight: 5 },
+      { values: tags, weight: 4 },
       { values: typeSpecific, weight: 4 },
-      { values: [profile.headline, profile.bio, profile.region, profile.timezone, typeLabel], weight: 1 },
+      { values: [headline, bio, region, timezone, typeLabel], weight: 1 },
     ]),
-    exactTokens: exactTokens([profile.displayName, profile.slug, ...profile.aliases, ...profile.tags, ...typeSpecific]),
+    exactTokens: exactTokens([profile.displayName, profile.slug, ...aliases, ...tags, ...typeSpecific]),
     vocabularyKeys: collectVocabularyKeys(vocabulary),
     trustRank: trustRankForProfile(profile),
     featuredRank: trustRankForProfile(profile),

--- a/convex/accounts.ts
+++ b/convex/accounts.ts
@@ -1,0 +1,81 @@
+import { getAuthUserId } from "@convex-dev/auth/server";
+
+import type { Id } from "./_generated/dataModel";
+import type { MutationCtx, QueryCtx } from "./_generated/server";
+import { query } from "./_generated/server";
+
+type AccountCtx = QueryCtx | MutationCtx;
+
+export async function getCurrentUser(ctx: AccountCtx) {
+  const userId = await getAuthUserId(ctx);
+
+  if (userId === null) {
+    return null;
+  }
+
+  return await ctx.db.get(userId);
+}
+
+export async function requireCurrentUser(ctx: AccountCtx) {
+  const user = await getCurrentUser(ctx);
+
+  if (user === null) {
+    throw new Error("A signed-in account is required.");
+  }
+
+  return user;
+}
+
+export async function requireVerifiedEmailUser(ctx: AccountCtx) {
+  const user = await requireCurrentUser(ctx);
+
+  if (user.email === undefined || user.emailVerificationTime === undefined) {
+    throw new Error("A verified email address is required before claim-level actions.");
+  }
+
+  return user;
+}
+
+export async function getLinkedProviderAccount(
+  ctx: AccountCtx,
+  userId: Id<"users">,
+  provider: string,
+) {
+  const accounts = await ctx.db
+    .query("authAccounts")
+    .withIndex("userIdAndProvider", (query) => query.eq("userId", userId).eq("provider", provider))
+    .take(1);
+
+  return accounts[0] ?? null;
+}
+
+export const viewer = query({
+  args: {},
+  handler: async (ctx) => {
+    const user = await getCurrentUser(ctx);
+
+    if (user === null) {
+      return null;
+    }
+
+    const linkedAccounts = await ctx.db
+      .query("authAccounts")
+      .withIndex("userIdAndProvider", (query) => query.eq("userId", user._id))
+      .collect();
+
+    return {
+      user: {
+        id: user._id,
+        name: user.name,
+        email: user.email,
+        emailVerified: user.emailVerificationTime !== undefined,
+        image: user.image,
+      },
+      linkedProviders: linkedAccounts.map((account) => ({
+        provider: account.provider,
+        providerAccountId: account.providerAccountId,
+        emailVerified: account.emailVerified !== undefined,
+      })),
+    };
+  },
+});

--- a/convex/auth.ts
+++ b/convex/auth.ts
@@ -58,7 +58,7 @@ export const { auth, signIn, signOut, store, isAuthenticated } = convexAuth({
     Discord({
       authorization: {
         params: {
-          scope: "identify email guilds",
+          scope: "identify email",
         },
       },
       profile(profile) {
@@ -106,7 +106,7 @@ export const { auth, signIn, signOut, store, isAuthenticated } = convexAuth({
   ],
   callbacks: {
     async redirect({ redirectTo }) {
-      if (redirectTo.startsWith("/")) {
+      if (redirectTo.startsWith("/") && !redirectTo.startsWith("//")) {
         return redirectTo;
       }
 

--- a/convex/auth.ts
+++ b/convex/auth.ts
@@ -1,0 +1,116 @@
+import Discord from "@auth/core/providers/discord";
+import Google from "@auth/core/providers/google";
+import { SESClient, SendEmailCommand } from "@aws-sdk/client-ses";
+import { Email } from "@convex-dev/auth/providers/Email";
+import { Password } from "@convex-dev/auth/providers/Password";
+import { convexAuth } from "@convex-dev/auth/server";
+
+function requiredEnv(name: string): string {
+  const value = process.env[name]?.trim();
+
+  if (!value) {
+    throw new Error(`${name} must be configured before sending auth email.`);
+  }
+
+  return value;
+}
+
+async function sendSesVerificationCode(email: string, token: string) {
+  const region = requiredEnv("AWS_SES_REGION");
+  const fromEmail = requiredEnv("AWS_SES_FROM_EMAIL");
+  const appName = process.env.VRDEX_APP_NAME?.trim() || "VRDex";
+  const client = new SESClient({ region });
+
+  await client.send(
+    new SendEmailCommand({
+      Source: fromEmail,
+      Destination: {
+        ToAddresses: [email],
+      },
+      Message: {
+        Subject: {
+          Charset: "UTF-8",
+          Data: `Your ${appName} verification code`,
+        },
+        Body: {
+          Text: {
+            Charset: "UTF-8",
+            Data: [
+              `Your ${appName} verification code is ${token}.`,
+              "",
+              "If you did not request this code, you can ignore this email.",
+            ].join("\n"),
+          },
+        },
+      },
+    }),
+  );
+}
+
+const SesOtp = Email({
+  async sendVerificationRequest({ identifier, token }) {
+    await sendSesVerificationCode(identifier, token);
+  },
+});
+
+export const { auth, signIn, signOut, store, isAuthenticated } = convexAuth({
+  providers: [
+    Discord({
+      authorization: {
+        params: {
+          scope: "identify email guilds",
+        },
+      },
+      profile(profile) {
+        const avatar = profile.avatar
+          ? `https://cdn.discordapp.com/avatars/${profile.id}/${profile.avatar}.png`
+          : undefined;
+
+        return {
+          id: profile.id,
+          name: profile.global_name ?? profile.username,
+          email: profile.email ?? undefined,
+          emailVerified: Boolean(profile.verified && profile.email),
+          image: avatar,
+        };
+      },
+    }),
+    Google({
+      profile(profile) {
+        return {
+          id: profile.sub,
+          name: profile.name,
+          email: profile.email,
+          emailVerified: Boolean(profile.email_verified && profile.email),
+          image: profile.picture,
+        };
+      },
+    }),
+    Password({
+      verify: SesOtp,
+      profile(params) {
+        const email = String(params.email ?? "").trim().toLowerCase();
+
+        if (!email) {
+          throw new Error("Email is required.");
+        }
+
+        return { email };
+      },
+      validatePasswordRequirements(password) {
+        if (password.length < 12) {
+          throw new Error("Password must be at least 12 characters.");
+        }
+      },
+    }),
+  ],
+  callbacks: {
+    async redirect({ redirectTo }) {
+      if (redirectTo.startsWith("/")) {
+        return redirectTo;
+      }
+
+      throw new Error("Only relative redirects are allowed.");
+    },
+  },
+});

--- a/convex/convex.config.ts
+++ b/convex/convex.config.ts
@@ -1,0 +1,8 @@
+import { defineApp } from "convex/server";
+import migrations from "@convex-dev/migrations/convex.config.js";
+
+const app = defineApp();
+
+app.use(migrations);
+
+export default app;

--- a/convex/http.ts
+++ b/convex/http.ts
@@ -1,0 +1,9 @@
+import { httpRouter } from "convex/server";
+
+import { auth } from "./auth";
+
+const http = httpRouter();
+
+auth.addHttpRoutes(http);
+
+export default http;

--- a/convex/migrations.ts
+++ b/convex/migrations.ts
@@ -1,4 +1,7 @@
-import type { Doc } from "./_generated/dataModel";
+import { Migrations } from "@convex-dev/migrations";
+
+import { components, internal } from "./_generated/api";
+import type { DataModel, Doc } from "./_generated/dataModel";
 import { internalMutation } from "./_generated/server";
 
 type LegacyProfile = Doc<"profiles"> & {
@@ -6,30 +9,35 @@ type LegacyProfile = Doc<"profiles"> & {
   publicSurfacingUpdatedAt?: number;
 };
 
-export const backfillProfilePublicSurfacingState = internalMutation({
-  args: {},
-  handler: async (ctx) => {
-    const now = Date.now();
-    const profiles = await ctx.db.query("profiles").collect();
-    let updated = 0;
+export const migrations = new Migrations<DataModel>(components.migrations, {
+  internalMutation,
+  defaultBatchSize: 50,
+  migrationsLocationPrefix: "migrations:",
+});
 
-    for (const profile of profiles) {
-      const legacyProfile = profile as LegacyProfile;
+export const backfillProfilePublicSurfacingState = migrations.define({
+  table: "profiles",
+  migrateOne: async (_ctx, profile) => {
+    const legacyProfile = profile as LegacyProfile;
 
-      if (
-        legacyProfile.publicSurfacingState !== undefined &&
-        legacyProfile.publicSurfacingUpdatedAt !== undefined
-      ) {
-        continue;
-      }
-
-      await ctx.db.patch(profile._id, {
-        publicSurfacingState: legacyProfile.publicSurfacingState ?? "public",
-        publicSurfacingUpdatedAt: legacyProfile.publicSurfacingUpdatedAt ?? now,
-      });
-      updated += 1;
+    if (
+      legacyProfile.publicSurfacingState !== undefined &&
+      legacyProfile.publicSurfacingUpdatedAt !== undefined
+    ) {
+      return;
     }
 
-    return { scanned: profiles.length, updated };
+    return {
+      publicSurfacingState: legacyProfile.publicSurfacingState ?? "public",
+      publicSurfacingUpdatedAt: legacyProfile.publicSurfacingUpdatedAt ?? Date.now(),
+    };
   },
 });
+
+export const runBackfillProfilePublicSurfacingState = migrations.runner(
+  internal.migrations.backfillProfilePublicSurfacingState,
+);
+
+export const runAll = migrations.runner([
+  internal.migrations.backfillProfilePublicSurfacingState,
+]);

--- a/convex/profileClaims.ts
+++ b/convex/profileClaims.ts
@@ -1,0 +1,520 @@
+import { v } from "convex/values";
+
+import { getLinkedProviderAccount, requireVerifiedEmailUser } from "./accounts";
+import { toAuthSubject } from "./_communityAuthority";
+import { internal } from "./_generated/api";
+import type { Doc, Id } from "./_generated/dataModel";
+import { action, internalMutation, internalQuery, mutation } from "./_generated/server";
+import { approveProfileClaimForUser, getActiveProfileOwner } from "./_profileOwnership";
+import { getProfileBySlug, validateProfileSlug } from "./_profileSlugs";
+import { createProfileSearchDocument, upsertSearchDocument } from "./_searchDocuments";
+
+const DAY_MS = 86_400_000;
+const vrchatTargetType = v.union(
+  v.literal("vrchat_user"),
+  v.literal("vrchat_group"),
+  v.literal("vrclinking"),
+);
+
+type VrchatTargetType = Doc<"profileVerificationAttempts">["targetType"];
+type VerificationAttemptAdapterContext = {
+  attempt: Doc<"profileVerificationAttempts">;
+  profile: {
+    id: Id<"profiles">;
+    slug: string;
+    profileType: Doc<"profiles">["profileType"];
+    displayName: string;
+  };
+};
+type VerifyAdapterResult =
+  | { state: Doc<"profileVerificationAttempts">["state"] }
+  | {
+      claimRequestId: Id<"profileClaimRequests">;
+      profileId: Id<"profiles">;
+      claimState: Doc<"profiles">["claimState"];
+    };
+
+async function requireLinkedDiscordAccount(ctx: Parameters<typeof getLinkedProviderAccount>[0], userId: Parameters<typeof getLinkedProviderAccount>[1]) {
+  const account = await getLinkedProviderAccount(ctx, userId, "discord");
+
+  if (account === null) {
+    throw new Error("A linked Discord account is required for this claim method.");
+  }
+
+  return account;
+}
+
+async function getClaimableProfileBySlug(
+  ctx: Parameters<typeof getProfileBySlug>[0],
+  slug: string,
+  expectedProfileType: "person" | "community",
+) {
+  const validation = validateProfileSlug(slug);
+
+  if (!validation.ok) {
+    throw new Error("A valid profile slug is required.");
+  }
+
+  const profile = await getProfileBySlug(ctx, validation.slug);
+
+  if (profile === null) {
+    throw new Error("Profile not found.");
+  }
+
+  if (profile.profileType !== expectedProfileType) {
+    throw new Error(`This claim method requires a ${expectedProfileType} profile.`);
+  }
+
+  return profile;
+}
+
+function proofMethodForTarget(targetType: VrchatTargetType): Doc<"profileVerificationAttempts">["method"] {
+  if (targetType === "vrchat_user") {
+    return "vrchat_user_proof";
+  }
+
+  if (targetType === "vrchat_group") {
+    return "vrchat_group_proof";
+  }
+
+  return "vrclinking_attestation";
+}
+
+function requireCompatibleProofTarget(profile: Doc<"profiles">, targetType: VrchatTargetType) {
+  if (targetType === "vrchat_user" && profile.profileType !== "person") {
+    throw new Error("VRChat user proof requires a person profile.");
+  }
+
+  if (targetType === "vrchat_group" && profile.profileType !== "community") {
+    throw new Error("VRChat group proof requires a community profile.");
+  }
+}
+
+function createProofCode(): string {
+  return `VRDEX-${crypto.randomUUID().replace(/-/g, "").slice(0, 12).toUpperCase()}`;
+}
+
+function requiredAdapterUrl(): string {
+  const value = process.env.VRCHAT_PROOF_ADAPTER_URL?.trim();
+
+  if (!value) {
+    throw new Error("VRCHAT_PROOF_ADAPTER_URL is not configured.");
+  }
+
+  return value;
+}
+
+export const claimExistingPersonWithDiscord = mutation({
+  args: {
+    profileSlug: v.string(),
+  },
+  handler: async (ctx, args) => {
+    const [user, identity] = await Promise.all([
+      requireVerifiedEmailUser(ctx),
+      ctx.auth.getUserIdentity(),
+    ]);
+    const [profile, discordAccount] = await Promise.all([
+      getClaimableProfileBySlug(ctx.db, args.profileSlug, "person"),
+      requireLinkedDiscordAccount(ctx, user._id),
+    ]);
+    const now = Date.now();
+    const claimRequestId = await ctx.db.insert("profileClaimRequests", {
+      profileId: profile._id,
+      profileSlug: profile.slug,
+      profileType: "person",
+      requestedDisplayName: profile.displayName,
+      userId: user._id,
+      method: "discord_person",
+      state: "approved",
+      evidenceSource: "discord_api",
+      evidenceSummary: `Linked Discord account ${discordAccount.providerAccountId} claimed person profile.`,
+      createdAt: now,
+      updatedAt: now,
+      verifiedAt: now,
+      reviewedAt: now,
+    });
+
+    await approveProfileClaimForUser(ctx.db, {
+      profile,
+      profileId: profile._id,
+      userId: user._id,
+      grantedByClaimRequestId: claimRequestId,
+      verified: false,
+      now,
+      ...(identity !== null ? { actor: toAuthSubject(identity) } : {}),
+      note: "Discord person claim grants owner control without stronger profile verification.",
+    });
+
+    const updatedProfile = await ctx.db.get(profile._id);
+    if (updatedProfile !== null) {
+      await upsertSearchDocument(ctx.db, createProfileSearchDocument(updatedProfile));
+    }
+
+    return {
+      claimRequestId,
+      profileId: profile._id,
+      claimState: updatedProfile?.claimState ?? profile.claimState,
+      profilePath: `/p/${profile.slug}`,
+    };
+  },
+});
+
+export const requestCommunityDiscordAdminClaim = mutation({
+  args: {
+    profileSlug: v.string(),
+    discordGuildId: v.string(),
+    discordGuildName: v.optional(v.string()),
+  },
+  handler: async (ctx, args) => {
+    const user = await requireVerifiedEmailUser(ctx);
+    const [profile, discordAccount] = await Promise.all([
+      getClaimableProfileBySlug(ctx.db, args.profileSlug, "community"),
+      requireLinkedDiscordAccount(ctx, user._id),
+    ]);
+    const activeOwner = await getActiveProfileOwner(ctx.db, profile._id);
+
+    if (activeOwner !== null && activeOwner.userId !== user._id) {
+      throw new Error("This community profile already has an active owner.");
+    }
+
+    if (activeOwner !== null) {
+      return {
+        profileId: profile._id,
+        profilePath: `/c/${profile.slug}`,
+        state: "already_owned" as const,
+      };
+    }
+
+    const now = Date.now();
+    const claimRequestId = await ctx.db.insert("profileClaimRequests", {
+      profileId: profile._id,
+      profileSlug: profile.slug,
+      profileType: "community",
+      requestedDisplayName: profile.displayName,
+      userId: user._id,
+      method: "discord_community_admin",
+      state: "pending",
+      discordGuildId: args.discordGuildId.trim(),
+      ...(args.discordGuildName?.trim() ? { discordGuildName: args.discordGuildName.trim() } : {}),
+      evidenceSource: "discord_api",
+      evidenceSummary: `Linked Discord account ${discordAccount.providerAccountId} requested Administrator verification.`,
+      createdAt: now,
+      updatedAt: now,
+    });
+
+    return {
+      claimRequestId,
+      profileId: profile._id,
+      profilePath: `/c/${profile.slug}`,
+      state: "pending_admin_verification" as const,
+    };
+  },
+});
+
+export const recordDiscordCommunityAdminApproval = internalMutation({
+  args: {
+    claimRequestId: v.id("profileClaimRequests"),
+    evidenceSummary: v.string(),
+  },
+  handler: async (ctx, args) => {
+    const claimRequest = await ctx.db.get(args.claimRequestId);
+
+    if (claimRequest === null) {
+      throw new Error("Claim request not found.");
+    }
+
+    if (claimRequest.method !== "discord_community_admin" || claimRequest.state !== "pending") {
+      throw new Error("Only pending Discord community admin claims can be approved this way.");
+    }
+
+    if (claimRequest.profileId === undefined) {
+      throw new Error("Claim request is missing a profile target.");
+    }
+
+    const profile = await ctx.db.get(claimRequest.profileId);
+
+    if (profile === null || profile.profileType !== "community") {
+      throw new Error("Community profile not found.");
+    }
+
+    const now = Date.now();
+
+    await ctx.db.patch(claimRequest._id, {
+      state: "approved",
+      evidenceSummary: args.evidenceSummary,
+      verifiedAt: now,
+      reviewedAt: now,
+      updatedAt: now,
+    });
+    await approveProfileClaimForUser(ctx.db, {
+      profile,
+      profileId: profile._id,
+      userId: claimRequest.userId,
+      grantedByClaimRequestId: claimRequest._id,
+      verified: true,
+      now,
+      note: "Discord Administrator permission verified by the Discord claim adapter.",
+    });
+
+    const updatedProfile = await ctx.db.get(profile._id);
+    if (updatedProfile !== null) {
+      await upsertSearchDocument(ctx.db, createProfileSearchDocument(updatedProfile));
+    }
+
+    return {
+      profileId: profile._id,
+      claimState: updatedProfile?.claimState ?? profile.claimState,
+    };
+  },
+});
+
+export const startVrchatProof = mutation({
+  args: {
+    profileSlug: v.string(),
+    targetType: vrchatTargetType,
+    targetExternalId: v.string(),
+  },
+  handler: async (ctx, args) => {
+    const user = await requireVerifiedEmailUser(ctx);
+    const profile = await getClaimableProfileBySlug(
+      ctx.db,
+      args.profileSlug,
+      args.targetType === "vrchat_group" ? "community" : "person",
+    );
+    requireCompatibleProofTarget(profile, args.targetType);
+
+    const activeOwner = await getActiveProfileOwner(ctx.db, profile._id);
+    if (activeOwner !== null && activeOwner.userId !== user._id) {
+      throw new Error("This profile already has an active owner.");
+    }
+
+    const targetExternalId = args.targetExternalId.trim();
+    if (!targetExternalId) {
+      throw new Error("A VRChat or VRCLinking target id is required.");
+    }
+
+    const now = Date.now();
+    const attemptId = await ctx.db.insert("profileVerificationAttempts", {
+      profileId: profile._id,
+      userId: user._id,
+      method: proofMethodForTarget(args.targetType),
+      targetType: args.targetType,
+      targetExternalId,
+      proofCode: createProofCode(),
+      state: "pending",
+      createdAt: now,
+      updatedAt: now,
+      expiresAt: now + DAY_MS,
+    });
+    const attempt = await ctx.db.get(attemptId);
+
+    if (attempt === null) {
+      throw new Error("Unable to create verification attempt.");
+    }
+
+    return {
+      attemptId,
+      profileId: profile._id,
+      proofCode: attempt.proofCode,
+      expiresAt: attempt.expiresAt,
+    };
+  },
+});
+
+export const getVerificationAttemptForAdapter = internalQuery({
+  args: {
+    attemptId: v.id("profileVerificationAttempts"),
+  },
+  handler: async (ctx, args) => {
+    const attempt = await ctx.db.get(args.attemptId);
+
+    if (attempt === null) {
+      return null;
+    }
+
+    const profile = await ctx.db.get(attempt.profileId);
+
+    if (profile === null) {
+      return null;
+    }
+
+    return {
+      attempt,
+      profile: {
+        id: profile._id,
+        slug: profile.slug,
+        profileType: profile.profileType,
+        displayName: profile.displayName,
+      },
+    };
+  },
+});
+
+export const recordVrchatProofVerification = internalMutation({
+  args: {
+    attemptId: v.id("profileVerificationAttempts"),
+    evidenceSource: v.union(v.literal("vrchat_api"), v.literal("vrclinking"), v.literal("manual")),
+    evidenceSummary: v.string(),
+  },
+  handler: async (ctx, args) => {
+    const attempt = await ctx.db.get(args.attemptId);
+
+    if (attempt === null) {
+      throw new Error("Verification attempt not found.");
+    }
+
+    if (attempt.state !== "pending") {
+      throw new Error("Only pending verification attempts can be approved.");
+    }
+
+    const now = Date.now();
+    if (attempt.expiresAt < now) {
+      await ctx.db.patch(attempt._id, { state: "expired", updatedAt: now });
+      throw new Error("Verification attempt has expired.");
+    }
+
+    const profile = await ctx.db.get(attempt.profileId);
+    if (profile === null) {
+      throw new Error("Profile not found.");
+    }
+
+    const claimRequestId = await ctx.db.insert("profileClaimRequests", {
+      profileId: profile._id,
+      profileSlug: profile.slug,
+      profileType: profile.profileType,
+      requestedDisplayName: profile.displayName,
+      userId: attempt.userId,
+      method: attempt.method,
+      state: "approved",
+      vrchatTargetId: attempt.targetExternalId,
+      evidenceSource: args.evidenceSource,
+      evidenceSummary: args.evidenceSummary,
+      createdAt: now,
+      updatedAt: now,
+      verifiedAt: now,
+      reviewedAt: now,
+    });
+
+    await ctx.db.patch(attempt._id, {
+      state: "verified",
+      evidenceSource: args.evidenceSource,
+      evidenceSummary: args.evidenceSummary,
+      verifiedAt: now,
+      updatedAt: now,
+    });
+    await approveProfileClaimForUser(ctx.db, {
+      profile,
+      profileId: profile._id,
+      userId: attempt.userId,
+      grantedByClaimRequestId: claimRequestId,
+      verified: true,
+      now,
+      note: "External profile proof code was verified by the VRChat proof adapter.",
+    });
+
+    const updatedProfile = await ctx.db.get(profile._id);
+    if (updatedProfile !== null) {
+      await upsertSearchDocument(ctx.db, createProfileSearchDocument(updatedProfile));
+    }
+
+    return {
+      claimRequestId,
+      profileId: profile._id,
+      claimState: updatedProfile?.claimState ?? profile.claimState,
+    };
+  },
+});
+
+export const recordVrchatProofFailure = internalMutation({
+  args: {
+    attemptId: v.id("profileVerificationAttempts"),
+    evidenceSource: v.optional(v.union(v.literal("vrchat_api"), v.literal("vrclinking"), v.literal("manual"))),
+    evidenceSummary: v.string(),
+  },
+  handler: async (ctx, args) => {
+    const attempt = await ctx.db.get(args.attemptId);
+
+    if (attempt === null) {
+      throw new Error("Verification attempt not found.");
+    }
+
+    if (attempt.state !== "pending") {
+      return { state: attempt.state };
+    }
+
+    const now = Date.now();
+    await ctx.db.patch(attempt._id, {
+      state: attempt.expiresAt < now ? "expired" : "failed",
+      ...(args.evidenceSource !== undefined ? { evidenceSource: args.evidenceSource } : {}),
+      evidenceSummary: args.evidenceSummary,
+      updatedAt: now,
+    });
+
+    return { state: attempt.expiresAt < now ? "expired" : "failed" };
+  },
+});
+
+export const verifyVrchatProofViaAdapter = action({
+  args: {
+    attemptId: v.id("profileVerificationAttempts"),
+  },
+  handler: async (ctx, args): Promise<VerifyAdapterResult> => {
+    const attemptContext = (await ctx.runQuery(internal.profileClaims.getVerificationAttemptForAdapter, {
+      attemptId: args.attemptId,
+    })) as VerificationAttemptAdapterContext | null;
+
+    if (attemptContext === null) {
+      throw new Error("Verification attempt not found.");
+    }
+
+    if (attemptContext.attempt.state !== "pending") {
+      return { state: attemptContext.attempt.state };
+    }
+
+    const adapterUrl = requiredAdapterUrl();
+    const response = await fetch(adapterUrl, {
+      method: "POST",
+      headers: {
+        "content-type": "application/json",
+      },
+      body: JSON.stringify({
+        targetType: attemptContext.attempt.targetType,
+        targetExternalId: attemptContext.attempt.targetExternalId,
+        proofCode: attemptContext.attempt.proofCode,
+        profile: attemptContext.profile,
+      }),
+    });
+
+    if (!response.ok) {
+      await ctx.runMutation(internal.profileClaims.recordVrchatProofFailure, {
+        attemptId: args.attemptId,
+        evidenceSource: "manual",
+        evidenceSummary: `Proof adapter returned HTTP ${response.status}.`,
+      });
+
+      return { state: "failed" as const };
+    }
+
+    const result = (await response.json()) as {
+      verified?: boolean;
+      evidenceSource?: "vrchat_api" | "vrclinking" | "manual";
+      evidenceSummary?: string;
+    };
+
+    if (result.verified !== true) {
+      await ctx.runMutation(internal.profileClaims.recordVrchatProofFailure, {
+        attemptId: args.attemptId,
+        evidenceSource: result.evidenceSource ?? "manual",
+        evidenceSummary: result.evidenceSummary ?? "Proof code was not found by the adapter.",
+      });
+
+      return { state: "failed" as const };
+    }
+
+    return await ctx.runMutation(internal.profileClaims.recordVrchatProofVerification, {
+      attemptId: args.attemptId,
+      evidenceSource: result.evidenceSource ?? "vrchat_api",
+      evidenceSummary: result.evidenceSummary ?? "Proof code was found by the configured adapter.",
+    });
+  },
+});

--- a/convex/profileClaims.ts
+++ b/convex/profileClaims.ts
@@ -10,6 +10,7 @@ import { getProfileBySlug, validateProfileSlug } from "./_profileSlugs";
 import { createProfileSearchDocument, upsertSearchDocument } from "./_searchDocuments";
 
 const DAY_MS = 86_400_000;
+const DISCORD_ADMINISTRATOR_PERMISSION = BigInt(8);
 const vrchatTargetType = v.union(
   v.literal("vrchat_user"),
   v.literal("vrchat_group"),
@@ -26,6 +27,10 @@ type VerificationAttemptAdapterContext = {
     displayName: string;
   };
 };
+type DiscordCommunityClaimAdapterContext = {
+  claimRequest: Doc<"profileClaimRequests">;
+  discordUserId: string;
+};
 type VerifyAdapterResult =
   | { state: Doc<"profileVerificationAttempts">["state"] }
   | {
@@ -33,6 +38,47 @@ type VerifyAdapterResult =
       profileId: Id<"profiles">;
       claimState: Doc<"profiles">["claimState"];
     };
+type DiscordAdminAdapterResult =
+  | { state: Doc<"profileClaimRequests">["state"] }
+  | {
+      profileId: Id<"profiles">;
+      claimState: Doc<"profiles">["claimState"];
+    };
+type DiscordGuild = {
+  id: string;
+  name?: string;
+  owner_id?: string;
+};
+type DiscordGuildMember = {
+  user?: { id?: string };
+  roles?: string[];
+};
+type DiscordRole = {
+  id: string;
+  name?: string;
+  permissions: string;
+};
+type ProofAdapterResponse = {
+  verified?: boolean;
+  evidenceSource?: "vrchat_api" | "vrclinking" | "manual";
+  evidenceSummary?: string;
+};
+
+function optionalEnv(name: string): string | undefined {
+  const value = process.env[name]?.trim();
+
+  return value || undefined;
+}
+
+function requiredEnv(name: string): string {
+  const value = optionalEnv(name);
+
+  if (!value) {
+    throw new Error(`${name} is not configured.`);
+  }
+
+  return value;
+}
 
 async function requireLinkedDiscordAccount(ctx: Parameters<typeof getLinkedProviderAccount>[0], userId: Parameters<typeof getLinkedProviderAccount>[1]) {
   const account = await getLinkedProviderAccount(ctx, userId, "discord");
@@ -94,14 +140,66 @@ function createProofCode(): string {
   return `VRDEX-${crypto.randomUUID().replace(/-/g, "").slice(0, 12).toUpperCase()}`;
 }
 
-function requiredAdapterUrl(): string {
-  const value = process.env.VRCHAT_PROOF_ADAPTER_URL?.trim();
-
-  if (!value) {
-    throw new Error("VRCHAT_PROOF_ADAPTER_URL is not configured.");
+function proofAdapterUrl(targetType: VrchatTargetType): string {
+  if (targetType === "vrclinking") {
+    return requiredEnv("VRCLINKING_PROOF_ADAPTER_URL");
   }
 
-  return value;
+  return requiredEnv("VRCHAT_PROOF_ADAPTER_URL");
+}
+
+function proofAdapterHeaders(): Record<string, string> {
+  const token = optionalEnv("VRCHAT_PROOF_ADAPTER_BEARER_TOKEN");
+
+  return {
+    "content-type": "application/json",
+    ...(token !== undefined ? { authorization: `Bearer ${token}` } : {}),
+  };
+}
+
+async function fetchDiscordJson<T>(path: string): Promise<T> {
+  const baseUrl = optionalEnv("DISCORD_API_BASE_URL") ?? "https://discord.com/api/v10";
+  const response = await fetch(`${baseUrl}${path}`, {
+    headers: {
+      authorization: `Bot ${requiredEnv("DISCORD_BOT_TOKEN")}`,
+    },
+  });
+
+  if (!response.ok) {
+    throw new Error(`Discord API returned HTTP ${response.status}.`);
+  }
+
+  return (await response.json()) as T;
+}
+
+async function verifyDiscordAdministratorPermission(discordGuildId: string, discordUserId: string) {
+  const [guild, member, roles] = await Promise.all([
+    fetchDiscordJson<DiscordGuild>(`/guilds/${encodeURIComponent(discordGuildId)}`),
+    fetchDiscordJson<DiscordGuildMember>(
+      `/guilds/${encodeURIComponent(discordGuildId)}/members/${encodeURIComponent(discordUserId)}`,
+    ),
+    fetchDiscordJson<DiscordRole[]>(`/guilds/${encodeURIComponent(discordGuildId)}/roles`),
+  ]);
+
+  if (guild.owner_id === discordUserId) {
+    return {
+      verified: true,
+      evidenceSummary: `Discord user ${discordUserId} owns guild ${guild.name ?? discordGuildId}.`,
+    };
+  }
+
+  const roleIds = new Set([discordGuildId, ...(member.roles ?? [])]);
+  const permissions = roles
+    .filter((role) => roleIds.has(role.id))
+    .reduce((combined, role) => combined | BigInt(role.permissions), BigInt(0));
+  const verified = (permissions & DISCORD_ADMINISTRATOR_PERMISSION) !== BigInt(0);
+
+  return {
+    verified,
+    evidenceSummary: verified
+      ? `Discord user ${discordUserId} has Administrator permission in guild ${guild.name ?? discordGuildId}.`
+      : `Discord user ${discordUserId} does not have Administrator permission in guild ${guild.name ?? discordGuildId}.`,
+  };
 }
 
 export const claimExistingPersonWithDiscord = mutation({
@@ -265,6 +363,98 @@ export const recordDiscordCommunityAdminApproval = internalMutation({
       profileId: profile._id,
       claimState: updatedProfile?.claimState ?? profile.claimState,
     };
+  },
+});
+
+export const getDiscordCommunityClaimForAdapter = internalQuery({
+  args: {
+    claimRequestId: v.id("profileClaimRequests"),
+  },
+  handler: async (ctx, args) => {
+    const user = await requireVerifiedEmailUser(ctx);
+    const claimRequest = await ctx.db.get(args.claimRequestId);
+
+    if (claimRequest === null) {
+      throw new Error("Claim request not found.");
+    }
+
+    if (claimRequest.userId !== user._id) {
+      throw new Error("Claim request does not belong to the signed-in user.");
+    }
+
+    if (claimRequest.method !== "discord_community_admin" || claimRequest.state !== "pending") {
+      throw new Error("Only pending Discord community admin claims can be verified this way.");
+    }
+
+    if (claimRequest.discordGuildId === undefined) {
+      throw new Error("Claim request is missing a Discord guild id.");
+    }
+
+    const discordAccount = await requireLinkedDiscordAccount(ctx, user._id);
+
+    return {
+      claimRequest,
+      discordUserId: discordAccount.providerAccountId,
+    } satisfies DiscordCommunityClaimAdapterContext;
+  },
+});
+
+export const recordDiscordCommunityAdminRejection = internalMutation({
+  args: {
+    claimRequestId: v.id("profileClaimRequests"),
+    evidenceSummary: v.string(),
+  },
+  handler: async (ctx, args) => {
+    const claimRequest = await ctx.db.get(args.claimRequestId);
+
+    if (claimRequest === null) {
+      throw new Error("Claim request not found.");
+    }
+
+    if (claimRequest.method !== "discord_community_admin" || claimRequest.state !== "pending") {
+      return { state: claimRequest.state };
+    }
+
+    const now = Date.now();
+    await ctx.db.patch(claimRequest._id, {
+      state: "rejected",
+      evidenceSummary: args.evidenceSummary,
+      rejectionReason: "Discord Administrator permission was not verified.",
+      reviewedAt: now,
+      updatedAt: now,
+    });
+
+    return { state: "rejected" as const };
+  },
+});
+
+export const verifyDiscordCommunityAdminClaim = action({
+  args: {
+    claimRequestId: v.id("profileClaimRequests"),
+  },
+  handler: async (ctx, args): Promise<DiscordAdminAdapterResult> => {
+    const claimContext = (await ctx.runQuery(internal.profileClaims.getDiscordCommunityClaimForAdapter, {
+      claimRequestId: args.claimRequestId,
+    })) as DiscordCommunityClaimAdapterContext;
+    const guildId = claimContext.claimRequest.discordGuildId;
+
+    if (guildId === undefined) {
+      throw new Error("Claim request is missing a Discord guild id.");
+    }
+
+    const result = await verifyDiscordAdministratorPermission(guildId, claimContext.discordUserId);
+
+    if (!result.verified) {
+      return await ctx.runMutation(internal.profileClaims.recordDiscordCommunityAdminRejection, {
+        claimRequestId: args.claimRequestId,
+        evidenceSummary: result.evidenceSummary,
+      });
+    }
+
+    return await ctx.runMutation(internal.profileClaims.recordDiscordCommunityAdminApproval, {
+      claimRequestId: args.claimRequestId,
+      evidenceSummary: result.evidenceSummary,
+    });
   },
 });
 
@@ -471,12 +661,10 @@ export const verifyVrchatProofViaAdapter = action({
       return { state: attemptContext.attempt.state };
     }
 
-    const adapterUrl = requiredAdapterUrl();
+    const adapterUrl = proofAdapterUrl(attemptContext.attempt.targetType);
     const response = await fetch(adapterUrl, {
       method: "POST",
-      headers: {
-        "content-type": "application/json",
-      },
+      headers: proofAdapterHeaders(),
       body: JSON.stringify({
         targetType: attemptContext.attempt.targetType,
         targetExternalId: attemptContext.attempt.targetExternalId,
@@ -495,11 +683,7 @@ export const verifyVrchatProofViaAdapter = action({
       return { state: "failed" as const };
     }
 
-    const result = (await response.json()) as {
-      verified?: boolean;
-      evidenceSource?: "vrchat_api" | "vrclinking" | "manual";
-      evidenceSummary?: string;
-    };
+    const result = (await response.json()) as ProofAdapterResponse;
 
     if (result.verified !== true) {
       await ctx.runMutation(internal.profileClaims.recordVrchatProofFailure, {

--- a/convex/profileClaims.ts
+++ b/convex/profileClaims.ts
@@ -215,6 +215,21 @@ export const claimExistingPersonWithDiscord = mutation({
       getClaimableProfileBySlug(ctx.db, args.profileSlug, "person"),
       requireLinkedDiscordAccount(ctx, user._id),
     ]);
+    const activeOwner = await getActiveProfileOwner(ctx.db, profile._id);
+
+    if (activeOwner !== null && activeOwner.userId !== user._id) {
+      throw new Error("This profile already has an active owner.");
+    }
+
+    if (activeOwner !== null) {
+      return {
+        profileId: profile._id,
+        claimState: profile.claimState,
+        profilePath: `/p/${profile.slug}`,
+        state: "already_owned" as const,
+      };
+    }
+
     const now = Date.now();
     const claimRequestId = await ctx.db.insert("profileClaimRequests", {
       profileId: profile._id,
@@ -516,10 +531,15 @@ export const getVerificationAttemptForAdapter = internalQuery({
     attemptId: v.id("profileVerificationAttempts"),
   },
   handler: async (ctx, args) => {
+    const user = await requireVerifiedEmailUser(ctx);
     const attempt = await ctx.db.get(args.attemptId);
 
     if (attempt === null) {
       return null;
+    }
+
+    if (attempt.userId !== user._id) {
+      throw new Error("Verification attempt does not belong to the signed-in user.");
     }
 
     const profile = await ctx.db.get(attempt.profileId);

--- a/convex/schema.ts
+++ b/convex/schema.ts
@@ -1,5 +1,6 @@
 import { defineSchema, defineTable } from "convex/server";
 import { v } from "convex/values";
+import { authTables } from "@convex-dev/auth/server";
 
 const claimState = v.union(
   v.literal("unclaimed"),
@@ -16,6 +17,12 @@ const publicSurfacingState = v.union(
   v.literal("public"),
   v.literal("opted_out"),
   v.literal("suppressed"),
+);
+
+const fieldVisibilityState = v.union(
+  v.literal("public"),
+  v.literal("unlisted"),
+  v.literal("private"),
 );
 
 const creationSource = v.union(
@@ -139,6 +146,44 @@ const communityCapability = v.union(
 
 const communityAuthorityState = v.union(v.literal("active"), v.literal("revoked"));
 
+const profileOwnerState = v.union(v.literal("active"), v.literal("revoked"));
+
+const profileClaimMethod = v.union(
+  v.literal("discord_person"),
+  v.literal("discord_community_admin"),
+  v.literal("vrchat_user_proof"),
+  v.literal("vrchat_group_proof"),
+  v.literal("vrclinking_attestation"),
+  v.literal("manual"),
+);
+
+const profileClaimRequestState = v.union(
+  v.literal("pending"),
+  v.literal("approved"),
+  v.literal("rejected"),
+  v.literal("expired"),
+);
+
+const profileVerificationTargetType = v.union(
+  v.literal("vrchat_user"),
+  v.literal("vrchat_group"),
+  v.literal("vrclinking"),
+);
+
+const profileVerificationAttemptState = v.union(
+  v.literal("pending"),
+  v.literal("verified"),
+  v.literal("failed"),
+  v.literal("expired"),
+);
+
+const profileVerificationEvidenceSource = v.union(
+  v.literal("discord_api"),
+  v.literal("vrchat_api"),
+  v.literal("vrclinking"),
+  v.literal("manual"),
+);
+
 const suppressionRequestType = v.union(
   v.literal("owner_opt_out"),
   v.literal("pre_claim_safety"),
@@ -194,6 +239,23 @@ const authSubject = v.object({
   displayName: v.optional(v.string()),
 });
 
+const fieldVisibility = v.object({
+  aliases: v.optional(fieldVisibilityState),
+  tags: v.optional(fieldVisibilityState),
+  headline: v.optional(fieldVisibilityState),
+  bio: v.optional(fieldVisibilityState),
+  about: v.optional(fieldVisibilityState),
+  avatarImageUrl: v.optional(fieldVisibilityState),
+  bannerImageUrl: v.optional(fieldVisibilityState),
+  outboundLinks: v.optional(fieldVisibilityState),
+  region: v.optional(fieldVisibilityState),
+  timezone: v.optional(fieldVisibilityState),
+  personPronouns: v.optional(fieldVisibilityState),
+  personRoleTags: v.optional(fieldVisibilityState),
+  communitySubtype: v.optional(fieldVisibilityState),
+  communityCategoryTags: v.optional(fieldVisibilityState),
+});
+
 const sharedProfileFields = {
   slug: v.string(),
   displayName: v.string(),
@@ -222,6 +284,7 @@ const sharedProfileFields = {
   publicSurfacingState,
   publicSurfacingUpdatedAt: v.optional(v.number()),
   publicSurfacingReason: v.optional(v.string()),
+  fieldVisibility: v.optional(fieldVisibility),
   creationSource,
   sourceAttribution: v.optional(
     v.object({
@@ -242,6 +305,7 @@ const sharedProfileFields = {
 };
 
 export default defineSchema({
+  ...authTables,
   profiles: defineTable(
     v.union(
       v.object({
@@ -429,6 +493,59 @@ export default defineSchema({
       "state",
       "communityProfileId",
     ]),
+  profileOwners: defineTable({
+    profileId: v.id("profiles"),
+    userId: v.id("users"),
+    roleKey: v.literal("owner"),
+    state: profileOwnerState,
+    grantedByClaimRequestId: v.optional(v.id("profileClaimRequests")),
+    grantedAt: v.number(),
+    revokedAt: v.optional(v.number()),
+    updatedAt: v.number(),
+  })
+    .index("by_profileId_state", ["profileId", "state"])
+    .index("by_userId_state", ["userId", "state"])
+    .index("by_profileId_roleKey_state", ["profileId", "roleKey", "state"]),
+  profileClaimRequests: defineTable({
+    profileId: v.optional(v.id("profiles")),
+    profileSlug: v.optional(v.string()),
+    profileType,
+    requestedDisplayName: v.optional(v.string()),
+    userId: v.id("users"),
+    method: profileClaimMethod,
+    state: profileClaimRequestState,
+    discordGuildId: v.optional(v.string()),
+    discordGuildName: v.optional(v.string()),
+    vrchatTargetId: v.optional(v.string()),
+    evidenceSource: v.optional(profileVerificationEvidenceSource),
+    evidenceSummary: v.optional(v.string()),
+    rejectionReason: v.optional(v.string()),
+    createdAt: v.number(),
+    updatedAt: v.number(),
+    verifiedAt: v.optional(v.number()),
+    reviewedAt: v.optional(v.number()),
+  })
+    .index("by_profileId_state", ["profileId", "state"])
+    .index("by_userId_state", ["userId", "state"])
+    .index("by_method_state", ["method", "state"]),
+  profileVerificationAttempts: defineTable({
+    profileId: v.id("profiles"),
+    userId: v.id("users"),
+    method: profileClaimMethod,
+    targetType: profileVerificationTargetType,
+    targetExternalId: v.string(),
+    proofCode: v.string(),
+    state: profileVerificationAttemptState,
+    evidenceSource: v.optional(profileVerificationEvidenceSource),
+    evidenceSummary: v.optional(v.string()),
+    createdAt: v.number(),
+    updatedAt: v.number(),
+    expiresAt: v.number(),
+    verifiedAt: v.optional(v.number()),
+  })
+    .index("by_profileId_state", ["profileId", "state"])
+    .index("by_userId_state", ["userId", "state"])
+    .index("by_state_expiresAt", ["state", "expiresAt"]),
   profileSuppressionRequests: defineTable({
     profileId: v.optional(v.id("profiles")),
     profileSlug: v.optional(v.string()),

--- a/convex/tsconfig.json
+++ b/convex/tsconfig.json
@@ -8,6 +8,7 @@
     "allowJs": true,
     "strict": true,
     "moduleResolution": "Bundler",
+    "jsx": "react-jsx",
     "skipLibCheck": true,
     "allowSyntheticDefaultImports": true,
 

--- a/docs/backend/convex-bootstrap.md
+++ b/docs/backend/convex-bootstrap.md
@@ -39,7 +39,8 @@ Notes:
 - The local Convex wrapper mirrors the repo-root `CONVEX_URL` into `apps/web/.env.local` as `NEXT_PUBLIC_CONVEX_URL` so the web app can follow the normal client-side Convex + Next.js convention without leaking a non-public variable through server props.
 - That same `NEXT_PUBLIC_CONVEX_URL` value is also what `fetchQuery` uses for the current server-side baseline route, so local client and server reads share one deployment setting.
 - Anonymous local backend state for this repo is kept under `.convex-home/` and `.convex-tmp/` so the bootstrap does not collide with other Convex projects on the same machine.
-- The current bootstrap is local-development focused. Production deploy keys, preview deployments, and frontend environment wiring belong to follow-on issues.
+- Production Convex deploys run from the baseline GitHub Actions workflow when `CONVEX_DEPLOY_KEY` is configured; otherwise the deploy job records a skip summary and exits cleanly.
+- Deploy-time data backfills are declared with `@convex-dev/migrations` and run through `migrations:runAll` after production function deploys.
 - Committed files in `convex/_generated/` are treated as checked-in build artifacts and should remain diff-free after `pnpm check:backend:generated`.
 
 ## Structure rule

--- a/docs/backend/profile-access-and-claims.md
+++ b/docs/backend/profile-access-and-claims.md
@@ -68,12 +68,12 @@ A weaker approval method must not downgrade an already verified profile. For exa
 Current claim-level actions require a signed-in Convex Auth user with a verified email address.
 
 - Discord person claims require a linked Discord provider account and grant `claimed_unverified` owner control for an existing person profile.
-- Discord community claims require a linked Discord provider account and create a pending `discord_community_admin` request. The profile is not granted until a Discord adapter verifies full Administrator permission.
+- Discord community claims require a linked Discord provider account and create a pending `discord_community_admin` request. The profile is not granted until `profileClaims:verifyDiscordCommunityAdminClaim` verifies full Administrator permission through a Discord bot token.
 - VRChat user proof requires a person profile and creates a proof-code attempt with `targetType: "vrchat_user"`.
 - VRChat group proof requires a community profile and creates a proof-code attempt with `targetType: "vrchat_group"`.
 - VRCLinking currently uses the same proof-code attempt table and adapter seam with `targetType: "vrclinking"` until a stable API contract is confirmed.
 
-The automated proof reader lives behind `profileClaims:verifyVrchatProofViaAdapter` and calls `VRCHAT_PROOF_ADAPTER_URL`. The adapter receives the target type, target external id, proof code, and safe profile context, then returns whether the code was found plus an evidence summary.
+The automated proof reader lives behind `profileClaims:verifyVrchatProofViaAdapter`. It calls `VRCHAT_PROOF_ADAPTER_URL` for VRChat user/group proofs and `VRCLINKING_PROOF_ADAPTER_URL` for VRCLinking proofs. The adapter receives the target type, target external id, proof code, and safe profile context, then returns whether the code was found plus an evidence summary.
 
 ## Field Visibility
 

--- a/docs/backend/profile-access-and-claims.md
+++ b/docs/backend/profile-access-and-claims.md
@@ -2,9 +2,9 @@
 
 ## Status Note
 
-This doc captures the permission and claim-state baseline for `#12` and `#13`.
+This doc captures the permission and claim-state baseline for `#12` and `#13`, extended by the first auth, ownership, field-visibility, Discord claim, and VRChat proof-code slice.
 
-It intentionally does not add account records, OAuth claim flows, VRChat proof-code verification, moderation UI, role delegation, or ownership transfer.
+It intentionally does not add moderation UI, role delegation, ownership transfer, contested-claim resolution, or a hard-coded VRCLinking API integration.
 
 ## Read Baseline
 
@@ -27,11 +27,21 @@ Community submitters may populate only a narrow safe field set for unclaimed pro
 
 Community submitters must not set fields that imply verified authority, private contact details, billing state, ownership, custom slugs, or sensitive visibility choices. Profile creation can still generate an initial slug from submitted display text.
 
-The current public mutation requires a Convex authenticated identity and stores source attribution, but it does not introduce a durable account table or ownership link. Freeform bios, about text, avatar URLs, banner URLs, private contact details, and custom slugs are intentionally outside the ordinary community-submission field set.
+The current public mutation requires a Convex authenticated identity and stores source attribution. Freeform bios, about text, avatar URLs, banner URLs, private contact details, and custom slugs are intentionally outside the ordinary community-submission field set.
 
 Claimed owners may edit normal profile fields after a claim attaches authority to the existing profile record. This baseline assumes claimed owners can edit identity, presentation, slug, tags, and type-specific profile fields, subject to future field-level visibility and abuse controls.
 
 Moderators may override profile fields later for safety, corrections, and abuse handling. The moderation UI and detailed audit model are deferred.
+
+## Ownership Records
+
+`profileOwners` records are the durable owner authority link between Convex Auth `users` and `profiles`.
+
+- `roleKey` is currently the singleton literal `owner`
+- only one active owner may exist for a profile at a time
+- repeated grants for the same active owner are idempotent
+- grants to a different active owner must fail until a future transfer or moderation flow revokes the old owner
+- claim approval must update the profile search document because trust rank and public trust labels can change
 
 ## Claim States
 
@@ -50,6 +60,30 @@ Allowed ordinary transitions are real state changes only:
 - `claimed_unverified` -> `claimed_verified`
 
 Downgrades, contested claims, transfer flows, and suppression flows require explicit moderation or ownership workflows later.
+
+A weaker approval method must not downgrade an already verified profile. For example, a later Discord person claim leaves an existing `claimed_verified` profile verified instead of moving it back to `claimed_unverified`.
+
+## Claim Methods
+
+Current claim-level actions require a signed-in Convex Auth user with a verified email address.
+
+- Discord person claims require a linked Discord provider account and grant `claimed_unverified` owner control for an existing person profile.
+- Discord community claims require a linked Discord provider account and create a pending `discord_community_admin` request. The profile is not granted until a Discord adapter verifies full Administrator permission.
+- VRChat user proof requires a person profile and creates a proof-code attempt with `targetType: "vrchat_user"`.
+- VRChat group proof requires a community profile and creates a proof-code attempt with `targetType: "vrchat_group"`.
+- VRCLinking currently uses the same proof-code attempt table and adapter seam with `targetType: "vrclinking"` until a stable API contract is confirmed.
+
+The automated proof reader lives behind `profileClaims:verifyVrchatProofViaAdapter` and calls `VRCHAT_PROOF_ADAPTER_URL`. The adapter receives the target type, target external id, proof code, and safe profile context, then returns whether the code was found plus an evidence summary.
+
+## Field Visibility
+
+Profile field visibility supports three states:
+
+- `public`: visible on direct profile pages and eligible for discovery/search/card projections
+- `unlisted`: visible on direct profile pages but omitted from discovery/search/card projections
+- `private`: omitted from all public projections
+
+`displayName`, `slug`, `profileType`, and trust labels remain public while the profile itself is public.
 
 ## Trust Labels
 
@@ -71,3 +105,4 @@ Future claim mutations must:
 - set `claimedAt` when `claimState` leaves `"unclaimed"`
 - preserve the profile `_id` and slug when authority changes
 - patch `updatedAt` on every profile write
+- use `profileOwners` for durable owner authority instead of interpreting provider login as ownership by itself

--- a/docs/backend/profile-schema.md
+++ b/docs/backend/profile-schema.md
@@ -4,7 +4,7 @@
 
 This doc captures the durable profile schema foundation started in `#9` and extended through `#10`, `#11`, `#12`, `#13`, `#22`, `#23`, `#25`, `#26`, `#30`, `#31`, `#32`, `#33`, `#82`, and `#90`.
 
-The schema is intentionally narrow. It establishes one shared `profiles` table for people and communities without introducing account tables, full claim flows, normalized link tables, asset tables, or advanced moderation workflows.
+The schema is intentionally narrow. It establishes one shared `profiles` table for people and communities plus first-slice account ownership, claim request, verification attempt, and field visibility tables without introducing normalized link tables, asset tables, or advanced moderation workflows.
 
 ## Locked Decisions
 
@@ -14,7 +14,7 @@ The schema is intentionally narrow. It establishes one shared `profiles` table f
 - claim state, publication state, and creation provenance are separate fields
 - community-submitted unclaimed records are represented by `creationSource: "community"` plus `claimState: "unclaimed"`
 - public surfacing state is separate from ordinary publication state so valid opt-out and suppression can hide otherwise-published profiles
-- account/user references are deferred until auth and claim issues define the account model
+- account/user ownership references live in `profileOwners`; provider login alone is not ownership
 - most public write mutations are deferred until auth and permissions are wired; `profiles:submitCommunityProfile` is the current auth-gated exception
 - the community submission mutation requires a Convex authenticated identity before writing
 - normalized alias, asset, and rich authored block tables are deferred to later profile presentation issues
@@ -51,6 +51,7 @@ State fields:
 - `publicSurfacingState`: `"public" | "opted_out" | "suppressed"`
 - `publicSurfacingUpdatedAt`: optional timestamp for the latest public-surfacing state change
 - `publicSurfacingReason`: optional short reason for opt-out or suppression state
+- `fieldVisibility`: optional per-field visibility map using `"public" | "unlisted" | "private"`
 - `claimedAt`: optional claim timestamp, present only after claim authority is established
 - `publishedAt`: optional publication timestamp, present once a profile has been published
 - `updatedAt`: application-maintained update timestamp that every profile mutation must refresh
@@ -64,6 +65,24 @@ Type-specific fields:
 - `community.categoryTags`: flexible category tags for community discovery and presentation
 
 Convex automatically provides `_id` and `_creationTime`; those are not duplicated in the schema.
+
+## Ownership And Claim Tables
+
+Convex Auth provides the `users` and `authAccounts` tables used by account and provider-link flows.
+
+`profileOwners` stores durable profile authority:
+
+- `profileId`: profile receiving ownership
+- `userId`: Convex Auth user that owns the profile
+- `roleKey`: currently the singleton literal `owner`
+- `state`: `"active" | "revoked"`
+- `grantedByClaimRequestId`: optional claim request that granted ownership
+
+`profileClaimRequests` stores claim review state for Discord, VRChat, VRCLinking, and manual methods.
+
+`profileVerificationAttempts` stores proof-code attempts for external proof readers. Attempts have a proof code, target type, target external id, state, expiry, and optional evidence summary.
+
+The first automated proof reader is an adapter action configured by `VRCHAT_PROOF_ADAPTER_URL`; it avoids hard-coding guessed VRChat or VRCLinking API behavior into the product backend.
 
 ## State Semantics
 
@@ -86,6 +105,14 @@ Convex automatically provides `_id` and `_creationTime`; those are not duplicate
 
 `creationSource` describes how the record entered the system. It is not an authority marker by itself; authority comes from `claimState` and later claim records.
 
+`fieldVisibility` controls public projection surfaces:
+
+- `public`: direct profile page plus discovery/search/card projections
+- `unlisted`: direct profile page only
+- `private`: hidden from public projections
+
+`displayName`, `slug`, `profileType`, and trust labels remain public while the profile itself is public.
+
 ## Mutation Contracts
 
 Convex schema validation cannot enforce conditional timestamp invariants, so profile mutations must preserve these application-level rules:
@@ -98,6 +125,8 @@ The first write path is `profiles:submitCommunityProfile`. It requires `ctx.auth
 
 The `migrations:backfillProfilePublicSurfacingState` internal mutation sets missing legacy `publicSurfacingState` values to `"public"` and fills `publicSurfacingUpdatedAt` so previously-written profiles keep their existing publication behavior after the surfacing-state schema addition.
 
+Deploy-time migrations use `@convex-dev/migrations` and are run by `migrations:runAll` after production function deploys when `CONVEX_DEPLOY_KEY` is configured.
+
 ## Initial Indexes
 
 - `by_slug`: canonical profile lookup and mutation-enforced slug uniqueness
@@ -107,6 +136,10 @@ The `migrations:backfillProfilePublicSurfacingState` internal mutation sets miss
 - `by_claimState_profileType`: moderation and claim-review flows by claim state, with optional type splitting
 - `by_creationSource_claimState`: moderation and community-submitted/unclaimed review flows
 - `by_profileType_sortName`: deterministic profile listing by type
+- `profileOwners.by_profileId_roleKey_state`: active owner singleton enforcement
+- `profileOwners.by_userId_state`: account profile ownership lookup
+- `profileClaimRequests.by_profileId_state`: profile claim review lookup
+- `profileVerificationAttempts.by_state_expiresAt`: pending proof attempt expiry scans
 
 ## Follow-On Boundaries
 

--- a/docs/backend/search-discovery.md
+++ b/docs/backend/search-discovery.md
@@ -9,6 +9,7 @@ Current recommendation and first implementation for the expanded public discover
 - public discovery starts from explicit VRDex records, not scraped popularity or private presence
 - search is a first-class product surface, not a secondary directory page
 - search and discovery must enforce `publicationState` and `publicSurfacingState`
+- search and discovery must enforce profile field visibility; `unlisted` direct-page fields are not indexed or shown on cards
 - community-submitted and unverified records can be discoverable only with visible trust and source labels
 - events, worlds, people, and communities participate in universal search through search documents
 - PostHog is the first-pass analytics target for discovery instrumentation when configured
@@ -31,6 +32,8 @@ Each document stores:
 The first live implementation uses Convex full-text search. Convex supports relevance ordering and prefix/typeahead behavior. Fuzzy typo matching should not be reimplemented with ad hoc regex piles or one-off Levenshtein hacks in app code.
 
 Profile and event mutations update their own search documents. Worlds do not yet have a public write mutation, so `search.rebuildWorldSearchDocuments` is an internal backfill hook for keeping world search documents populated until that write path exists.
+
+Profile search documents always include public identity basics such as display name, slug, profile type, and route. Optional profile fields only participate when their `fieldVisibility` is `public`; `unlisted` fields remain visible on direct profile pages but are omitted from search text, exact tokens, vocabulary keys, summaries, and image cards.
 
 ## Semantic And Vector Search Seam
 

--- a/docs/deployment/convex-environments.md
+++ b/docs/deployment/convex-environments.md
@@ -1,0 +1,32 @@
+# Convex Environments
+
+## Locked Decision
+
+VRDex keeps three Convex execution targets separate:
+
+- local development: anonymous local Convex from `pnpm dev:backend:local` or `pnpm verify:backend:local`
+- deployed smoke testing: the shared development Convex deployment
+- production release: the production Convex deployment
+
+## Current Deployments
+
+Do not commit deploy keys. Store them in GitHub/hosting secret stores and local ignored env files only.
+
+- development cloud URL: `https://scrupulous-corgi-247.convex.cloud`
+- production cloud URL: `https://superb-pig-954.convex.cloud`
+
+GitHub Actions secret names:
+
+- `CONVEX_DEPLOY_KEY_DEV`: development deployment key
+- `CONVEX_DEPLOY_KEY_PROD`: production deployment key used by the main-branch deploy workflow
+
+Local ignored env names:
+
+- `CONVEX_DEPLOY_KEY_DEV`
+- `CONVEX_DEPLOY_KEY_PROD`
+- `CONVEX_URL_DEV`
+- `CONVEX_URL_PROD`
+
+## Notes
+
+There are two similarly named Convex projects in the account history: `vrdex` and `vrdex-85631`. Current recommendation is to keep the `vrdex` line of deployments and archive/delete the other only after confirming no dashboard, env, or deployment history still depends on it.

--- a/docs/deployment/ses-auth-email.md
+++ b/docs/deployment/ses-auth-email.md
@@ -1,0 +1,38 @@
+# SES Auth Email
+
+## Current Recommendation
+
+Use Amazon SES for Convex Auth password and email verification messages.
+
+The Terraform stack at `infra/terraform/ses` provisions the SES domain identity, DKIM, custom MAIL FROM records, and an optional least-privilege IAM access key for Convex.
+
+## Convex Environment Variables
+
+Set these in each Convex deployment that sends email:
+
+- `AWS_SES_REGION`
+- `AWS_SES_FROM_EMAIL`
+- `AWS_ACCESS_KEY_ID`
+- `AWS_SECRET_ACCESS_KEY`
+- `VRDEX_APP_NAME` optional display name for email copy
+
+## Adapter Environment Variables
+
+Discord community Administrator verification:
+
+- `DISCORD_BOT_TOKEN`: Discord bot token for reading guild, member, and role state
+- `DISCORD_API_BASE_URL`: optional override, defaults to `https://discord.com/api/v10`
+
+The bot must be present in claimed guilds and able to read members and roles.
+
+VRChat and VRCLinking proof-code verification:
+
+- `VRCHAT_PROOF_ADAPTER_URL`: POST endpoint for VRChat user/group proof checks
+- `VRCLINKING_PROOF_ADAPTER_URL`: POST endpoint for VRCLinking proof checks
+- `VRCHAT_PROOF_ADAPTER_BEARER_TOKEN`: optional bearer token sent to both proof adapters
+
+Proof adapters receive JSON with `targetType`, `targetExternalId`, `proofCode`, and safe profile context. They must return JSON with `verified`, `evidenceSource`, and `evidenceSummary`.
+
+## Sandbox Note
+
+SES domain verification and DKIM do not automatically move an AWS account out of SES sandbox mode. Request SES production access in AWS before relying on real user emails outside verified recipient addresses.

--- a/infra/terraform/ses/.terraform.lock.hcl
+++ b/infra/terraform/ses/.terraform.lock.hcl
@@ -1,0 +1,25 @@
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
+
+provider "registry.terraform.io/hashicorp/aws" {
+  version     = "5.100.0"
+  constraints = "~> 5.0"
+  hashes = [
+    "h1:H3mU/7URhP0uCRGK8jeQRKxx2XFzEqLiOq/L2Bbiaxs=",
+    "zh:054b8dd49f0549c9a7cc27d159e45327b7b65cf404da5e5a20da154b90b8a644",
+    "zh:0b97bf8d5e03d15d83cc40b0530a1f84b459354939ba6f135a0086c20ebbe6b2",
+    "zh:1589a2266af699cbd5d80737a0fe02e54ec9cf2ca54e7e00ac51c7359056f274",
+    "zh:6330766f1d85f01ae6ea90d1b214b8b74cc8c1badc4696b165b36ddd4cc15f7b",
+    "zh:7c8c2e30d8e55291b86fcb64bdf6c25489d538688545eb48fd74ad622e5d3862",
+    "zh:99b1003bd9bd32ee323544da897148f46a527f622dc3971af63ea3e251596342",
+    "zh:9b12af85486a96aedd8d7984b0ff811a4b42e3d88dad1a3fb4c0b580d04fa425",
+    "zh:9f8b909d3ec50ade83c8062290378b1ec553edef6a447c56dadc01a99f4eaa93",
+    "zh:aaef921ff9aabaf8b1869a86d692ebd24fbd4e12c21205034bb679b9caf883a2",
+    "zh:ac882313207aba00dd5a76dbd572a0ddc818bb9cbf5c9d61b28fe30efaec951e",
+    "zh:bb64e8aff37becab373a1a0cc1080990785304141af42ed6aa3dd4913b000421",
+    "zh:dfe495f6621df5540d9c92ad40b8067376350b005c637ea6efac5dc15028add4",
+    "zh:f0ddf0eaf052766cfe09dea8200a946519f653c384ab4336e2a4a64fdd6310e9",
+    "zh:f1b7e684f4c7ae1eed272b6de7d2049bb87a0275cb04dbb7cda6636f600699c9",
+    "zh:ff461571e3f233699bf690db319dfe46aec75e58726636a0d97dd9ac6e32fb70",
+  ]
+}

--- a/infra/terraform/ses/README.md
+++ b/infra/terraform/ses/README.md
@@ -1,0 +1,30 @@
+# SES Auth Email Terraform
+
+This stack provisions the SES sender identity VRDex needs for Convex Auth password and email verification messages.
+
+It creates:
+
+- SES domain identity
+- Easy DKIM tokens
+- optional Route 53 verification and DKIM records
+- optional custom MAIL FROM domain records
+- optional least-privilege IAM access key for Convex `ses:SendEmail`
+
+## Usage
+
+1. Copy `terraform.tfvars.example` to `terraform.tfvars` and set the real domain values.
+2. Run `terraform init`.
+3. Run `terraform plan` and review the SES, Route 53, and IAM changes.
+4. Apply only after confirming the DNS zone and sender domain.
+5. Store the sensitive outputs in Convex env, not in git.
+
+Convex env values after apply:
+
+- `AWS_SES_REGION`: `terraform output -raw aws_ses_region`
+- `AWS_SES_FROM_EMAIL`: `terraform output -raw aws_ses_from_email`
+- `AWS_ACCESS_KEY_ID`: `terraform output -raw aws_access_key_id`
+- `AWS_SECRET_ACCESS_KEY`: `terraform output -raw aws_secret_access_key`
+
+SES accounts can remain in sandbox mode even after domain verification. If production sending is still sandboxed, request SES production access in the AWS console before relying on real user emails.
+
+Use a secure Terraform backend for this stack before applying with `create_iam_access_key = true`; the access key secret is stored in Terraform state.

--- a/infra/terraform/ses/main.tf
+++ b/infra/terraform/ses/main.tf
@@ -1,0 +1,119 @@
+data "aws_caller_identity" "current" {}
+
+data "aws_route53_zone" "ses" {
+  count = var.create_route53_records && var.route53_zone_id == null ? 1 : 0
+
+  name         = var.hosted_zone_name != null ? var.hosted_zone_name : var.domain_name
+  private_zone = false
+}
+
+locals {
+  from_email       = var.from_email != null ? var.from_email : "no-reply@${var.domain_name}"
+  mail_from_domain = "${var.mail_from_subdomain}.${var.domain_name}"
+  route53_zone_id = var.route53_zone_id != null ? var.route53_zone_id : (
+    var.create_route53_records ? data.aws_route53_zone.ses[0].zone_id : null
+  )
+  tags = merge(
+    {
+      Project   = "VRDex"
+      ManagedBy = "Terraform"
+      Component = "ses-auth-email"
+    },
+    var.tags,
+  )
+}
+
+resource "aws_ses_domain_identity" "vrdex" {
+  domain = var.domain_name
+}
+
+resource "aws_ses_domain_dkim" "vrdex" {
+  domain = aws_ses_domain_identity.vrdex.domain
+}
+
+resource "aws_route53_record" "ses_domain_verification" {
+  count = var.create_route53_records ? 1 : 0
+
+  zone_id = local.route53_zone_id
+  name    = "_amazonses.${aws_ses_domain_identity.vrdex.domain}"
+  type    = "TXT"
+  ttl     = 600
+  records = [aws_ses_domain_identity.vrdex.verification_token]
+}
+
+resource "aws_ses_domain_identity_verification" "vrdex" {
+  count = var.create_route53_records && var.wait_for_domain_verification ? 1 : 0
+
+  domain = aws_ses_domain_identity.vrdex.domain
+
+  depends_on = [aws_route53_record.ses_domain_verification]
+}
+
+resource "aws_route53_record" "ses_dkim" {
+  count = var.create_route53_records ? 3 : 0
+
+  zone_id = local.route53_zone_id
+  name    = "${aws_ses_domain_dkim.vrdex.dkim_tokens[count.index]}._domainkey.${var.domain_name}"
+  type    = "CNAME"
+  ttl     = 600
+  records = ["${aws_ses_domain_dkim.vrdex.dkim_tokens[count.index]}.dkim.amazonses.com"]
+}
+
+resource "aws_ses_domain_mail_from" "vrdex" {
+  domain           = aws_ses_domain_identity.vrdex.domain
+  mail_from_domain = local.mail_from_domain
+}
+
+resource "aws_route53_record" "ses_mail_from_mx" {
+  count = var.create_route53_records ? 1 : 0
+
+  zone_id = local.route53_zone_id
+  name    = aws_ses_domain_mail_from.vrdex.mail_from_domain
+  type    = "MX"
+  ttl     = 600
+  records = ["10 feedback-smtp.${var.aws_region}.amazonses.com"]
+}
+
+resource "aws_route53_record" "ses_mail_from_spf" {
+  count = var.create_route53_records ? 1 : 0
+
+  zone_id = local.route53_zone_id
+  name    = aws_ses_domain_mail_from.vrdex.mail_from_domain
+  type    = "TXT"
+  ttl     = 600
+  records = ["v=spf1 include:amazonses.com ~all"]
+}
+
+resource "aws_iam_user" "convex_ses_sender" {
+  count = var.create_iam_access_key ? 1 : 0
+
+  name = "vrdex-convex-ses-sender"
+  path = "/service/"
+}
+
+data "aws_iam_policy_document" "convex_ses_sender" {
+  count = var.create_iam_access_key ? 1 : 0
+
+  statement {
+    sid = "AllowSendingFromVRDexIdentity"
+    actions = [
+      "ses:SendEmail",
+      "ses:SendRawEmail",
+    ]
+    resources = [aws_ses_domain_identity.vrdex.arn]
+  }
+}
+
+resource "aws_iam_user_policy" "convex_ses_sender" {
+  count = var.create_iam_access_key ? 1 : 0
+
+  name   = "send-vrdex-auth-email"
+  user   = aws_iam_user.convex_ses_sender[0].name
+  policy = data.aws_iam_policy_document.convex_ses_sender[0].json
+}
+
+resource "aws_iam_access_key" "convex_ses_sender" {
+  count = var.create_iam_access_key ? 1 : 0
+
+  user = aws_iam_user.convex_ses_sender[0].name
+}

--- a/infra/terraform/ses/outputs.tf
+++ b/infra/terraform/ses/outputs.tf
@@ -1,0 +1,62 @@
+output "aws_ses_region" {
+  description = "Set this as AWS_SES_REGION in Convex."
+  value       = var.aws_region
+}
+
+output "aws_ses_from_email" {
+  description = "Set this as AWS_SES_FROM_EMAIL in Convex."
+  value       = local.from_email
+}
+
+output "ses_identity_arn" {
+  description = "SES identity ARN allowed by the generated IAM sender policy."
+  value       = aws_ses_domain_identity.vrdex.arn
+}
+
+output "ses_domain_verification_record" {
+  description = "Manual DNS record to create if create_route53_records is false."
+  value = {
+    name  = "_amazonses.${aws_ses_domain_identity.vrdex.domain}"
+    type  = "TXT"
+    value = aws_ses_domain_identity.vrdex.verification_token
+  }
+}
+
+output "ses_dkim_records" {
+  description = "Manual DKIM CNAME records to create if create_route53_records is false."
+  value = [
+    for token in aws_ses_domain_dkim.vrdex.dkim_tokens : {
+      name  = "${token}._domainkey.${var.domain_name}"
+      type  = "CNAME"
+      value = "${token}.dkim.amazonses.com"
+    }
+  ]
+}
+
+output "ses_mail_from_records" {
+  description = "Manual custom MAIL FROM DNS records to create if create_route53_records is false."
+  value = [
+    {
+      name  = local.mail_from_domain
+      type  = "MX"
+      value = "10 feedback-smtp.${var.aws_region}.amazonses.com"
+    },
+    {
+      name  = local.mail_from_domain
+      type  = "TXT"
+      value = "v=spf1 include:amazonses.com ~all"
+    },
+  ]
+}
+
+output "aws_access_key_id" {
+  description = "Set this as AWS_ACCESS_KEY_ID in Convex when create_iam_access_key is true."
+  value       = var.create_iam_access_key ? aws_iam_access_key.convex_ses_sender[0].id : null
+  sensitive   = true
+}
+
+output "aws_secret_access_key" {
+  description = "Set this as AWS_SECRET_ACCESS_KEY in Convex when create_iam_access_key is true."
+  value       = var.create_iam_access_key ? aws_iam_access_key.convex_ses_sender[0].secret : null
+  sensitive   = true
+}

--- a/infra/terraform/ses/terraform.tfvars.example
+++ b/infra/terraform/ses/terraform.tfvars.example
@@ -1,0 +1,15 @@
+aws_region  = "us-east-1"
+domain_name = "vrdex.net"
+from_email  = "no-reply@vrdex.net"
+
+# Set one of these when using Route 53 DNS automation.
+# hosted_zone_name = "vrdex.net"
+# route53_zone_id  = "Z0000000000000000000"
+
+create_route53_records       = true
+wait_for_domain_verification = false
+create_iam_access_key        = true
+
+tags = {
+  Environment = "production"
+}

--- a/infra/terraform/ses/variables.tf
+++ b/infra/terraform/ses/variables.tf
@@ -1,0 +1,58 @@
+variable "aws_region" {
+  description = "AWS region for the SES identity. Convex must use the same value as AWS_SES_REGION."
+  type        = string
+  default     = "us-east-1"
+}
+
+variable "domain_name" {
+  description = "Domain identity to verify in SES, for example vrdex.app."
+  type        = string
+}
+
+variable "from_email" {
+  description = "Email address Convex Auth should use as AWS_SES_FROM_EMAIL. Defaults to no-reply@domain_name."
+  type        = string
+  default     = null
+}
+
+variable "mail_from_subdomain" {
+  description = "Subdomain for SES custom MAIL FROM."
+  type        = string
+  default     = "bounce"
+}
+
+variable "hosted_zone_name" {
+  description = "Route 53 public hosted zone name. Defaults to domain_name when Route 53 records are enabled."
+  type        = string
+  default     = null
+}
+
+variable "route53_zone_id" {
+  description = "Route 53 public hosted zone id. Set this when the zone name is ambiguous."
+  type        = string
+  default     = null
+}
+
+variable "create_route53_records" {
+  description = "Whether Terraform should create SES verification, DKIM, SPF, and MAIL FROM records in Route 53."
+  type        = bool
+  default     = true
+}
+
+variable "wait_for_domain_verification" {
+  description = "Whether Terraform should wait for SES domain identity verification after DNS records are created."
+  type        = bool
+  default     = false
+}
+
+variable "create_iam_access_key" {
+  description = "Whether to create a least-privilege IAM access key for Convex SES SendEmail calls. Store the secret output in Convex env, never in git."
+  type        = bool
+  default     = true
+}
+
+variable "tags" {
+  description = "Additional resource tags."
+  type        = map(string)
+  default     = {}
+}

--- a/infra/terraform/ses/versions.tf
+++ b/infra/terraform/ses/versions.tf
@@ -1,0 +1,18 @@
+terraform {
+  required_version = ">= 1.6.0"
+
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 5.0"
+    }
+  }
+}
+
+provider "aws" {
+  region = var.aws_region
+
+  default_tags {
+    tags = local.tags
+  }
+}

--- a/package.json
+++ b/package.json
@@ -35,5 +35,11 @@
     "lint-staged": "^16.3.3",
     "tsx": "^4.22.1",
     "typescript": "^5.9.3"
+  },
+  "dependencies": {
+    "@auth/core": "^0.37.4",
+    "@aws-sdk/client-ses": "^3.1055.0",
+    "@convex-dev/auth": "^0.0.92",
+    "@convex-dev/migrations": "^0.3.4"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -7,6 +7,19 @@ settings:
 importers:
 
   .:
+    dependencies:
+      '@auth/core':
+        specifier: ^0.37.4
+        version: 0.37.4
+      '@aws-sdk/client-ses':
+        specifier: ^3.1055.0
+        version: 3.1055.0
+      '@convex-dev/auth':
+        specifier: ^0.0.92
+        version: 0.0.92(@auth/core@0.37.4)(convex@1.32.0(react@19.2.3))(react@19.2.3)
+      '@convex-dev/migrations':
+        specifier: ^0.3.4
+        version: 0.3.4(convex@1.32.0(react@19.2.3))
     devDependencies:
       '@types/node':
         specifier: ^22.19.15
@@ -29,6 +42,9 @@ importers:
 
   apps/web:
     dependencies:
+      '@convex-dev/auth':
+        specifier: ^0.0.92
+        version: 0.0.92(@auth/core@0.37.4)(convex@1.32.0(react@19.2.3))(react@19.2.3)
       convex:
         specifier: ^1.32.0
         version: 1.32.0(react@19.2.3)
@@ -78,6 +94,105 @@ packages:
   '@alloc/quick-lru@5.2.0':
     resolution: {integrity: sha512-UrcABB+4bUrFABwbluTIBErXwvbsU/V7TZWfmbgJfbkwiBuziS9gxdODUyuiecfdGQ85jglMW6juS3+z5TsKLw==}
     engines: {node: '>=10'}
+
+  '@auth/core@0.37.4':
+    resolution: {integrity: sha512-HOXJwXWXQRhbBDHlMU0K/6FT1v+wjtzdKhsNg0ZN7/gne6XPsIrjZ4daMcFnbq0Z/vsAbYBinQhhua0d77v7qw==}
+    peerDependencies:
+      '@simplewebauthn/browser': ^9.0.1
+      '@simplewebauthn/server': ^9.0.2
+      nodemailer: ^6.8.0
+    peerDependenciesMeta:
+      '@simplewebauthn/browser':
+        optional: true
+      '@simplewebauthn/server':
+        optional: true
+      nodemailer:
+        optional: true
+
+  '@aws-crypto/crc32@5.2.0':
+    resolution: {integrity: sha512-nLbCWqQNgUiwwtFsen1AdzAtvuLRsQS8rYgMuxCrdKf9kOssamGLuPwyTY9wyYblNr9+1XM8v6zoDTPPSIeANg==}
+    engines: {node: '>=16.0.0'}
+
+  '@aws-crypto/sha256-browser@5.2.0':
+    resolution: {integrity: sha512-AXfN/lGotSQwu6HNcEsIASo7kWXZ5HYWvfOmSNKDsEqC4OashTp8alTmaz+F7TC2L083SFv5RdB+qU3Vs1kZqw==}
+
+  '@aws-crypto/sha256-js@5.2.0':
+    resolution: {integrity: sha512-FFQQyu7edu4ufvIZ+OadFpHHOt+eSTBaYaki44c+akjg7qZg9oOQeLlk77F6tSYqjDAFClrHJk9tMf0HdVyOvA==}
+    engines: {node: '>=16.0.0'}
+
+  '@aws-crypto/supports-web-crypto@5.2.0':
+    resolution: {integrity: sha512-iAvUotm021kM33eCdNfwIN//F77/IADDSs58i+MDaOqFrVjZo9bAal0NK7HurRuWLLpF1iLX7gbWrjHjeo+YFg==}
+
+  '@aws-crypto/util@5.2.0':
+    resolution: {integrity: sha512-4RkU9EsI6ZpBve5fseQlGNUWKMa1RLPQ1dnjnQoe07ldfIzcsGb5hC5W0Dm7u423KWzawlrpbjXBrXCEv9zazQ==}
+
+  '@aws-sdk/client-ses@3.1055.0':
+    resolution: {integrity: sha512-YrwjiKvFEXcocX5sKu/fzUr0EyGRlCFoK3We+zu6/QNNB6EEym0x0fjEJOg9cLVkR7d/X/xm3JseivcmbcHrFw==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/core@3.974.14':
+    resolution: {integrity: sha512-ppamm04uoj3hhNO5IlQSs5D6rWX1fWkzcn6a4pZrojk8Y6ObY9wzLDdT/Eq3gv6O9hOebi9tYTNB8b8fQj9XJw==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/credential-provider-env@3.972.40':
+    resolution: {integrity: sha512-jjT0p0Y7KZtcvExYiPCLJnqM9lkXDV1KBEg/13OE2DXv/9batzlyJHVKUEnRNJccY0O2Sul17E1su38CgdBhGQ==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/credential-provider-http@3.972.42':
+    resolution: {integrity: sha512-+3fsKtWybe5BjKEUA3/07oh7Ayfd82IED2+gyyaVfS/4PU78E3TaOQxSGOJ1t7Imefoidw/ne9QA7apX8wEnJg==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/credential-provider-ini@3.972.44':
+    resolution: {integrity: sha512-gZFw5wBefCIPg9vpT+gV5FdhfNKhYTVDZa1IsZCcn3SRoYUOJ/E05vwIogkJoonqBL0ttBGi5vhthX7xceekRg==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/credential-provider-login@3.972.44':
+    resolution: {integrity: sha512-QqEGHfQeZgUDqh7zpqHufrZ8T644ELEWvB+4gUdewLyRw4IRF+6CJqeQuRWqucZdQzoQeMh7fNAD9BWxFAdNig==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/credential-provider-node@3.972.45':
+    resolution: {integrity: sha512-3YCv52ExXIRz3LAVNysevd+s7akSpg9dl39v9LJ7dOQH+s5rHi3jMZYQyxwMmglxQGMuzYRfQ0o1VSP2UOlIRw==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/credential-provider-process@3.972.40':
+    resolution: {integrity: sha512-cXaozlgJCOwmE6D7x4npcPdyk7kiFZdrGjN3D6tXXtItJJMNGPafDfAJn4YQmciMooG/X+b0Y6RTqdVVMx26jg==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/credential-provider-sso@3.972.44':
+    resolution: {integrity: sha512-YePoj5kQuPmE0MHnyftXCfsO8ZSBd2kDr50XEIUrdejSbGFlayYvUuCohdb8drhGhPm6b65o7H1eC26EZhwUvA==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/credential-provider-web-identity@3.972.44':
+    resolution: {integrity: sha512-Ys/JJe++8Z2Y5meR1taMBaVcrGBA0/XsVTQR+qOKZbdNyg+8Jlv5rYZSwh8SqEHY00goSOZy7PHzZ2rLNQxDLg==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/nested-clients@3.997.12':
+    resolution: {integrity: sha512-Js2VYaCM269feB0cs0cGmlIhdOgT9aMqzdBx68lCy6kVCYfzr0T36ovUFDvfUmatkuBeyBJhCwaLBh7P8meH5Q==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/signature-v4-multi-region@3.996.29':
+    resolution: {integrity: sha512-Few9FoQqOt/0KSvZYP+qdW0dfOhfQ9N+gl2UUDvCPW6mkPKHli9LMbKxWj+wZ5zKPaOoqxuR3Hhy3OTpndkfSw==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/token-providers@3.1054.0':
+    resolution: {integrity: sha512-hG9YKApmZOw+drJ9Nuoaf/OvC8e5W1+3eoLeN5p2uVCZRWsv27teIS0b4kiH6Sfv3WMmamqYJxmE2WMwyp/L/A==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/types@3.973.9':
+    resolution: {integrity: sha512-kuBfgQVdcz5Bmapc4A13YbpVw/pXkesfhetcFYwbntqas8sF41OHyd4o28+/TG2ZQdHBsv90Lsu5y6oitvYCdg==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/util-locate-window@3.965.5':
+    resolution: {integrity: sha512-WhlJNNINQB+9qtLtZJcpQdgZw3SCDCpXdUJP7cToGwHbCWCnRckGlc6Bx/OhWwIYFNAn+FIydY8SZ0QmVu3xTQ==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/xml-builder@3.972.26':
+    resolution: {integrity: sha512-cDbrqvDS73whl6YAPSPq0U6whzG6UWI9PuWh0wrUuGoZexhWEqhdunbukV7iBoaWnFV1AODutM5hOD6rtn439g==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws/lambda-invoke-store@0.2.4':
+    resolution: {integrity: sha512-iY8yvjE0y651BixKNPgmv1WrQc+GZ142sb0z4gYnChDDY2YqI4P/jsSopBWrKfAt7LOJAkOXt7rC/hms+WclQQ==}
+    engines: {node: '>=18.0.0'}
 
   '@babel/code-frame@7.29.0':
     resolution: {integrity: sha512-9NhCeYjq9+3uxgdtp20LSiJXJvN0FeCtNGpJxuMFZ1Kv3cWUNb6DOhJwUvcVCzKGR66cw4njwM6hrJLqgOwbcw==}
@@ -145,6 +260,22 @@ packages:
   '@babel/types@7.29.0':
     resolution: {integrity: sha512-LwdZHpScM4Qz8Xw2iKSzS+cfglZzJGvofQICy7W7v4caru4EaAmyUuO6BGrbyQ2mYV11W0U8j5mBhd14dd3B0A==}
     engines: {node: '>=6.9.0'}
+
+  '@convex-dev/auth@0.0.92':
+    resolution: {integrity: sha512-tNRIMTDxi2vrbT+3vz1FgNR1321IfIBDDBy59zul7E1DyzWQKoU0OzgFqWbiVm3o8gn0eQsYTU3UHNRX9kp3wQ==}
+    hasBin: true
+    peerDependencies:
+      '@auth/core': ^0.37.0
+      convex: ^1.17.0
+      react: ^18.2.0 || ^19.0.0-0
+    peerDependenciesMeta:
+      react:
+        optional: true
+
+  '@convex-dev/migrations@0.3.4':
+    resolution: {integrity: sha512-fCUkc4hDzkZTgxicjV1WN4QfUdDDPPrMtvC7VgSLTGssg1B8pm+XlPC6NbZ2Aes38Xf5iiodX+y8VnU96narKQ==}
+    peerDependencies:
+      convex: ^1.24.8
 
   '@emnapi/core@1.8.1':
     resolution: {integrity: sha512-AvT9QFpxK0Zd8J0jopedNm+w/2fIzvtPKPjqyw9jwvBaReTTqPBk9Hixaz7KbjimP+QNz605/XnjFcDAL2pqBg==}
@@ -731,6 +862,9 @@ packages:
     cpu: [x64]
     os: [win32]
 
+  '@nodable/entities@2.1.0':
+    resolution: {integrity: sha512-nyT7T3nbMyBI/lvr6L5TyWbFJAI9FTgVRakNoBqCD+PmID8DzFrrNdLLtHMwMszOtqZa8PAOV24ZqDnQrhQINA==}
+
   '@nodelib/fs.scandir@2.1.5':
     resolution: {integrity: sha512-vq24Bq3ym5HEQm2NKCr3yXDwjc7vTsEThRDnkp2DK9p1uqLR+DHurm/NOTo0KG7HYHU7eppKZj3MyqYuMBf62g==}
     engines: {node: '>= 8'}
@@ -819,6 +953,21 @@ packages:
     resolution: {integrity: sha512-/UhIkaZgPutTFmQ7RnIJGgDXZmtEJ7Dvi86xNTFWcnRxVRNk/aotsqDJYeEvDP+FSMB2SdW+pQzNMcWP0rwuNA==}
     engines: {node: '>=14'}
 
+  '@oslojs/asn1@1.0.0':
+    resolution: {integrity: sha512-zw/wn0sj0j0QKbIXfIlnEcTviaCzYOY3V5rAyjR6YtOByFtJiT574+8p9Wlach0lZH9fddD4yb9laEAIl4vXQA==}
+
+  '@oslojs/binary@1.0.0':
+    resolution: {integrity: sha512-9RCU6OwXU6p67H4NODbuxv2S3eenuQ4/WFLrsq+K/k682xrznH5EVWA7N4VFk9VYVcbFtKqur5YQQZc0ySGhsQ==}
+
+  '@oslojs/crypto@1.0.1':
+    resolution: {integrity: sha512-7n08G8nWjAr/Yu3vu9zzrd0L9XnrJfpMioQcvCMxBIiF5orECHe5/3J0jmXRVvgfqMm/+4oxlQ+Sq39COYLcNQ==}
+
+  '@oslojs/encoding@1.1.0':
+    resolution: {integrity: sha512-70wQhgYmndg4GCPxPPxPGevRKqTIJ2Nh4OkiMWmDAVYsTQ+Ta7Sq+rPevXyXGdzr30/qZBnyOalCszoMxlyldQ==}
+
+  '@panva/hkdf@1.2.1':
+    resolution: {integrity: sha512-6oclG6Y3PiDFcoyk8srjLfVKyMfVCKJ27JwNPViuXziFpmdz+MZnZN/aKY0JGXgYuO/VghU0jcOAZgWXZ1Dmrw==}
+
   '@playwright/test@1.60.0':
     resolution: {integrity: sha512-O71yZIbAh/PxDMNGns37GHBIfrVkEVyn+AXyIa5dOTfb4/xNvRWV+Vv/NMbNCtODB/pO7vLlF2OTmMVLhmr7Ag==}
     engines: {node: '>=18'}
@@ -862,6 +1011,42 @@ packages:
 
   '@rtsao/scc@1.1.0':
     resolution: {integrity: sha512-zt6OdqaDoOnJ1ZYsCYGt9YmWzDXl4vQdKTyJev62gFhRGKdx7mcT54V9KIjg+d2wi9EXsPvAPKe7i7WjfVWB8g==}
+
+  '@smithy/core@3.24.5':
+    resolution: {integrity: sha512-Kt8phUg45M15EjhYAbZ+fFikYneijLu9Liugz8ZsYz2i8j0hzGv27LWKpEHYRfvj+LyCOSijpcR/2i8RouV+cA==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/credential-provider-imds@4.3.5':
+    resolution: {integrity: sha512-yiF8xHpdkaTfzLVqFzsP6WvNghEK+qZzLYWFD13L2SsFhbXwBGlxdocKF95qjr7s5lE5NRage+EJFK4mAsx88Q==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/fetch-http-handler@5.4.5':
+    resolution: {integrity: sha512-SK3VMeH0fibgdTg2QeB+O4p7Yy/2E5HBOHJeC58FshkDdeuX8lOgO7PfjYfLyPLP1ch55j91cQqKBzDS0mRjSQ==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/is-array-buffer@2.2.0':
+    resolution: {integrity: sha512-GGP3O9QFD24uGeAXYUjwSTXARoqpZykHadOmA8G5vfJPK0/DC67qa//0qvqrJzL1xc8WQWX7/yc7fwudjPHPhA==}
+    engines: {node: '>=14.0.0'}
+
+  '@smithy/node-http-handler@4.7.5':
+    resolution: {integrity: sha512-3dA9TQ+ybRSZ/m0wnbZhiBy4Dezjgq1Ib/ZZrYTpJDBgpoLLU/SDzZc/g0x0MNAdOJe1wPcM+x2PBRmoOur+Sw==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/signature-v4@5.4.5':
+    resolution: {integrity: sha512-QBJKWGqIknH0dc9LWpfH1mkdokAx6iXYN3UcQ3eY6uIEyScuoQAhfl94ge7ozUy9WgFUdE8xsvwBjaYBbWmPNA==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/types@4.14.2':
+    resolution: {integrity: sha512-P+otAxbV4CqBybp7EkcJCrig63yE2E7PuNVOmilVMRcx/O+QDzGULTrKsq4DV13gSfak9ObPrWaHl/9bL5YcWw==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/util-buffer-from@2.2.0':
+    resolution: {integrity: sha512-IJdWBbTcMQ6DA0gdNhh/BwrLkDR+ADW5Kr1aZmd4k3DIF6ezMV4R2NIAmT08wQJ3yUK82thHWmC/TnK/wpMMIA==}
+    engines: {node: '>=14.0.0'}
+
+  '@smithy/util-utf8@2.3.0':
+    resolution: {integrity: sha512-R8Rdn8Hy72KKcebgLiv8jQcQkXoLMOGGv5uI1/k0l+snqkOzQ1R0ChUBCxWMlBsFMekWjq0wRudIweFs7sKT5A==}
+    engines: {node: '>=14.0.0'}
 
   '@swc/helpers@0.5.15':
     resolution: {integrity: sha512-JQ5TuMi45Owi4/BIMAJBoSQoOJu12oOk/gADqlcUL9JEdHB8vyjUSsxqeNXnmXHjYKMi2WcYtezGEEhqUI/E2g==}
@@ -1233,6 +1418,9 @@ packages:
     engines: {node: '>=6.0.0'}
     hasBin: true
 
+  bowser@2.14.1:
+    resolution: {integrity: sha512-tzPjzCxygAKWFOJP011oxFHs57HzIhOEracIgAePE4pqB3LikALKnSzUyU4MGs9/iCEUuHlAJTjTc5M+u7YEGg==}
+
   brace-expansion@1.1.12:
     resolution: {integrity: sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==}
 
@@ -1318,6 +1506,10 @@ packages:
         optional: true
       react:
         optional: true
+
+  cookie@1.1.1:
+    resolution: {integrity: sha512-ei8Aos7ja0weRpFzJnEA9UHJ/7XQmqglbRwnf2ATjcB9Wq874VKH9kfjjirM6UhU2/E5fFYadylyhFldcqSidQ==}
+    engines: {node: '>=18'}
 
   core-js@3.49.0:
     resolution: {integrity: sha512-es1U2+YTtzpwkxVLwAFdSpaIMyQaq0PBgm3YD1W3Qpsn1NAmO3KSgZfu+oGSWVu6NvLHoHCV/aYcsE5wiB7ALg==}
@@ -1590,6 +1782,13 @@ packages:
   fast-levenshtein@2.0.6:
     resolution: {integrity: sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==}
 
+  fast-xml-builder@1.2.0:
+    resolution: {integrity: sha512-00aAWieqff+ZJhsXA4g1g7M8k+7AYoMUUHF+/zFb5U6Uv/P0Vl4QZo84/IcufzYalLuEj9928bXN9PbbFzMF0Q==}
+
+  fast-xml-parser@5.7.3:
+    resolution: {integrity: sha512-C0AaNuC+mscy6vrAQKAc/rMq+zAPHodfHGZu4sGVehvAQt/JLG1O5zEcYcXSY5zSqr4YVgxsB+pHXTq0i7eDlg==}
+    hasBin: true
+
   fastq@1.20.1:
     resolution: {integrity: sha512-GGToxJ/w1x32s/D2EKND7kTil4n8OVk/9mycTc4VDza13lOvpUZTGX3mFSCtV9ksdGBVzvsyAVLM6mHFThxXxw==}
 
@@ -1823,6 +2022,10 @@ packages:
     resolution: {integrity: sha512-5KoIu2Ngpyek75jXodFvnafB6DJgr3u8uuK0LEZJjrU19DrMD3EVERaR8sjz8CCGgpZvxPl9SuE1GMVPFHx1mw==}
     engines: {node: '>= 0.4'}
 
+  is-network-error@1.3.2:
+    resolution: {integrity: sha512-PhBY86zaxNZUuWP6h13Vu5oFe0XY6/UlKzQnYFELzGVHygP3MxmvTfYSG7GN3aIab/iWudSMgjSnG9Dq+nHrgA==}
+    engines: {node: '>=16'}
+
   is-number-object@1.1.1:
     resolution: {integrity: sha512-lZhclumE1G6VYD8VHe35wFaIif+CTy5SJIi5+3y4psDgWu4wPDoBhF8NxUOinEc7pHgiTsT6MaBb92rKhhD+Xw==}
     engines: {node: '>= 0.4'}
@@ -1881,6 +2084,9 @@ packages:
     resolution: {integrity: sha512-ekilCSN1jwRvIbgeg/57YFh8qQDNbwDb9xT/qu2DAHbFFZUicIl4ygVaAvzveMhMVr3LnpSKTNnwt8PoOfmKhQ==}
     hasBin: true
 
+  jose@5.10.0:
+    resolution: {integrity: sha512-s+3Al/p9g32Iq+oqXxkW//7jk2Vig6FF1CFqzVXoTUXt2qz89YWbL+OwS17NFYEvxC35n0FKeGO2LGYSxeM2Gg==}
+
   js-tokens@4.0.0:
     resolution: {integrity: sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==}
 
@@ -1914,6 +2120,10 @@ packages:
   jsx-ast-utils@3.3.5:
     resolution: {integrity: sha512-ZZow9HBI5O6EPgSJLUb8n2NKgmVWTwCvHGwFuJlMjvLFqlGG6pjirPhtdsseaLZjSibD8eegzmYpUZwoIlj2cQ==}
     engines: {node: '>=4.0'}
+
+  jwt-decode@4.0.0:
+    resolution: {integrity: sha512-+KJGIyHgkGuIq3IEBNftfhW/LfWhXUIY6OmyVWjliu5KH1y0fw7VQ8YndE2O4qZdMSd9SqbnC8GOcZEy0Om7sA==}
+    engines: {node: '>=18'}
 
   keyv@4.5.4:
     resolution: {integrity: sha512-oxVHkHR/EJf2CNXnWxRLW6mg7JyCCUcG0DtEGmL2ctUo1PNTin1PUil+r/+4r5MpVgC/fn1kjsx7mjSujKqIpw==}
@@ -2029,6 +2239,10 @@ packages:
   lru-cache@5.1.1:
     resolution: {integrity: sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==}
 
+  lucia@3.2.2:
+    resolution: {integrity: sha512-P1FlFBGCMPMXu+EGdVD9W4Mjm0DqsusmKgO7Xc33mI5X1bklmsQb0hfzPhXomQr9waWIBDsiOjvr1e6BTaUqpA==}
+    deprecated: This package has been deprecated. Please see https://lucia-auth.com/lucia-v3/migrate.
+
   magic-string@0.30.21:
     resolution: {integrity: sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==}
 
@@ -2102,6 +2316,9 @@ packages:
   node-releases@2.0.36:
     resolution: {integrity: sha512-TdC8FSgHz8Mwtw9g5L4gR/Sh9XhSP/0DEkQxfEFXOpiul5IiHgHan2VhYYb6agDSfp4KuvltmGApc8HMgUrIkA==}
 
+  oauth4webapi@3.8.6:
+    resolution: {integrity: sha512-iwemM91xz8nryHti2yTmg5fhyEMVOkOXwHNqbvcATjyajb5oQxCQzrNOA6uElRHuMhQQTKUyFKV9y/CNyg25BQ==}
+
   object-assign@4.1.1:
     resolution: {integrity: sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==}
     engines: {node: '>=0.10.0'}
@@ -2162,12 +2379,19 @@ packages:
     resolution: {integrity: sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==}
     engines: {node: '>=8'}
 
+  path-expression-matcher@1.5.0:
+    resolution: {integrity: sha512-cbrerZV+6rvdQrrD+iGMcZFEiiSrbv9Tfdkvnusy6y0x0GKBXREFg/Y65GhIfm0tnLntThhzCnfKwp1WRjeCyQ==}
+    engines: {node: '>=14.0.0'}
+
   path-key@3.1.1:
     resolution: {integrity: sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==}
     engines: {node: '>=8'}
 
   path-parse@1.0.7:
     resolution: {integrity: sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==}
+
+  path-to-regexp@6.3.0:
+    resolution: {integrity: sha512-Yhpw4T9C6hPpgPeA28us07OJeqZ5EzQTkbfwuhsUg0c237RomFoETJgmp2sa3F/41gfLE6G5cqcYwznmeEeOlQ==}
 
   picocolors@1.1.1:
     resolution: {integrity: sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==}
@@ -2204,6 +2428,14 @@ packages:
 
   posthog-js@1.376.2:
     resolution: {integrity: sha512-Anz2pCp7dcNbammTExiZpcKC08dxfrHYaJgaXH6rq5x3Zcfj/4FkcMJF2cGCrdQXel5Y4vftiVSseZda0HAQTQ==}
+
+  preact-render-to-string@6.5.11:
+    resolution: {integrity: sha512-ubnauqoGczeGISiOh6RjX0/cdaF8v/oDXIjO85XALCQjwQP+SB4RDXXtvZ6yTYSjG+PC1QRP2AhPgCEsM2EvUw==}
+    peerDependencies:
+      preact: '>=10'
+
+  preact@10.24.3:
+    resolution: {integrity: sha512-Z2dPnBnMUfyQfSQ+GBdsGa16hz35YmLmtTLhM169uW944hYL6xzTYkJjC07j+Wosz733pMWx0fgON3JNw1jJQA==}
 
   preact@10.29.2:
     resolution: {integrity: sha512-7tNmwg/7mzzAoB/8kSg6Hl37JraAZw3Z3A0JSY7VXlZwo82Xn0G7wKbNNs2qoF4ZEEsQGTwDAroNdqKs1ofJxQ==}
@@ -2308,6 +2540,9 @@ packages:
     resolution: {integrity: sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==}
     engines: {node: '>=10'}
     hasBin: true
+
+  server-only@0.0.1:
+    resolution: {integrity: sha512-qepMx2JxAa5jjfzxG79yPPq+8BuFToHd1hm7kI+Z4zAq1ftQiP7HcxMhDDItrbtwVeLg/cY2JnKnrcFkmiswNA==}
 
   set-function-length@1.2.2:
     resolution: {integrity: sha512-pgRc4hJ4/sNjWCSS9AmnS40x3bNMDTknHgL5UaMBTMyJnU90EgWh1Rz+MC9eFu4BuN/UwZjKQuY/1v3rM7HMfg==}
@@ -2418,6 +2653,9 @@ packages:
   strip-json-comments@3.1.1:
     resolution: {integrity: sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==}
     engines: {node: '>=8'}
+
+  strnum@2.3.0:
+    resolution: {integrity: sha512-ums3KNd42PGyx5xaoVTO1mjU1bH3NpY4vsrVlnv9PNGqQj8wd7rJ6nEypLrJ7z5vxK5RP0yMLo6J/Gsm62DI5Q==}
 
   styled-jsx@5.1.6:
     resolution: {integrity: sha512-qSVyDTeMotdvQYoHWLNGwRFJHC+i+ZvdBRYosOFgC+Wg1vx4frN2/RG/NA7SYqqvKNLf39P2LSRA2pu6n0XYZA==}
@@ -2571,6 +2809,10 @@ packages:
       utf-8-validate:
         optional: true
 
+  xml-naming@0.1.0:
+    resolution: {integrity: sha512-k8KO9hrMyNk6tUWqUfkTEZbezRRpONVOzUTnc97VnCvyj6Tf9lyUR9EDAIeiVLv56jsMcoXEwjW8Kv5yPY52lw==}
+    engines: {node: '>=16.0.0'}
+
   yallist@3.1.1:
     resolution: {integrity: sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==}
 
@@ -2595,6 +2837,200 @@ packages:
 snapshots:
 
   '@alloc/quick-lru@5.2.0': {}
+
+  '@auth/core@0.37.4':
+    dependencies:
+      '@panva/hkdf': 1.2.1
+      jose: 5.10.0
+      oauth4webapi: 3.8.6
+      preact: 10.24.3
+      preact-render-to-string: 6.5.11(preact@10.24.3)
+
+  '@aws-crypto/crc32@5.2.0':
+    dependencies:
+      '@aws-crypto/util': 5.2.0
+      '@aws-sdk/types': 3.973.9
+      tslib: 2.8.1
+
+  '@aws-crypto/sha256-browser@5.2.0':
+    dependencies:
+      '@aws-crypto/sha256-js': 5.2.0
+      '@aws-crypto/supports-web-crypto': 5.2.0
+      '@aws-crypto/util': 5.2.0
+      '@aws-sdk/types': 3.973.9
+      '@aws-sdk/util-locate-window': 3.965.5
+      '@smithy/util-utf8': 2.3.0
+      tslib: 2.8.1
+
+  '@aws-crypto/sha256-js@5.2.0':
+    dependencies:
+      '@aws-crypto/util': 5.2.0
+      '@aws-sdk/types': 3.973.9
+      tslib: 2.8.1
+
+  '@aws-crypto/supports-web-crypto@5.2.0':
+    dependencies:
+      tslib: 2.8.1
+
+  '@aws-crypto/util@5.2.0':
+    dependencies:
+      '@aws-sdk/types': 3.973.9
+      '@smithy/util-utf8': 2.3.0
+      tslib: 2.8.1
+
+  '@aws-sdk/client-ses@3.1055.0':
+    dependencies:
+      '@aws-crypto/sha256-browser': 5.2.0
+      '@aws-crypto/sha256-js': 5.2.0
+      '@aws-sdk/core': 3.974.14
+      '@aws-sdk/credential-provider-node': 3.972.45
+      '@aws-sdk/types': 3.973.9
+      '@smithy/core': 3.24.5
+      '@smithy/fetch-http-handler': 5.4.5
+      '@smithy/node-http-handler': 4.7.5
+      '@smithy/types': 4.14.2
+      tslib: 2.8.1
+
+  '@aws-sdk/core@3.974.14':
+    dependencies:
+      '@aws-sdk/types': 3.973.9
+      '@aws-sdk/xml-builder': 3.972.26
+      '@aws/lambda-invoke-store': 0.2.4
+      '@smithy/core': 3.24.5
+      '@smithy/signature-v4': 5.4.5
+      '@smithy/types': 4.14.2
+      bowser: 2.14.1
+      tslib: 2.8.1
+
+  '@aws-sdk/credential-provider-env@3.972.40':
+    dependencies:
+      '@aws-sdk/core': 3.974.14
+      '@aws-sdk/types': 3.973.9
+      '@smithy/core': 3.24.5
+      '@smithy/types': 4.14.2
+      tslib: 2.8.1
+
+  '@aws-sdk/credential-provider-http@3.972.42':
+    dependencies:
+      '@aws-sdk/core': 3.974.14
+      '@aws-sdk/types': 3.973.9
+      '@smithy/core': 3.24.5
+      '@smithy/fetch-http-handler': 5.4.5
+      '@smithy/node-http-handler': 4.7.5
+      '@smithy/types': 4.14.2
+      tslib: 2.8.1
+
+  '@aws-sdk/credential-provider-ini@3.972.44':
+    dependencies:
+      '@aws-sdk/core': 3.974.14
+      '@aws-sdk/credential-provider-env': 3.972.40
+      '@aws-sdk/credential-provider-http': 3.972.42
+      '@aws-sdk/credential-provider-login': 3.972.44
+      '@aws-sdk/credential-provider-process': 3.972.40
+      '@aws-sdk/credential-provider-sso': 3.972.44
+      '@aws-sdk/credential-provider-web-identity': 3.972.44
+      '@aws-sdk/nested-clients': 3.997.12
+      '@aws-sdk/types': 3.973.9
+      '@smithy/core': 3.24.5
+      '@smithy/credential-provider-imds': 4.3.5
+      '@smithy/types': 4.14.2
+      tslib: 2.8.1
+
+  '@aws-sdk/credential-provider-login@3.972.44':
+    dependencies:
+      '@aws-sdk/core': 3.974.14
+      '@aws-sdk/nested-clients': 3.997.12
+      '@aws-sdk/types': 3.973.9
+      '@smithy/core': 3.24.5
+      '@smithy/types': 4.14.2
+      tslib: 2.8.1
+
+  '@aws-sdk/credential-provider-node@3.972.45':
+    dependencies:
+      '@aws-sdk/credential-provider-env': 3.972.40
+      '@aws-sdk/credential-provider-http': 3.972.42
+      '@aws-sdk/credential-provider-ini': 3.972.44
+      '@aws-sdk/credential-provider-process': 3.972.40
+      '@aws-sdk/credential-provider-sso': 3.972.44
+      '@aws-sdk/credential-provider-web-identity': 3.972.44
+      '@aws-sdk/types': 3.973.9
+      '@smithy/core': 3.24.5
+      '@smithy/credential-provider-imds': 4.3.5
+      '@smithy/types': 4.14.2
+      tslib: 2.8.1
+
+  '@aws-sdk/credential-provider-process@3.972.40':
+    dependencies:
+      '@aws-sdk/core': 3.974.14
+      '@aws-sdk/types': 3.973.9
+      '@smithy/core': 3.24.5
+      '@smithy/types': 4.14.2
+      tslib: 2.8.1
+
+  '@aws-sdk/credential-provider-sso@3.972.44':
+    dependencies:
+      '@aws-sdk/core': 3.974.14
+      '@aws-sdk/nested-clients': 3.997.12
+      '@aws-sdk/token-providers': 3.1054.0
+      '@aws-sdk/types': 3.973.9
+      '@smithy/core': 3.24.5
+      '@smithy/types': 4.14.2
+      tslib: 2.8.1
+
+  '@aws-sdk/credential-provider-web-identity@3.972.44':
+    dependencies:
+      '@aws-sdk/core': 3.974.14
+      '@aws-sdk/nested-clients': 3.997.12
+      '@aws-sdk/types': 3.973.9
+      '@smithy/core': 3.24.5
+      '@smithy/types': 4.14.2
+      tslib: 2.8.1
+
+  '@aws-sdk/nested-clients@3.997.12':
+    dependencies:
+      '@aws-crypto/sha256-browser': 5.2.0
+      '@aws-crypto/sha256-js': 5.2.0
+      '@aws-sdk/core': 3.974.14
+      '@aws-sdk/signature-v4-multi-region': 3.996.29
+      '@aws-sdk/types': 3.973.9
+      '@smithy/core': 3.24.5
+      '@smithy/fetch-http-handler': 5.4.5
+      '@smithy/node-http-handler': 4.7.5
+      '@smithy/types': 4.14.2
+      tslib: 2.8.1
+
+  '@aws-sdk/signature-v4-multi-region@3.996.29':
+    dependencies:
+      '@aws-sdk/types': 3.973.9
+      '@smithy/signature-v4': 5.4.5
+      '@smithy/types': 4.14.2
+      tslib: 2.8.1
+
+  '@aws-sdk/token-providers@3.1054.0':
+    dependencies:
+      '@aws-sdk/core': 3.974.14
+      '@aws-sdk/nested-clients': 3.997.12
+      '@aws-sdk/types': 3.973.9
+      '@smithy/core': 3.24.5
+      '@smithy/types': 4.14.2
+      tslib: 2.8.1
+
+  '@aws-sdk/types@3.973.9':
+    dependencies:
+      '@smithy/types': 4.14.2
+      tslib: 2.8.1
+
+  '@aws-sdk/util-locate-window@3.965.5':
+    dependencies:
+      tslib: 2.8.1
+
+  '@aws-sdk/xml-builder@3.972.26':
+    dependencies:
+      '@smithy/types': 4.14.2
+      fast-xml-parser: 5.7.3
+      tslib: 2.8.1
+
+  '@aws/lambda-invoke-store@0.2.4': {}
 
   '@babel/code-frame@7.29.0':
     dependencies:
@@ -2695,6 +3131,27 @@ snapshots:
     dependencies:
       '@babel/helper-string-parser': 7.27.1
       '@babel/helper-validator-identifier': 7.28.5
+
+  '@convex-dev/auth@0.0.92(@auth/core@0.37.4)(convex@1.32.0(react@19.2.3))(react@19.2.3)':
+    dependencies:
+      '@auth/core': 0.37.4
+      '@oslojs/crypto': 1.0.1
+      '@oslojs/encoding': 1.1.0
+      convex: 1.32.0(react@19.2.3)
+      cookie: 1.1.1
+      is-network-error: 1.3.2
+      jose: 5.10.0
+      jwt-decode: 4.0.0
+      lucia: 3.2.2
+      oauth4webapi: 3.8.6
+      path-to-regexp: 6.3.0
+      server-only: 0.0.1
+    optionalDependencies:
+      react: 19.2.3
+
+  '@convex-dev/migrations@0.3.4(convex@1.32.0(react@19.2.3))':
+    dependencies:
+      convex: 1.32.0(react@19.2.3)
 
   '@emnapi/core@1.8.1':
     dependencies:
@@ -3078,6 +3535,8 @@ snapshots:
   '@next/swc-win32-x64-msvc@16.1.6':
     optional: true
 
+  '@nodable/entities@2.1.0': {}
+
   '@nodelib/fs.scandir@2.1.5':
     dependencies:
       '@nodelib/fs.stat': 2.0.5
@@ -3168,6 +3627,21 @@ snapshots:
 
   '@opentelemetry/semantic-conventions@1.41.1': {}
 
+  '@oslojs/asn1@1.0.0':
+    dependencies:
+      '@oslojs/binary': 1.0.0
+
+  '@oslojs/binary@1.0.0': {}
+
+  '@oslojs/crypto@1.0.1':
+    dependencies:
+      '@oslojs/asn1': 1.0.0
+      '@oslojs/binary': 1.0.0
+
+  '@oslojs/encoding@1.1.0': {}
+
+  '@panva/hkdf@1.2.1': {}
+
   '@playwright/test@1.60.0':
     dependencies:
       playwright: 1.60.0
@@ -3201,6 +3675,54 @@ snapshots:
   '@protobufjs/utf8@1.1.1': {}
 
   '@rtsao/scc@1.1.0': {}
+
+  '@smithy/core@3.24.5':
+    dependencies:
+      '@aws-crypto/crc32': 5.2.0
+      '@smithy/types': 4.14.2
+      tslib: 2.8.1
+
+  '@smithy/credential-provider-imds@4.3.5':
+    dependencies:
+      '@smithy/core': 3.24.5
+      '@smithy/types': 4.14.2
+      tslib: 2.8.1
+
+  '@smithy/fetch-http-handler@5.4.5':
+    dependencies:
+      '@smithy/core': 3.24.5
+      '@smithy/types': 4.14.2
+      tslib: 2.8.1
+
+  '@smithy/is-array-buffer@2.2.0':
+    dependencies:
+      tslib: 2.8.1
+
+  '@smithy/node-http-handler@4.7.5':
+    dependencies:
+      '@smithy/core': 3.24.5
+      '@smithy/types': 4.14.2
+      tslib: 2.8.1
+
+  '@smithy/signature-v4@5.4.5':
+    dependencies:
+      '@smithy/core': 3.24.5
+      '@smithy/types': 4.14.2
+      tslib: 2.8.1
+
+  '@smithy/types@4.14.2':
+    dependencies:
+      tslib: 2.8.1
+
+  '@smithy/util-buffer-from@2.2.0':
+    dependencies:
+      '@smithy/is-array-buffer': 2.2.0
+      tslib: 2.8.1
+
+  '@smithy/util-utf8@2.3.0':
+    dependencies:
+      '@smithy/util-buffer-from': 2.2.0
+      tslib: 2.8.1
 
   '@swc/helpers@0.5.15':
     dependencies:
@@ -3565,6 +4087,8 @@ snapshots:
 
   baseline-browser-mapping@2.10.0: {}
 
+  bowser@2.14.1: {}
+
   brace-expansion@1.1.12:
     dependencies:
       balanced-match: 1.0.2
@@ -3647,6 +4171,8 @@ snapshots:
     transitivePeerDependencies:
       - bufferutil
       - utf-8-validate
+
+  cookie@1.1.1: {}
 
   core-js@3.49.0: {}
 
@@ -4113,6 +4639,18 @@ snapshots:
 
   fast-levenshtein@2.0.6: {}
 
+  fast-xml-builder@1.2.0:
+    dependencies:
+      path-expression-matcher: 1.5.0
+      xml-naming: 0.1.0
+
+  fast-xml-parser@5.7.3:
+    dependencies:
+      '@nodable/entities': 2.1.0
+      fast-xml-builder: 1.2.0
+      path-expression-matcher: 1.5.0
+      strnum: 2.3.0
+
   fastq@1.20.1:
     dependencies:
       reusify: 1.1.0
@@ -4338,6 +4876,8 @@ snapshots:
 
   is-negative-zero@2.0.3: {}
 
+  is-network-error@1.3.2: {}
+
   is-number-object@1.1.1:
     dependencies:
       call-bound: 1.0.4
@@ -4399,6 +4939,8 @@ snapshots:
 
   jiti@2.6.1: {}
 
+  jose@5.10.0: {}
+
   js-tokens@4.0.0: {}
 
   js-yaml@4.1.1:
@@ -4425,6 +4967,8 @@ snapshots:
       array.prototype.flat: 1.3.3
       object.assign: 4.1.7
       object.values: 1.2.1
+
+  jwt-decode@4.0.0: {}
 
   keyv@4.5.4:
     dependencies:
@@ -4532,6 +5076,11 @@ snapshots:
     dependencies:
       yallist: 3.1.1
 
+  lucia@3.2.2:
+    dependencies:
+      '@oslojs/crypto': 1.0.1
+      '@oslojs/encoding': 1.1.0
+
   magic-string@0.30.21:
     dependencies:
       '@jridgewell/sourcemap-codec': 1.5.5
@@ -4599,6 +5148,8 @@ snapshots:
       semver: 6.3.1
 
   node-releases@2.0.36: {}
+
+  oauth4webapi@3.8.6: {}
 
   object-assign@4.1.1: {}
 
@@ -4675,9 +5226,13 @@ snapshots:
 
   path-exists@4.0.0: {}
 
+  path-expression-matcher@1.5.0: {}
+
   path-key@3.1.1: {}
 
   path-parse@1.0.7: {}
+
+  path-to-regexp@6.3.0: {}
 
   picocolors@1.1.1: {}
 
@@ -4722,6 +5277,12 @@ snapshots:
       preact: 10.29.2
       query-selector-shadow-dom: 1.0.1
       web-vitals: 5.2.0
+
+  preact-render-to-string@6.5.11(preact@10.24.3):
+    dependencies:
+      preact: 10.24.3
+
+  preact@10.24.3: {}
 
   preact@10.29.2: {}
 
@@ -4841,6 +5402,8 @@ snapshots:
   semver@6.3.1: {}
 
   semver@7.7.4: {}
+
+  server-only@0.0.1: {}
 
   set-function-length@1.2.2:
     dependencies:
@@ -5021,6 +5584,8 @@ snapshots:
   strip-bom@3.0.0: {}
 
   strip-json-comments@3.1.1: {}
+
+  strnum@2.3.0: {}
 
   styled-jsx@5.1.6(@babel/core@7.29.0)(react@19.2.3):
     dependencies:
@@ -5218,6 +5783,8 @@ snapshots:
       strip-ansi: 7.2.0
 
   ws@8.18.0: {}
+
+  xml-naming@0.1.0: {}
 
   yallist@3.1.1: {}
 

--- a/tests/backend/profile-foundation.test.ts
+++ b/tests/backend/profile-foundation.test.ts
@@ -1,7 +1,9 @@
 import assert from "node:assert/strict";
 import { describe, it } from "node:test";
 
-import type { Doc } from "../../convex/_generated/dataModel";
+import type { Doc, Id } from "../../convex/_generated/dataModel";
+import { isProfileFieldVisible } from "../../convex/_profileFieldVisibility";
+import { grantProfileOwner } from "../../convex/_profileOwnership";
 import {
   createProfileSlugBase,
   createProfileSlugCandidate,
@@ -144,6 +146,90 @@ describe("profile claim-state helpers", () => {
   });
 });
 
+describe("profile ownership helpers", () => {
+  function createOwnerDb(existingOwners: Array<Record<string, unknown>>) {
+    const inserted: Array<{ table: string; document: Record<string, unknown> }> = [];
+
+    return {
+      inserted,
+      db: {
+        query(table: string) {
+          assert.equal(table, "profileOwners");
+
+          return {
+            withIndex(_index: string, builder: (query: unknown) => unknown) {
+              const values: Record<string, unknown> = {};
+              const query = {
+                eq(field: string, value: unknown) {
+                  values[field] = value;
+                  return query;
+                },
+              };
+
+              builder(query);
+
+              return {
+                async take(limit: number) {
+                  return existingOwners
+                    .filter((owner) =>
+                      Object.entries(values).every(([field, value]) => owner[field] === value),
+                    )
+                    .slice(0, limit);
+                },
+              };
+            },
+          };
+        },
+        async insert(table: string, document: Record<string, unknown>) {
+          inserted.push({ table, document });
+          return "owner-new" as Id<"profileOwners">;
+        },
+      },
+    };
+  }
+
+  it("keeps profile owner authority as a singleton", async () => {
+    const profileId = "profile123" as Id<"profiles">;
+    const userId = "user123" as Id<"users">;
+    const existingOwner = {
+      _id: "owner-existing" as Id<"profileOwners">,
+      profileId,
+      userId,
+      roleKey: "owner",
+      state: "active",
+      grantedAt: 1,
+      updatedAt: 1,
+    };
+    const sameOwnerDb = createOwnerDb([existingOwner]);
+
+    assert.equal(
+      await grantProfileOwner(sameOwnerDb.db as never, { profileId, userId, now: 2 }),
+      existingOwner._id,
+    );
+    assert.equal(sameOwnerDb.inserted.length, 0);
+
+    const newOwnerDb = createOwnerDb([]);
+    assert.equal(await grantProfileOwner(newOwnerDb.db as never, { profileId, userId, now: 2 }), "owner-new");
+    assert.deepEqual(newOwnerDb.inserted[0], {
+      table: "profileOwners",
+      document: {
+        profileId,
+        userId,
+        roleKey: "owner",
+        state: "active",
+        grantedAt: 2,
+        updatedAt: 2,
+      },
+    });
+
+    const conflictingOwnerDb = createOwnerDb([{ ...existingOwner, userId: "otherUser" }]);
+    await assert.rejects(
+      () => grantProfileOwner(conflictingOwnerDb.db as never, { profileId, userId, now: 2 }),
+      /already has an active owner/,
+    );
+  });
+});
+
 describe("profile submission helpers", () => {
   it("normalizes sort names and community submission lists", () => {
     assert.equal(createProfileSortName("  DJ Céline  "), "dj celine");
@@ -274,6 +360,61 @@ describe("public profile projection", () => {
     assert.equal(publicProfile.trustLabel, "community_submitted");
     assert.equal(publicProfile.outboundLinks.length, 1);
     assert.equal(publicProfile.outboundLinks[0]?.url, "https://example.invalid/dj-celine-kofi");
+  });
+
+  it("keeps unlisted fields on direct profiles and hides private fields", () => {
+    const profile = {
+      profileType: "person",
+      slug: "dj-celine",
+      displayName: "DJ Celine",
+      sortName: "dj celine",
+      aliases: ["Celine"],
+      tags: ["House"],
+      headline: "Private headline",
+      bio: "Unlisted bio",
+      avatarImageUrl: "https://example.invalid/private-avatar.png",
+      bannerImageUrl: "https://example.invalid/banner.png",
+      outboundLinks: [
+        {
+          type: "website",
+          label: "Website",
+          url: "https://example.invalid",
+          source: "owner_authored",
+        },
+      ],
+      claimState: "claimed_unverified",
+      publicationState: "published",
+      publicSurfacingState: "public",
+      creationSource: "self",
+      publishedAt: 1,
+      updatedAt: 1,
+      fieldVisibility: {
+        aliases: "private",
+        tags: "unlisted",
+        headline: "private",
+        bio: "unlisted",
+        avatarImageUrl: "private",
+        bannerImageUrl: "public",
+        outboundLinks: "private",
+        personRoleTags: "private",
+      },
+      person: {
+        roleTags: ["DJ"],
+      },
+    } as Doc<"profiles">;
+
+    const publicProfile = toPublicProfile(profile);
+
+    assert.equal(isProfileFieldVisible(profile, "tags", "profile_page"), true);
+    assert.equal(isProfileFieldVisible(profile, "tags", "discovery"), false);
+    assert.deepEqual(publicProfile.aliases, []);
+    assert.deepEqual(publicProfile.tags, ["House"]);
+    assert.equal(publicProfile.headline, undefined);
+    assert.equal(publicProfile.bio, "Unlisted bio");
+    assert.equal(publicProfile.avatarImageUrl, undefined);
+    assert.equal(publicProfile.bannerImageUrl, "https://example.invalid/banner.png");
+    assert.deepEqual(publicProfile.outboundLinks, []);
+    assert.deepEqual(publicProfile.person.roleTags, []);
   });
 });
 

--- a/tests/backend/search-discovery.test.ts
+++ b/tests/backend/search-discovery.test.ts
@@ -56,6 +56,50 @@ describe("search document projection", () => {
     assert.deepEqual(document.vocabularyKeys, ["person_role:dj", "profile_tag:melodic_house"]);
   });
 
+  it("omits unlisted and private profile fields from discovery documents", () => {
+    const profile = {
+      _id: "profile123",
+      slug: "dj-aurora",
+      displayName: "DJ Aurora",
+      sortName: "dj aurora",
+      aliases: ["Private Alias"],
+      tags: ["Unlisted Tag"],
+      headline: "Private headline",
+      bio: "Public bio",
+      avatarImageUrl: "https://example.invalid/private-avatar.png",
+      bannerImageUrl: "https://example.invalid/public-banner.png",
+      claimState: "claimed_verified",
+      publicationState: "published",
+      publicSurfacingState: "public",
+      creationSource: "self",
+      updatedAt: 1,
+      fieldVisibility: {
+        aliases: "private",
+        tags: "unlisted",
+        headline: "private",
+        bio: "public",
+        avatarImageUrl: "private",
+        bannerImageUrl: "public",
+        personRoleTags: "unlisted",
+      },
+      profileType: "person",
+      person: {
+        roleTags: ["Unlisted Role"],
+      },
+    } as unknown as Doc<"profiles">;
+
+    const document = createProfileSearchDocument(profile);
+
+    assert.equal(document.summary, "Public bio");
+    assert.equal(document.imageUrl, "https://example.invalid/public-banner.png");
+    assert.equal(document.searchText.includes("Private Alias"), false);
+    assert.equal(document.searchText.includes("Unlisted Tag"), false);
+    assert.equal(document.searchText.includes("Private headline"), false);
+    assert.equal(document.searchText.includes("Unlisted Role"), false);
+    assert.deepEqual(document.vocabularyKeys, []);
+    assert.deepEqual(document.exactTokens, ["dj aurora"]);
+  });
+
   it("builds world and event documents for universal search", () => {
     const world = {
       _id: "world123",


### PR DESCRIPTION
## Summary
- Add Convex Auth foundation with Discord, Google, password + SES verification, Next.js auth providers, sign-in/account pages, and account-aware profile submission.
- Add profile ownership, claim request, verification attempt, and field-level visibility schema/helpers.
- Add executable Discord Administrator verification plus split VRChat and VRCLinking proof-code adapter seams.
- Convert profile surfacing backfill to `@convex-dev/migrations` and add gated production Convex deploy/migration workflow.
- Add SES Terraform for `vrdex.net`, deployment docs, and environment-specific Convex secret names.
- Add a graceful `/account` fallback for preview environments whose configured Convex deployment has not received the latest functions yet.
- Address AI review hardening: block protocol-relative auth redirects, drop unused Discord `guilds` OAuth scope, require VRChat/VRCLinking proof-attempt ownership, and preflight Discord person-claim ownership.
- Update public profile/search projections, backend docs, and tests for owner singleton and direct-page vs discovery visibility.

## Verification
- `pnpm verify`
- `pnpm --filter web typecheck`
- `pnpm --filter web build` with `NEXT_PUBLIC_CONVEX_URL` intentionally empty to reproduce CI prerender behavior.
- `terraform fmt -recursive infra/terraform/ses`
- `terraform init -backend=false` in `infra/terraform/ses`
- `terraform validate` in `infra/terraform/ses`
- `terraform apply -auto-approve tfplan` in `infra/terraform/ses`; created 12 SES/DNS/IAM resources for `vrdex.net`.
- `terraform plan -var "domain_name=vrdex.net" -var "from_email=no-reply@vrdex.net" -detailed-exitcode` in `infra/terraform/ses`; no changes after apply.
- AWS SES checks: domain verification `Success`, DKIM verification `Success`, SES production access enabled, sending enabled.
- Convex dev/prod environment checks: `AWS_SES_REGION=us-east-1` and `AWS_SES_FROM_EMAIL=no-reply@vrdex.net` are set; AWS key material was set without printing it.
- GitHub Actions on commit `f8daaf2`: Lint Web, Typecheck Web, Typecheck Backend, Verify Backend Local, Build Web, Playwright Public Preview, Vercel Preview, Analyze JavaScript and TypeScript, and CodeQL all passed.
- Greptile reviewed commit `1f7b189`; all four findings were accepted, fixed in `f8daaf2`, replied to, and resolved.
- Branch preview visual smoke: `/account` renders the backend-unavailable fallback instead of an application error; `/sign-in` and `/submit` render normally. Screenshot captured locally as `vrdex-pr99-account-preview-fallback.png`.
- Earlier visual smoke: `/account` signed-out render captured as `vrdex-account-signed-out.png` during local Playwright check. Signed-in claim UI could not be exercised locally without configured OAuth/provider credentials and a deployed matching Convex function bundle.

## Notes
- Production Convex deploy/migration remains gated by the workflow condition and environment-specific secrets; the PR run skipped the production deploy job as expected.
- Terraform local state now exists under the ignored `infra/terraform/ses` working directory and contains sensitive state. Keep it local/secure until a remote state backend is chosen.
- Runtime claim verification still needs real secret configuration before end-to-end smoke: Discord bot token, OAuth credentials, and proof adapter URLs/tokens.
- Codex code review could not run because the account has reached Codex review usage limits.
- `VRCHAT_PROOF_ADAPTER_URL` and `VRCLINKING_PROOF_ADAPTER_URL` are separate adapter seams; no guessed VRCLinking API behavior is hard-coded.