### PR TITLE
Prepare docs domain deployment

### DIFF
--- a/.github/workflows/docs-deploy.yml
+++ b/.github/workflows/docs-deploy.yml
@@ -1,0 +1,112 @@
+name: Docs Deploy
+
+on:
+  workflow_run:
+    workflows:
+      - Baseline Checks
+    types:
+      - completed
+    branches:
+      - main
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: docs-deploy-main
+  cancel-in-progress: false
+
+jobs:
+  deploy-docs:
+    name: Deploy Docs
+    if: github.event_name == 'workflow_dispatch' || github.event.workflow_run.conclusion == 'success'
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event_name == 'workflow_run' && github.event.workflow_run.head_sha || github.sha }}
+
+      - name: Check docs deploy configuration
+        id: gate
+        env:
+          VERCEL_TOKEN: ${{ secrets.VERCEL_TOKEN }}
+          VERCEL_ORG_ID: ${{ secrets.VERCEL_ORG_ID }}
+          VERCEL_DOCS_PROJECT_ID: ${{ secrets.VERCEL_DOCS_PROJECT_ID }}
+        run: |
+          set -euo pipefail
+
+          missing=()
+          if [ -z "$VERCEL_TOKEN" ]; then missing+=("VERCEL_TOKEN"); fi
+          if [ -z "$VERCEL_ORG_ID" ]; then missing+=("VERCEL_ORG_ID"); fi
+          if [ -z "$VERCEL_DOCS_PROJECT_ID" ]; then missing+=("VERCEL_DOCS_PROJECT_ID"); fi
+
+          if [ "${#missing[@]}" -gt 0 ]; then
+            echo "enabled=false" >> "$GITHUB_OUTPUT"
+            {
+              echo "## Docs deploy"
+              echo "Skipped because required docs deployment settings are missing:"
+              printf -- '- %s\n' "${missing[@]}"
+            } >> "$GITHUB_STEP_SUMMARY"
+            exit 0
+          fi
+
+          echo "enabled=true" >> "$GITHUB_OUTPUT"
+
+      - name: Setup pnpm
+        if: steps.gate.outputs.enabled == 'true'
+        uses: pnpm/action-setup@v4
+
+      - name: Setup Node.js
+        if: steps.gate.outputs.enabled == 'true'
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: pnpm
+
+      - name: Install dependencies
+        if: steps.gate.outputs.enabled == 'true'
+        run: pnpm install --frozen-lockfile
+
+      - name: Verify docs
+        if: steps.gate.outputs.enabled == 'true'
+        run: pnpm verify:docs
+
+      - name: Pull Vercel docs production environment
+        if: steps.gate.outputs.enabled == 'true'
+        env:
+          VERCEL_TOKEN: ${{ secrets.VERCEL_TOKEN }}
+          VERCEL_ORG_ID: ${{ secrets.VERCEL_ORG_ID }}
+          VERCEL_PROJECT_ID: ${{ secrets.VERCEL_DOCS_PROJECT_ID }}
+        run: pnpm dlx vercel@54.4.1 pull --yes --environment=production --token "$VERCEL_TOKEN"
+
+      - name: Build Vercel docs output
+        if: steps.gate.outputs.enabled == 'true'
+        env:
+          VERCEL_TOKEN: ${{ secrets.VERCEL_TOKEN }}
+          VERCEL_ORG_ID: ${{ secrets.VERCEL_ORG_ID }}
+          VERCEL_PROJECT_ID: ${{ secrets.VERCEL_DOCS_PROJECT_ID }}
+        run: pnpm dlx vercel@54.4.1 build --prod --token "$VERCEL_TOKEN"
+
+      - name: Deploy Vercel docs output
+        if: steps.gate.outputs.enabled == 'true'
+        env:
+          VERCEL_TOKEN: ${{ secrets.VERCEL_TOKEN }}
+          VERCEL_ORG_ID: ${{ secrets.VERCEL_ORG_ID }}
+          VERCEL_PROJECT_ID: ${{ secrets.VERCEL_DOCS_PROJECT_ID }}
+        run: |
+          set -euo pipefail
+          deployment_url=$(pnpm dlx vercel@54.4.1 deploy --prebuilt --prod --token "$VERCEL_TOKEN" | tail -n 1)
+          if [ -z "$deployment_url" ]; then
+            echo "Vercel docs deployment did not return a URL." >&2
+            exit 1
+          fi
+
+          {
+            echo "## Docs deploy"
+            echo "Vercel docs deployment: $deployment_url"
+            echo "Expected custom domain after provider setup: https://docs.vrdex.net"
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/docs/README.md
+++ b/docs/README.md
@@ -19,6 +19,7 @@ This repo keeps durable markdown under `docs/` so product, developer, engineerin
 - `docs/developers/vrdex-mcp-read-tools.md` - documentation-only first pass for standalone read-only VRDex MCP tools
 - `docs/engineering/service-map.md` - cross-link map for services, docs, and implementation surfaces
 - `docs/deployment/aws-baseline.md` - first-pass AWS service baseline for SES and future S3 assets
+- `docs/deployment/docs-site.md` - Docusaurus docs deployment runbook for `docs.vrdex.net`
 - `docs/developers/self-hosting-and-iac.md` - self-hosting, hosted deployment, and IaC ownership direction
 - `docs/deployment/vercel-preview.md` - initial Vercel hosted-preview setup and validation path
 - `docs/deployment/ses-auth-email.md` - SES auth email and Convex environment variables

--- a/docs/deployment/docs-site.md
+++ b/docs/deployment/docs-site.md
@@ -1,0 +1,78 @@
+# Docs Site Deployment
+
+## Status
+
+Current deployment runbook for [#125](https://github.com/BASIC-BIT/VRDex/issues/125).
+
+The Docusaurus docs app exists and builds, but `https://docs.vrdex.net` is not live until the Vercel docs project, custom domain binding, GitHub secret, and Route 53 DNS record are configured.
+
+## Current State
+
+- `apps/docs` is the Docusaurus shell.
+- Canonical markdown stays under `docs/`.
+- `pnpm verify:docs` runs `markdownlint-cli2` and `docusaurus build`.
+- `apps/docs/docusaurus.config.js` uses `url: "https://docs.vrdex.net"` and `baseUrl: "/"`.
+- `docs.vrdex.net` currently has no DNS record.
+
+## Target Hosted Shape
+
+Create or import a Vercel project for docs only:
+
+| Setting | Value |
+| --- | --- |
+| Vercel project name | `vr-dex-docs` |
+| Repository | `BASIC-BIT/VRDex` |
+| Root directory | `apps/docs` |
+| Framework preset | Docusaurus or Other |
+| Build command | `pnpm build` |
+| Output directory | `build` |
+| Production domain | `docs.vrdex.net` |
+
+Run Vercel CLI commands from the repository root once the project root directory is set to `apps/docs`; running from `apps/docs` can make Vercel resolve the app root twice. Use root-level `pnpm verify:docs` in CI before deployment, but keep the Vercel project build command relative to the docs app root.
+
+## GitHub Actions Settings
+
+The `Docs Deploy` workflow runs after `Baseline Checks` succeeds on `main` and can also be run manually.
+
+It deploys only when these repository secrets exist:
+
+- `VERCEL_TOKEN`
+- `VERCEL_ORG_ID`
+- `VERCEL_DOCS_PROJECT_ID`
+
+If any required setting is missing, the workflow writes a skip summary and exits successfully instead of partially deploying docs. `VERCEL_DOCS_PROJECT_ID` should point to the docs Vercel project, not the existing web app project.
+
+## DNS
+
+DNS for `docs.vrdex.net` should be managed in the Route 53 public hosted zone for `vrdex.net`.
+
+After `docs.vrdex.net` is added to the Vercel docs project, copy the exact DNS record Vercel provides into Route 53. Do not commit provider-generated hosted zone IDs, project IDs, account IDs, or secret values into public docs.
+
+Expected validation after DNS propagation:
+
+```powershell
+Resolve-DnsName -Name "docs.vrdex.net"
+```
+
+## Verification
+
+Before provider setup:
+
+- `pnpm verify:docs`
+- `pnpm verify`
+- `Docs Deploy` workflow skips with a missing-settings summary if the docs project secret is not configured
+
+After provider setup:
+
+- `Docs Deploy` workflow succeeds on `main`
+- `https://docs.vrdex.net/` loads the Docusaurus landing page
+- `https://docs.vrdex.net/docs/` loads the canonical docs index
+- `https://docs.vrdex.net/docs/developers/` loads the developer lane
+- `https://docs.vrdex.net/docs/engineering/` loads the engineering lane
+
+## Safety Rules
+
+- Do not expose private partner context in public Docusaurus docs.
+- Do not commit provider IDs or generated DNS target values unless there is a specific public operational reason.
+- Keep secret values in GitHub/Vercel/provider secret stores only.
+- Keep public docs deployment separate from the `apps/web` Vercel project so docs changes do not accidentally alter app routing.

--- a/docs/developers/self-hosting-and-iac.md
+++ b/docs/developers/self-hosting-and-iac.md
@@ -26,7 +26,7 @@ The BASIC BIT hosted deployment currently uses:
 - PostHog project `447783` for hosted product analytics
 - Terraform stacks under `infra/terraform/`
 - GitHub Actions for baseline checks, deployed health, CodeQL, and staging deploys
-- Docusaurus scaffold under `apps/docs`, reading canonical markdown from `docs/`
+- Docusaurus scaffold under `apps/docs`, reading canonical markdown from `docs/`; [#125](https://github.com/BASIC-BIT/VRDex/issues/125) owns deployment to `docs.vrdex.net`
 
 ## IaC Ownership Table
 
@@ -37,6 +37,7 @@ The BASIC BIT hosted deployment currently uses:
 | PostHog project metadata | `infra/terraform/posthog` | Imports hosted project `447783`; sensitive project token output feeds Vercel stack locally. |
 | Hosted Vercel PostHog env vars | `infra/terraform/vercel` | Owns `NEXT_PUBLIC_POSTHOG_KEY` and `NEXT_PUBLIC_POSTHOG_HOST` for production, default preview, and configured staging custom environment IDs. |
 | Vercel project, staging environment, and E2E helper vars | manual bootstrap plus docs | Documented in `docs/deployment/vercel-preview.md`; not Terraform-owned yet. |
+| Docs Vercel project and `docs.vrdex.net` domain | planned manual bootstrap plus workflow | Runbook lives in `docs/deployment/docs-site.md`; [#125](https://github.com/BASIC-BIT/VRDex/issues/125) owns provider setup. |
 | Convex deployment keys and env vars | provider secret store plus docs | Documented in `docs/deployment/convex-environments.md` and `docs/deployment/ses-auth-email.md`. |
 | Convex custom domains | deferred manual provider setup | Runbook lives in `docs/deployment/convex-environments.md`; requires Convex Pro and dashboard-provided DNS records before Route 53 records. |
 | Profile asset storage | planned follow-up | Direction documented in `docs/deployment/aws-baseline.md`; [#115](https://github.com/BASIC-BIT/VRDex/issues/115) owns the S3 Terraform/runtime baseline. |


### PR DESCRIPTION
## Summary

- Add a skip-safe `Docs Deploy` GitHub Actions workflow for the future `apps/docs` Vercel project.
- Add a Docusaurus-visible `docs/deployment/docs-site.md` runbook for `docs.vrdex.net` setup.
- Cross-link the docs deploy runbook from the docs index and self-hosting/IaC ownership table.

## Verification

- `pnpm verify:docs`

## Notes

This prepares the checked-in deployment path only. It does not create the Vercel docs project, bind `docs.vrdex.net`, configure Route 53, or add `VERCEL_DOCS_PROJECT_ID`.

Refs #125