### PR TITLE
Shorten hosted adapter E2E alias

### DIFF
--- a/apps/web/e2e/auth-claim.flow.spec.ts
+++ b/apps/web/e2e/auth-claim.flow.spec.ts
@@ -199,7 +199,7 @@ test("verified email account can complete community and VRChat adapter claims @f
       runId,
       profileType: "community",
       displayName: `Playwright Community ${runSuffix}`,
-      aliases: [`Adapter Community ${runSuffix}`],
+      aliases: [`Adapter ${runSuffix}`],
       tags: ["playwright", "adapter-flow"],
       subtype: "VRChat group",
       categoryTags: ["Adapter verified"],


### PR DESCRIPTION
## What changed
- Shorten the hosted adapter E2E community alias fixture from `Adapter Community ...` to `Adapter ...`.

## Why
Hosted run IDs are longer than local run IDs, and the previous alias could exceed the 60-character profile alias validation limit.

## Testing
- `PLAYWRIGHT_TEST_PORT=3004 pnpm --filter web exec playwright test --grep "community and VRChat adapter claims" --project=desktop-chromium`

## Rollout
After merge, redeploy Vercel staging and re-enable `VRDEX_HOSTED_E2E_ADAPTER_HELPERS`.