### PR TITLE
Document hosted E2E rollout envs

### DIFF
--- a/docs/deployment/convex-environments.md
+++ b/docs/deployment/convex-environments.md
@@ -39,6 +39,9 @@ Development/staging Convex env names:
 - `VRDEX_E2E_CONVEX_SECRET`: non-empty sentinel also configured in the hosted app environment
 - `VRDEX_ENABLE_E2E_AUTH_HELPERS=true`: optional, only when hosted auth/claim E2E is intentionally enabled
 - `VRDEX_ENABLE_E2E_ADAPTER_HELPERS=true`: optional, only when hosted adapter E2E is intentionally enabled
+- `SITE_URL=https://staging.vrdex.net`: required by Convex Auth email/password redirects for hosted auth E2E
+- `JWT_PRIVATE_KEY`: Convex Auth RS256 private key, generated for the shared development deployment and never printed
+- `JWKS`: Convex Auth public key set matching `JWT_PRIVATE_KEY`
 - `DISCORD_API_BASE_URL`: optional hosted adapter stub base URL, usually `https://staging.vrdex.net/api/e2e/adapters/discord`
 - `DISCORD_BOT_TOKEN`: staging-only adapter token matching the hosted app environment
 - `VRCHAT_PROOF_ADAPTER_URL`: optional hosted adapter stub URL, usually `https://staging.vrdex.net/api/e2e/adapters/vrchat-proof`
@@ -48,6 +51,8 @@ Development/staging Convex env names:
 The browser-facing token stays in the web host and GitHub Actions as `VRDEX_E2E_BROWSER_TOKEN` / `VRDEX_HOSTED_E2E_BROWSER_TOKEN`; it is not needed by Convex.
 
 The shared development deployment `scrupulous-corgi-247` is the current hosted E2E backend for Vercel `staging`. The `Staging Deploy` GitHub Actions workflow deploys Convex development functions with `CONVEX_DEPLOY_KEY_DEV` before deploying Vercel `staging` and running hosted data-flow health.
+
+Current recommendation: generate Convex Auth JWT keys through a non-printing command path and set them with `convex env set -- NAME VALUE`, because PEM values begin with dashes and can be parsed as CLI options if passed in the wrong position.
 
 Manual fallback if the workflow is unavailable:
 

--- a/docs/deployment/vercel-preview.md
+++ b/docs/deployment/vercel-preview.md
@@ -33,6 +33,8 @@ The workflow can also deploy a matching Convex preview backend when this optiona
 
 If any are missing, the `Vercel Preview` job passes and writes a step summary explaining that deployment is skipped. This keeps baseline CI green before the hosted project is linked, while making the missing live-deploy blocker explicit.
 
+`VERCEL_TOKEN` must be a Vercel account access token created from Vercel account settings. The local Vercel CLI session token from `auth.json` is not accepted by `vercel --token` in GitHub Actions and should not be stored as this secret.
+
 When `CONVEX_DEPLOY_KEY_PREVIEW` exists, the workflow runs `convex deploy --preview-create pr-<number>` before the Vercel build and writes the resulting `NEXT_PUBLIC_CONVEX_URL` into the Vercel build environment. This keeps PR previews from accidentally pointing at stale shared dev/prod Convex functions.
 
 ## Web environment
@@ -86,17 +88,17 @@ The `staging` Vercel environment points at the shared Convex development deploym
 - `VRDEX_ENABLE_E2E_HELPERS=true`
 - `VRDEX_E2E_BROWSER_TOKEN`: sensitive value matching GitHub Actions secret `VRDEX_HOSTED_E2E_BROWSER_TOKEN`
 - `VRDEX_E2E_CONVEX_SECRET`: sensitive value matching Convex dev env `VRDEX_E2E_CONVEX_SECRET`
-- `VRDEX_ENABLE_E2E_AUTH_HELPERS`: unset until hosted auth/claim E2E is intentionally enabled
-- `VRDEX_ENABLE_E2E_ADAPTER_HELPERS`: unset until hosted adapter E2E is intentionally enabled
-- `DISCORD_BOT_TOKEN`: unset until hosted adapter E2E is intentionally enabled
-- `VRCHAT_PROOF_ADAPTER_BEARER_TOKEN`: unset until hosted adapter E2E is intentionally enabled
+- `VRDEX_ENABLE_E2E_AUTH_HELPERS=true`: enabled for hosted auth/claim E2E
+- `VRDEX_ENABLE_E2E_ADAPTER_HELPERS=true`: enabled for hosted adapter E2E
+- `DISCORD_BOT_TOKEN`: staging-only adapter token matching Convex dev env `DISCORD_BOT_TOKEN`
+- `VRCHAT_PROOF_ADAPTER_BEARER_TOKEN`: staging-only adapter token matching Convex dev env `VRCHAT_PROOF_ADAPTER_BEARER_TOKEN`
 
 GitHub Actions uses these repository settings for hosted mutation health:
 
 - variable `VRDEX_HOSTED_E2E_BASE_URL=https://staging.vrdex.net`
-- variable `VRDEX_HOSTED_E2E_EXTENDED_PROFILE_FLOW=true`: optional, only after staging has deployed the E2E profile helper route version that accepts extended profile fields
-- variable `VRDEX_HOSTED_E2E_AUTH_HELPERS=true`: optional, only after hosted auth helpers are enabled in Vercel staging and Convex dev
-- variable `VRDEX_HOSTED_E2E_ADAPTER_HELPERS=true`: optional, only after hosted adapter helpers are enabled in Vercel staging and Convex dev
+- variable `VRDEX_HOSTED_E2E_EXTENDED_PROFILE_FLOW=true`
+- variable `VRDEX_HOSTED_E2E_AUTH_HELPERS=true`
+- variable `VRDEX_HOSTED_E2E_ADAPTER_HELPERS=true`
 - secret `VRDEX_HOSTED_E2E_BROWSER_TOKEN`
 
 The `Staging Deploy` workflow runs after `Baseline Checks` succeeds on `main` and can also be run manually. It requires these settings:


### PR DESCRIPTION
## What changed
- Document the hosted Convex Auth env names now required for staging auth E2E.
- Record that `VERCEL_TOKEN` must be a real Vercel account access token, not the local CLI session token.
- Update staging hosted E2E docs to reflect the enabled auth and adapter helper flags.

## Why
The hosted rollout now has provider-side env changes that should not remain dashboard-only knowledge.

## Testing
- `git diff --check`
- Hosted Data Flow Health run `26743846965` passed with extended profile, auth helpers, and adapter helpers enabled.