### PR TITLE
Scope hosted discovery visibility assertions

### DIFF
--- a/apps/web/e2e/profile-submission.flow.spec.ts
+++ b/apps/web/e2e/profile-submission.flow.spec.ts
@@ -125,17 +125,20 @@ test("profile field visibility keeps unlisted fields on profiles and out of disc
     await expect(page.getByText(privateRole)).toHaveCount(0);
 
     await page.goto(`/discover?q=${encodeURIComponent(directOnlyAlias)}`);
-    await expect(page.getByText("No public results matched that search yet.")).toBeVisible();
-    await expect(page.getByText(displayName, { exact: true })).toHaveCount(0);
+    let searchResults = page.locator("section").filter({ hasText: "Search results" }).first();
+    await expect(searchResults.getByText("No public results matched that search yet.")).toBeVisible();
+    await expect(searchResults.getByText(displayName, { exact: true })).toHaveCount(0);
 
     await page.goto(`/discover?q=${encodeURIComponent(directOnlyBio)}`);
-    await expect(page.getByText("No public results matched that search yet.")).toBeVisible();
-    await expect(page.getByText(displayName, { exact: true })).toHaveCount(0);
+    searchResults = page.locator("section").filter({ hasText: "Search results" }).first();
+    await expect(searchResults.getByText("No public results matched that search yet.")).toBeVisible();
+    await expect(searchResults.getByText(displayName, { exact: true })).toHaveCount(0);
 
     await page.goto(`/discover?q=${encodeURIComponent(publicTag)}`);
-    await expect(page.getByText(displayName, { exact: true })).toBeVisible();
-    await expect(page.getByText(directOnlyBio)).toHaveCount(0);
-    await expect(page.getByText(privateRole)).toHaveCount(0);
+    searchResults = page.locator("section").filter({ hasText: "Search results" }).first();
+    await expect(searchResults.getByText(displayName, { exact: true })).toBeVisible();
+    await expect(searchResults.getByText(directOnlyBio)).toHaveCount(0);
+    await expect(searchResults.getByText(privateRole)).toHaveCount(0);
   } finally {
     if (createdSlug || runId) {
       const cleanupResponse = await request.delete("/api/e2e/profile-submissions", {


### PR DESCRIPTION
## What changed
- Scope the extended-profile discovery assertions to the Search results section.
- Keep display-name checks from failing when the same profile appears elsewhere on the discovery page.

## Why
Hosted staging showed the profile display name in non-search discovery sections while correctly returning no search results for unlisted fields.

## Testing
- `PLAYWRIGHT_TEST_PORT=3003 pnpm --filter web exec playwright test --grep "profile field visibility" --project=desktop-chromium`

## Rollout
After merge, redeploy Vercel staging and re-enable `VRDEX_HOSTED_E2E_EXTENDED_PROFILE_FLOW`.