### PR TITLE
Automate staging deploys

### DIFF
--- a/.github/workflows/staging-deploy.yml
+++ b/.github/workflows/staging-deploy.yml
@@ -1,0 +1,136 @@
+name: Staging Deploy
+
+on:
+  workflow_run:
+    workflows:
+      - Baseline Checks
+    types:
+      - completed
+    branches:
+      - main
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: staging-deploy-main
+  cancel-in-progress: false
+
+jobs:
+  deploy-staging:
+    name: Deploy Staging
+    if: github.event_name == 'workflow_dispatch' || github.event.workflow_run.conclusion == 'success'
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event_name == 'workflow_run' && github.event.workflow_run.head_sha || github.sha }}
+
+      - name: Check staging deploy configuration
+        id: gate
+        env:
+          CONVEX_DEPLOY_KEY_DEV: ${{ secrets.CONVEX_DEPLOY_KEY_DEV }}
+          VERCEL_TOKEN: ${{ secrets.VERCEL_TOKEN }}
+          VERCEL_ORG_ID: ${{ secrets.VERCEL_ORG_ID }}
+          VERCEL_PROJECT_ID: ${{ secrets.VERCEL_PROJECT_ID }}
+          HOSTED_BASE_URL: ${{ vars.VRDEX_HOSTED_E2E_BASE_URL }}
+          HOSTED_BROWSER_TOKEN: ${{ secrets.VRDEX_HOSTED_E2E_BROWSER_TOKEN }}
+        run: |
+          set -euo pipefail
+
+          missing=()
+          if [ -z "$CONVEX_DEPLOY_KEY_DEV" ]; then missing+=("CONVEX_DEPLOY_KEY_DEV"); fi
+          if [ -z "$VERCEL_TOKEN" ]; then missing+=("VERCEL_TOKEN"); fi
+          if [ -z "$VERCEL_ORG_ID" ]; then missing+=("VERCEL_ORG_ID"); fi
+          if [ -z "$VERCEL_PROJECT_ID" ]; then missing+=("VERCEL_PROJECT_ID"); fi
+          if [ -z "$HOSTED_BASE_URL" ]; then missing+=("VRDEX_HOSTED_E2E_BASE_URL"); fi
+          if [ -z "$HOSTED_BROWSER_TOKEN" ]; then missing+=("VRDEX_HOSTED_E2E_BROWSER_TOKEN"); fi
+
+          if [ "${#missing[@]}" -gt 0 ]; then
+            echo "enabled=false" >> "$GITHUB_OUTPUT"
+            {
+              echo "## Staging deploy"
+              echo "Skipped because required staging deployment settings are missing:"
+              printf -- '- %s\n' "${missing[@]}"
+            } >> "$GITHUB_STEP_SUMMARY"
+            exit 0
+          fi
+
+          echo "enabled=true" >> "$GITHUB_OUTPUT"
+          echo "hosted_base_url=$HOSTED_BASE_URL" >> "$GITHUB_OUTPUT"
+
+      - name: Setup pnpm
+        if: steps.gate.outputs.enabled == 'true'
+        uses: pnpm/action-setup@v4
+
+      - name: Setup Node.js
+        if: steps.gate.outputs.enabled == 'true'
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: pnpm
+
+      - name: Install dependencies
+        if: steps.gate.outputs.enabled == 'true'
+        run: pnpm install --frozen-lockfile
+
+      - name: Deploy Convex development functions
+        if: steps.gate.outputs.enabled == 'true'
+        env:
+          CONVEX_DEPLOY_KEY: ${{ secrets.CONVEX_DEPLOY_KEY_DEV }}
+        run: pnpm exec convex deploy --yes --typecheck=enable
+
+      - name: Deploy Vercel staging
+        if: steps.gate.outputs.enabled == 'true'
+        id: vercel
+        env:
+          VERCEL_TOKEN: ${{ secrets.VERCEL_TOKEN }}
+          VERCEL_ORG_ID: ${{ secrets.VERCEL_ORG_ID }}
+          VERCEL_PROJECT_ID: ${{ secrets.VERCEL_PROJECT_ID }}
+        run: |
+          set -euo pipefail
+          deployment_url=$(pnpm dlx vercel@54.4.1 deploy --target=staging --yes --token "$VERCEL_TOKEN" | tail -n 1)
+          if [ -z "$deployment_url" ]; then
+            echo "Vercel staging deployment did not return a URL." >&2
+            exit 1
+          fi
+
+          echo "url=$deployment_url" >> "$GITHUB_OUTPUT"
+          {
+            echo "## Staging deploy"
+            echo "Convex development functions deployed."
+            echo "Vercel staging deployment: $deployment_url"
+            echo "Hosted health target: ${{ steps.gate.outputs.hosted_base_url }}"
+          } >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Install Playwright Chromium
+        if: steps.gate.outputs.enabled == 'true'
+        working-directory: apps/web
+        run: pnpm exec playwright install --with-deps chromium
+
+      - name: Run hosted staging data-flow health
+        if: steps.gate.outputs.enabled == 'true'
+        id: health
+        env:
+          PLAYWRIGHT_BASE_URL: ${{ steps.gate.outputs.hosted_base_url }}
+          PLAYWRIGHT_RECORD_VIDEO: "true"
+          PLAYWRIGHT_SKIP_WEBSERVERS: "true"
+          VRDEX_E2E_BROWSER_TOKEN: ${{ secrets.VRDEX_HOSTED_E2E_BROWSER_TOKEN }}
+          VRDEX_E2E_RUN_ID: staging-deploy-${{ github.run_id }}-${{ github.run_attempt }}
+        run: pnpm test:e2e:hosted
+
+      - name: Upload staging deploy artifacts
+        if: always() && steps.gate.outputs.enabled == 'true'
+        uses: actions/upload-artifact@v4
+        with:
+          name: staging-deploy-health
+          if-no-files-found: warn
+          retention-days: 7
+          path: |
+            apps/web/playwright-report
+            apps/web/test-results
+            apps/web/playwright-artifacts

--- a/docs/deployment/convex-environments.md
+++ b/docs/deployment/convex-environments.md
@@ -40,7 +40,9 @@ Development/staging Convex env names:
 
 The browser-facing token stays in the web host and GitHub Actions as `VRDEX_E2E_BROWSER_TOKEN` / `VRDEX_HOSTED_E2E_BROWSER_TOKEN`; it is not needed by Convex.
 
-The shared development deployment `scrupulous-corgi-247` is the current hosted E2E backend for Vercel `staging`. If new Convex functions are required for hosted E2E, push them to the dev deployment before rerunning deployed health:
+The shared development deployment `scrupulous-corgi-247` is the current hosted E2E backend for Vercel `staging`. The `Staging Deploy` GitHub Actions workflow deploys Convex development functions with `CONVEX_DEPLOY_KEY_DEV` before deploying Vercel `staging` and running hosted data-flow health.
+
+Manual fallback if the workflow is unavailable:
 
 ```powershell
 $env:CONVEX_DEPLOYMENT="dev:scrupulous-corgi-247"; $env:CONVEX_SELF_HOSTED_URL=""; pnpm exec convex dev --once --typecheck=try --tail-logs=disable

--- a/docs/deployment/vercel-preview.md
+++ b/docs/deployment/vercel-preview.md
@@ -86,6 +86,15 @@ GitHub Actions uses these repository settings for hosted mutation health:
 - variable `VRDEX_HOSTED_E2E_BASE_URL=https://staging.vrdex.net`
 - secret `VRDEX_HOSTED_E2E_BROWSER_TOKEN`
 
+The `Staging Deploy` workflow runs after `Baseline Checks` succeeds on `main` and can also be run manually. It requires these settings:
+
+- secret `CONVEX_DEPLOY_KEY_DEV`: deploys functions/schema to `scrupulous-corgi-247`
+- secrets `VERCEL_TOKEN`, `VERCEL_ORG_ID`, `VERCEL_PROJECT_ID`: deploy Vercel `staging`
+- variable `VRDEX_HOSTED_E2E_BASE_URL`: hosted health target, currently `https://staging.vrdex.net`
+- secret `VRDEX_HOSTED_E2E_BROWSER_TOKEN`: browser token for hosted E2E helper calls
+
+If any required setting is missing, the workflow writes a skip summary and exits successfully instead of partially deploying staging. When enabled, the workflow deploys Convex development functions first, then deploys Vercel `staging`, then runs `pnpm test:e2e:hosted` against `VRDEX_HOSTED_E2E_BASE_URL`.
+
 ## Validation
 
 The Vercel build runs `pnpm build:vercel`, which executes `apps/web/scripts/check-vercel-env.mjs` before `next build`.


### PR DESCRIPTION
## What changed
- Adds a `Staging Deploy` workflow that runs after successful `Baseline Checks` on `main`, plus manual dispatch.
- Deploys Convex development functions first, then Vercel `staging`, then runs hosted `@flow` health against `VRDEX_HOSTED_E2E_BASE_URL`.
- Gates the workflow on required repo settings and writes an explicit skip summary if any setting is missing.
- Documents the staging automation and manual Convex fallback.

## Current blocker
Repository secrets currently include `CONVEX_DEPLOY_KEY_DEV`, `VERCEL_ORG_ID`, `VERCEL_PROJECT_ID`, and `VRDEX_HOSTED_E2E_BROWSER_TOKEN`, but not `VERCEL_TOKEN`. Until `VERCEL_TOKEN` is added, the workflow will skip safely instead of partially deploying staging.

## Testing
- `git diff --check`
- `pnpm dlx prettier --check .github/workflows/staging-deploy.yml docs/deployment/convex-environments.md docs/deployment/vercel-preview.md`
- Baseline Checks passed: https://github.com/BASIC-BIT/VRDex/actions/runs/26697796464

## Risk
This introduces a post-main automation path, but it is gated fail-closed. When enabled, it will mutate the shared Convex dev deployment and Vercel `staging` environment only after `main` baseline checks pass.