### PR TITLE
Include mutation flow in local E2E

### DIFF
--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -12,7 +12,7 @@
     "check:vercel-env": "node ./scripts/check-vercel-env.mjs",
     "start": "next start",
     "lint": "eslint",
-    "test:e2e": "playwright test --grep-invert \"@visual|@flow|@snapshot\"",
+    "test:e2e": "playwright test --grep-invert \"@visual|@snapshot\"",
     "test:e2e:hosted": "playwright test --grep @flow --project=desktop-chromium",
     "test:e2e:hosted:smoke": "playwright test --grep-invert \"@visual|@flow|@snapshot\"",
     "test:e2e:snapshots": "playwright test --grep @snapshot",

--- a/apps/web/playwright.config.mjs
+++ b/apps/web/playwright.config.mjs
@@ -15,9 +15,17 @@ const reuseConvexServer = process.env.PLAYWRIGHT_REUSE_CONVEX === "true";
 const skipWebServers = process.env.PLAYWRIGHT_SKIP_WEBSERVERS === "true" || Boolean(hostedBaseURL);
 const skipConvexServer = skipWebServers || process.env.PLAYWRIGHT_SKIP_CONVEX_DEV === "true";
 const recordVideo = process.env.PLAYWRIGHT_RECORD_VIDEO === "true";
+const e2eHelpersEnabled = process.env.VRDEX_ENABLE_E2E_HELPERS ?? (hostedBaseURL ? undefined : "true");
 const allowFixtureSearchFallthrough =
   process.env.VRDEX_ALLOW_PLAYWRIGHT_FIXTURE_SEARCH_FALLTHROUGH === "true" ||
-  process.env.VRDEX_ENABLE_E2E_HELPERS === "true";
+  e2eHelpersEnabled === "true";
+const localE2eHelperEnv = hostedBaseURL
+  ? {}
+  : {
+      VRDEX_ENABLE_E2E_HELPERS: e2eHelpersEnabled ?? "true",
+      VRDEX_E2E_BROWSER_TOKEN: process.env.VRDEX_E2E_BROWSER_TOKEN ?? "local-playwright-token",
+      VRDEX_E2E_CONVEX_SECRET: process.env.VRDEX_E2E_CONVEX_SECRET ?? "local-convex-e2e-secret",
+    };
 
 if (!hostedBaseURL) {
   process.env.CONVEX_URL = convexUrl;
@@ -29,6 +37,7 @@ const sharedEnv = {
   CONVEX_URL: convexUrl,
   NEXT_PUBLIC_CONVEX_URL: convexUrl,
   VRDEX_ENABLE_PLAYWRIGHT_FIXTURES: "true",
+  ...localE2eHelperEnv,
   ...(allowFixtureSearchFallthrough
     ? { VRDEX_ALLOW_PLAYWRIGHT_FIXTURE_SEARCH_FALLTHROUGH: "true" }
     : {}),

--- a/docs/testing/playwright-visual-preview.md
+++ b/docs/testing/playwright-visual-preview.md
@@ -6,7 +6,7 @@ See `docs/testing/playwright-image-diffing.md` for the committed-baseline image 
 
 ## Local commands
 
-- Smoke public routes: `pnpm test:e2e`
+- Smoke public routes and run the local mutation-backed data flow: `pnpm test:e2e`
 - Capture public route screenshots: `pnpm test:e2e:visual`
 - Compare public route screenshots against baselines: `pnpm test:e2e:snapshots`
 - Update public route screenshot baselines: `pnpm test:e2e:snapshots:update`
@@ -50,7 +50,7 @@ POSIX shell hosted production smoke run:
 PLAYWRIGHT_BASE_URL=https://vrdex.net PLAYWRIGHT_SKIP_WEBSERVERS=true pnpm test:e2e:hosted:smoke
 ```
 
-The visual suite starts a local Convex backend and Next dev server by default. Setting `PLAYWRIGHT_BASE_URL` switches Playwright to hosted mode and disables local web servers. Profile screenshots use deterministic Next-server fixtures when `VRDEX_ENABLE_PLAYWRIGHT_FIXTURES=true`, while `/server-status` still exercises the real local Convex health query. Fixture profiles are disabled when `NODE_ENV=production`.
+The local Playwright suite starts a local Convex backend and Next dev server by default. Setting `PLAYWRIGHT_BASE_URL` switches Playwright to hosted mode and disables local web servers. Local webserver runs set token-gated E2E helper defaults so `pnpm test:e2e` includes the mutation-backed `@flow` journey without additional env setup. Profile screenshots use deterministic Next-server fixtures when `VRDEX_ENABLE_PLAYWRIGHT_FIXTURES=true`, while `/server-status` still exercises the real local Convex health query. Fixture profiles are disabled when `NODE_ENV=production`.
 
 ## Captured routes
 


### PR DESCRIPTION
## What changed
- Makes local Playwright webserver runs default the existing token-gated E2E helper env.
- Includes the mutation-backed `@flow` profile submission journey in `pnpm test:e2e` by excluding only visual/snapshot suites.
- Updates the Playwright testing docs so the local command reflects smoke plus mutation coverage.

## Why
Closes a concrete issue #100 acceptance gap: the normal local E2E command should include at least one mutation-backed journey, not only public render checks.

## Testing
- `node --check apps/web/playwright.config.mjs`
- `git diff --check`
- `pnpm test:e2e`
- `pnpm --filter web lint`
- `pnpm --filter web typecheck`
- Baseline Checks passed: https://github.com/BASIC-BIT/VRDex/actions/runs/26697296794

## Risk
Local-only Playwright startup behavior changes. Hosted and production smoke modes still require explicit `PLAYWRIGHT_BASE_URL`; hosted smoke still excludes `@flow`, and production E2E helpers remain blocked by the route guard.