### PR TITLE
Document staging E2E environment

### DIFF
--- a/docs/deployment/convex-environments.md
+++ b/docs/deployment/convex-environments.md
@@ -40,6 +40,12 @@ Development/staging Convex env names:
 
 The browser-facing token stays in the web host and GitHub Actions as `VRDEX_E2E_BROWSER_TOKEN` / `VRDEX_HOSTED_E2E_BROWSER_TOKEN`; it is not needed by Convex.
 
+The shared development deployment `scrupulous-corgi-247` is the current hosted E2E backend for Vercel `staging`. If new Convex functions are required for hosted E2E, push them to the dev deployment before rerunning deployed health:
+
+```powershell
+$env:CONVEX_DEPLOYMENT="dev:scrupulous-corgi-247"; $env:CONVEX_SELF_HOSTED_URL=""; pnpm exec convex dev --once --typecheck=try --tail-logs=disable
+```
+
 ## Notes
 
 There are two similarly named Convex projects in the account history: `vrdex` and `vrdex-85631`. Current recommendation is to keep the `vrdex` line of deployments and archive/delete the other only after confirming no dashboard, env, or deployment history still depends on it.

--- a/docs/deployment/vercel-preview.md
+++ b/docs/deployment/vercel-preview.md
@@ -55,6 +55,31 @@ Production should keep `VRDEX_ENABLE_E2E_HELPERS=false` or unset, and should not
 
 Preview deployment protection must allow unauthenticated reads if the PR preview is meant to be reviewed outside the Vercel dashboard.
 
+## Staging Hosted E2E Environment
+
+Locked decision: `staging` is the shared non-production Vercel custom environment for deployed mutation-backed Playwright health checks.
+
+- target name: `staging`
+- type: Preview custom environment
+- branch tracking: `staging`
+- stable alias: `https://vr-dex-web-env-staging-basicbit.vercel.app`
+- deploy command from the repository root: `pnpm dlx vercel@54.4.1 deploy --target=staging --yes`
+
+The `staging` Vercel environment points at the shared Convex development deployment:
+
+- `NEXT_PUBLIC_CONVEX_URL=https://scrupulous-corgi-247.convex.cloud`
+- `CONVEX_URL=https://scrupulous-corgi-247.convex.cloud`
+- `VRDEX_REQUIRE_CONVEX_URL=true`
+- `NEXT_PUBLIC_VRDEX_SUBMISSIONS_AUTH_READY=false`
+- `VRDEX_ENABLE_E2E_HELPERS=true`
+- `VRDEX_E2E_BROWSER_TOKEN`: sensitive value matching GitHub Actions secret `VRDEX_HOSTED_E2E_BROWSER_TOKEN`
+- `VRDEX_E2E_CONVEX_SECRET`: sensitive value matching Convex dev env `VRDEX_E2E_CONVEX_SECRET`
+
+GitHub Actions uses these repository settings for hosted mutation health:
+
+- variable `VRDEX_HOSTED_E2E_BASE_URL=https://vr-dex-web-env-staging-basicbit.vercel.app`
+- secret `VRDEX_HOSTED_E2E_BROWSER_TOKEN`
+
 ## Validation
 
 The Vercel build runs `pnpm build:vercel`, which executes `apps/web/scripts/check-vercel-env.mjs` before `next build`.

--- a/docs/testing/playwright-visual-preview.md
+++ b/docs/testing/playwright-visual-preview.md
@@ -133,3 +133,5 @@ The `Deployed Health Checks` workflow runs after merges to `main`, after success
 - `Production Smoke Health` uses the production deployment status URL when the workflow was triggered by a successful production deployment, otherwise `VRDEX_PRODUCTION_SMOKE_BASE_URL`, to run read-only public route smoke against production.
 
 Manual dispatch can run `all`, `staging-mutation`, or `production-smoke`. The optional `base_url` override applies only when dispatching a single selected target. The deployed health workflow uploads artifacts and fails the workflow on test failure, but it does not create GitHub issues automatically.
+
+Current hosted mutation target: `https://vr-dex-web-env-staging-basicbit.vercel.app`, backed by the shared Convex development deployment. The deployed health workflow run `26682711966` passed `staging-mutation` after the Vercel staging environment and Convex dev E2E helper variables were configured.


### PR DESCRIPTION
## What changed
- Records the Vercel custom environment staging and its stable hosted E2E alias.
- Documents the GitHub Actions and Vercel env names used for hosted mutation health without secret values.
- Records the Convex dev deployment push command needed when hosted E2E functions change.

## Testing
- git diff --check`n- Deployed Health Checks staging-mutation passed in run 26682711966: https://github.com/BASIC-BIT/VRDex/actions/runs/26682711966

## Risk
Docs-only repository change. Provider settings were already created and validated.