### PR TITLE
Fix docs Vercel deploy path

### DIFF
--- a/.github/workflows/docs-deploy.yml
+++ b/.github/workflows/docs-deploy.yml
@@ -81,7 +81,7 @@ jobs:
           VERCEL_TOKEN: ${{ secrets.VERCEL_TOKEN }}
           VERCEL_ORG_ID: ${{ secrets.VERCEL_ORG_ID }}
           VERCEL_PROJECT_ID: ${{ secrets.VERCEL_DOCS_PROJECT_ID }}
-        run: pnpm dlx vercel@54.4.1 pull --yes --environment=production --token "$VERCEL_TOKEN"
+        run: pnpm dlx vercel@54.4.1 pull --yes --environment=production --cwd apps/docs --token "$VERCEL_TOKEN"
 
       - name: Build Vercel docs output
         if: steps.gate.outputs.enabled == 'true'
@@ -89,7 +89,7 @@ jobs:
           VERCEL_TOKEN: ${{ secrets.VERCEL_TOKEN }}
           VERCEL_ORG_ID: ${{ secrets.VERCEL_ORG_ID }}
           VERCEL_PROJECT_ID: ${{ secrets.VERCEL_DOCS_PROJECT_ID }}
-        run: pnpm dlx vercel@54.4.1 build --prod --token "$VERCEL_TOKEN"
+        run: pnpm dlx vercel@54.4.1 build --prod --cwd apps/docs --token "$VERCEL_TOKEN"
 
       - name: Deploy Vercel docs output
         if: steps.gate.outputs.enabled == 'true'
@@ -99,7 +99,7 @@ jobs:
           VERCEL_PROJECT_ID: ${{ secrets.VERCEL_DOCS_PROJECT_ID }}
         run: |
           set -euo pipefail
-          deployment_url=$(pnpm dlx vercel@54.4.1 deploy --prebuilt --prod --token "$VERCEL_TOKEN" | tail -n 1)
+          deployment_url=$(pnpm dlx vercel@54.4.1 deploy --prebuilt --prod --cwd apps/docs --token "$VERCEL_TOKEN" | tail -n 1)
           if [ -z "$deployment_url" ]; then
             echo "Vercel docs deployment did not return a URL." >&2
             exit 1

--- a/apps/docs/vercel.json
+++ b/apps/docs/vercel.json
@@ -1,0 +1,5 @@
+{
+  "$schema": "https://openapi.vercel.sh/vercel.json",
+  "buildCommand": "pnpm build",
+  "outputDirectory": "build"
+}

--- a/docs/deployment/docs-site.md
+++ b/docs/deployment/docs-site.md
@@ -28,7 +28,9 @@ Create or import a Vercel project for docs only:
 | Output directory | `build` |
 | Production domain | `docs.vrdex.net` |
 
-Run Vercel CLI commands from the repository root once the project root directory is set to `apps/docs`; running from `apps/docs` can make Vercel resolve the app root twice. Use root-level `pnpm verify:docs` in CI before deployment, but keep the Vercel project build command relative to the docs app root.
+`apps/docs/vercel.json` records the docs-local build command and output directory. The `Docs Deploy` workflow runs Vercel CLI commands from the repository root with `--cwd apps/docs`, which keeps the deploy path reproducible even if the provider project root setting is still `.`.
+
+Use root-level `pnpm verify:docs` in CI before deployment, but keep the Vercel project build command relative to the docs app root.
 
 ## GitHub Actions Settings
 

--- a/docs/deployment/docs-site.md
+++ b/docs/deployment/docs-site.md
@@ -22,13 +22,14 @@ Create or import a Vercel project for docs only:
 | --- | --- |
 | Vercel project name | `vr-dex-docs` |
 | Repository | `BASIC-BIT/VRDex` |
-| Root directory | `apps/docs` |
+| Vercel project root directory | repository root (`.`) |
+| Docs app directory | `apps/docs`, selected by workflow `--cwd apps/docs` flags |
 | Framework preset | Docusaurus or Other |
-| Build command | `pnpm build` |
-| Output directory | `build` |
+| Build command | `pnpm build`, from `apps/docs/vercel.json` |
+| Output directory | `build`, from `apps/docs/vercel.json` |
 | Production domain | `docs.vrdex.net` |
 
-`apps/docs/vercel.json` records the docs-local build command and output directory. The `Docs Deploy` workflow runs Vercel CLI commands from the repository root with `--cwd apps/docs`, which keeps the deploy path reproducible even if the provider project root setting is still `.`.
+`apps/docs/vercel.json` records the docs-local build command and output directory. The `Docs Deploy` workflow runs Vercel CLI commands from the repository root with `--cwd apps/docs`, so the Vercel project root should stay at the repository root instead of also being set to `apps/docs`.
 
 Use root-level `pnpm verify:docs` in CI before deployment, but keep the Vercel project build command relative to the docs app root.
 


### PR DESCRIPTION
## Summary

- Add `apps/docs/vercel.json` so the docs app has a checked-in Vercel build/output config.
- Run docs Vercel pull/build/deploy commands with `--cwd apps/docs` in the docs deploy workflow.
- Update the docs-site runbook to reflect the reproducible deploy path.

## Verification

- `pnpm verify:docs`
- `pnpm dlx vercel@54.4.1 pull --yes --environment=production --cwd apps/docs`
- `pnpm dlx vercel@54.4.1 build --prod --cwd apps/docs --yes`

Refs #125