### PR TITLE
Add docs site Terraform automation

### DIFF
--- a/.github/workflows/terraform.yml
+++ b/.github/workflows/terraform.yml
@@ -34,7 +34,6 @@ on:
 
 permissions:
   contents: read
-  id-token: write
 
 concurrency:
   group: terraform-${{ github.event_name }}-${{ github.ref }}
@@ -76,6 +75,9 @@ jobs:
     name: Terraform ${{ matrix.stack.name }}
     runs-on: ubuntu-latest
     timeout-minutes: 20
+    permissions:
+      contents: read
+      id-token: write
     strategy:
       fail-fast: false
       matrix:
@@ -119,7 +121,7 @@ jobs:
             plan: "true"
             auto_apply: "true"
             manual_apply: "true"
-            requires_aws: "false"
+            requires_aws: "true"
             requires_vercel: "false"
             requires_posthog: "true"
             requires_posthog_public_key: "false"
@@ -130,7 +132,7 @@ jobs:
             plan: "true"
             auto_apply: "true"
             manual_apply: "true"
-            requires_aws: "false"
+            requires_aws: "true"
             requires_vercel: "true"
             requires_posthog: "false"
             requires_posthog_public_key: "true"
@@ -234,7 +236,7 @@ jobs:
           aws-region: ${{ env.AWS_REGION }}
 
       - name: Initialize remote backend
-        if: steps.selection.outputs.run == 'true' && steps.gate.outputs.plan_enabled == 'true'
+        if: steps.selection.outputs.run == 'true' && steps.gate.outputs.plan_enabled == 'true' && matrix.stack.backend == 'true'
         working-directory: ${{ matrix.stack.path }}
         run: terraform init -reconfigure
 

--- a/.github/workflows/terraform.yml
+++ b/.github/workflows/terraform.yml
@@ -1,0 +1,276 @@
+name: Terraform
+
+on:
+  pull_request:
+    paths:
+      - .github/workflows/terraform.yml
+      - infra/terraform/**
+  workflow_run:
+    workflows:
+      - Baseline Checks
+    types:
+      - completed
+    branches:
+      - main
+  workflow_dispatch:
+    inputs:
+      stack:
+        description: Terraform stack to run.
+        required: true
+        default: all
+        type: choice
+        options:
+          - all
+          - state-mgmt
+          - docs-site
+          - ses
+          - posthog
+          - vercel
+      apply:
+        description: Apply the selected stack after a successful plan.
+        required: true
+        default: false
+        type: boolean
+
+permissions:
+  contents: read
+  id-token: write
+
+concurrency:
+  group: terraform-${{ github.event_name }}-${{ github.ref }}
+  cancel-in-progress: false
+
+env:
+  TF_IN_AUTOMATION: "true"
+  TF_INPUT: "false"
+  AWS_REGION: us-east-1
+  AWS_TERRAFORM_ROLE_ARN: ${{ vars.AWS_TERRAFORM_ROLE_ARN || secrets.AWS_TERRAFORM_ROLE_ARN }}
+  VERCEL_API_TOKEN: ${{ secrets.VERCEL_API_TOKEN || secrets.VERCEL_TOKEN }}
+  POSTHOG_API_KEY: ${{ secrets.POSTHOG_API_KEY }}
+  TERRAFORM_POSTHOG_PUBLIC_KEY: ${{ secrets.TERRAFORM_POSTHOG_PUBLIC_KEY }}
+  TERRAFORM_SES_DOMAIN_NAME: ${{ vars.TERRAFORM_SES_DOMAIN_NAME }}
+  TERRAFORM_SES_FROM_EMAIL: ${{ vars.TERRAFORM_SES_FROM_EMAIL }}
+  TERRAFORM_ROUTE53_ZONE_ID: ${{ vars.TERRAFORM_ROUTE53_ZONE_ID }}
+
+jobs:
+  terraform-fmt:
+    name: Terraform Format
+    if: github.event_name == 'pull_request' || github.event_name == 'workflow_dispatch'
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Terraform
+        uses: hashicorp/setup-terraform@v3
+        with:
+          terraform_version: 1.10.5
+          terraform_wrapper: false
+
+      - name: Check formatting
+        run: terraform fmt -check -recursive infra/terraform
+
+  terraform-stack:
+    name: Terraform ${{ matrix.stack.name }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    strategy:
+      fail-fast: false
+      matrix:
+        stack:
+          - name: state-mgmt
+            path: infra/terraform/state-mgmt
+            backend: "false"
+            plan: "false"
+            auto_apply: "false"
+            manual_apply: "false"
+            requires_aws: "false"
+            requires_vercel: "false"
+            requires_posthog: "false"
+            requires_posthog_public_key: "false"
+            requires_ses_domain: "false"
+          - name: docs-site
+            path: infra/terraform/docs-site
+            backend: "true"
+            plan: "true"
+            auto_apply: "true"
+            manual_apply: "true"
+            requires_aws: "true"
+            requires_vercel: "true"
+            requires_posthog: "false"
+            requires_posthog_public_key: "false"
+            requires_ses_domain: "false"
+          - name: ses
+            path: infra/terraform/ses
+            backend: "true"
+            plan: "true"
+            auto_apply: "true"
+            manual_apply: "true"
+            requires_aws: "true"
+            requires_vercel: "false"
+            requires_posthog: "false"
+            requires_posthog_public_key: "false"
+            requires_ses_domain: "true"
+          - name: posthog
+            path: infra/terraform/posthog
+            backend: "true"
+            plan: "true"
+            auto_apply: "true"
+            manual_apply: "true"
+            requires_aws: "false"
+            requires_vercel: "false"
+            requires_posthog: "true"
+            requires_posthog_public_key: "false"
+            requires_ses_domain: "false"
+          - name: vercel
+            path: infra/terraform/vercel
+            backend: "true"
+            plan: "true"
+            auto_apply: "true"
+            manual_apply: "true"
+            requires_aws: "false"
+            requires_vercel: "true"
+            requires_posthog: "false"
+            requires_posthog_public_key: "true"
+            requires_ses_domain: "false"
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event_name == 'workflow_run' && github.event.workflow_run.head_sha || github.sha }}
+
+      - name: Setup Terraform
+        uses: hashicorp/setup-terraform@v3
+        with:
+          terraform_version: 1.10.5
+          terraform_wrapper: false
+
+      - name: Check stack selection
+        id: selection
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          SELECTED_STACK: ${{ github.event_name == 'workflow_dispatch' && inputs.stack || 'all' }}
+        run: |
+          set -euo pipefail
+
+          if [ "$EVENT_NAME" = "workflow_dispatch" ] && [ "$SELECTED_STACK" != "all" ] && [ "$SELECTED_STACK" != "${{ matrix.stack.name }}" ]; then
+            echo "run=false" >> "$GITHUB_OUTPUT"
+            {
+              echo "## Terraform ${{ matrix.stack.name }}"
+              echo "Skipped because workflow dispatch selected \`$SELECTED_STACK\`."
+            } >> "$GITHUB_STEP_SUMMARY"
+            exit 0
+          fi
+
+          echo "run=true" >> "$GITHUB_OUTPUT"
+
+      - name: Initialize for validation
+        if: steps.selection.outputs.run == 'true'
+        working-directory: ${{ matrix.stack.path }}
+        run: terraform init -backend=false
+
+      - name: Validate
+        if: steps.selection.outputs.run == 'true'
+        working-directory: ${{ matrix.stack.path }}
+        run: terraform validate
+
+      - name: Check plan gate
+        if: steps.selection.outputs.run == 'true'
+        id: gate
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          WORKFLOW_RUN_CONCLUSION: ${{ github.event_name == 'workflow_run' && github.event.workflow_run.conclusion || '' }}
+          APPLY_REQUESTED: ${{ github.event_name == 'workflow_dispatch' && inputs.apply || false }}
+        run: |
+          set -euo pipefail
+
+          if [ "${{ matrix.stack.plan }}" != "true" ]; then
+            echo "plan_enabled=false" >> "$GITHUB_OUTPUT"
+            echo "apply_enabled=false" >> "$GITHUB_OUTPUT"
+            {
+              echo "## Terraform ${{ matrix.stack.name }}"
+              echo "Plan skipped because this stack is validation-only in CI."
+            } >> "$GITHUB_STEP_SUMMARY"
+            exit 0
+          fi
+
+          missing=()
+          if [ "${{ matrix.stack.requires_aws }}" = "true" ] && [ -z "$AWS_TERRAFORM_ROLE_ARN" ]; then missing+=("AWS_TERRAFORM_ROLE_ARN"); fi
+          if [ "${{ matrix.stack.requires_vercel }}" = "true" ] && [ -z "$VERCEL_API_TOKEN" ]; then missing+=("VERCEL_API_TOKEN or VERCEL_TOKEN"); fi
+          if [ "${{ matrix.stack.requires_posthog }}" = "true" ] && [ -z "$POSTHOG_API_KEY" ]; then missing+=("POSTHOG_API_KEY"); fi
+          if [ "${{ matrix.stack.requires_posthog_public_key }}" = "true" ] && [ -z "$TERRAFORM_POSTHOG_PUBLIC_KEY" ]; then missing+=("TERRAFORM_POSTHOG_PUBLIC_KEY"); fi
+          if [ "${{ matrix.stack.requires_ses_domain }}" = "true" ] && [ -z "$TERRAFORM_SES_DOMAIN_NAME" ]; then missing+=("TERRAFORM_SES_DOMAIN_NAME"); fi
+
+          if [ "${#missing[@]}" -gt 0 ]; then
+            echo "plan_enabled=false" >> "$GITHUB_OUTPUT"
+            echo "apply_enabled=false" >> "$GITHUB_OUTPUT"
+            {
+              echo "## Terraform ${{ matrix.stack.name }}"
+              echo "Plan skipped because required settings are missing:"
+              printf -- '- %s\n' "${missing[@]}"
+            } >> "$GITHUB_STEP_SUMMARY"
+            exit 0
+          fi
+
+          apply_enabled=false
+          if [ "$EVENT_NAME" = "workflow_run" ] && [ "$WORKFLOW_RUN_CONCLUSION" = "success" ] && [ "${{ matrix.stack.auto_apply }}" = "true" ]; then
+            apply_enabled=true
+          fi
+          if [ "$EVENT_NAME" = "workflow_dispatch" ] && [ "$APPLY_REQUESTED" = "true" ] && [ "${{ matrix.stack.manual_apply }}" = "true" ]; then
+            apply_enabled=true
+          fi
+
+          echo "plan_enabled=true" >> "$GITHUB_OUTPUT"
+          echo "apply_enabled=$apply_enabled" >> "$GITHUB_OUTPUT"
+
+      - name: Configure AWS credentials
+        if: steps.selection.outputs.run == 'true' && steps.gate.outputs.plan_enabled == 'true' && matrix.stack.requires_aws == 'true'
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: ${{ env.AWS_TERRAFORM_ROLE_ARN }}
+          aws-region: ${{ env.AWS_REGION }}
+
+      - name: Initialize remote backend
+        if: steps.selection.outputs.run == 'true' && steps.gate.outputs.plan_enabled == 'true'
+        working-directory: ${{ matrix.stack.path }}
+        run: terraform init -reconfigure
+
+      - name: Plan
+        if: steps.selection.outputs.run == 'true' && steps.gate.outputs.plan_enabled == 'true'
+        working-directory: ${{ matrix.stack.path }}
+        env:
+          TF_VAR_posthog_public_key: ${{ env.TERRAFORM_POSTHOG_PUBLIC_KEY }}
+        run: |
+          set -euo pipefail
+
+          args=()
+          case "${{ matrix.stack.name }}" in
+            docs-site)
+              if [ -n "$TERRAFORM_ROUTE53_ZONE_ID" ]; then args+=("-var=route53_zone_id=$TERRAFORM_ROUTE53_ZONE_ID"); fi
+              ;;
+            ses)
+              args+=("-var=domain_name=$TERRAFORM_SES_DOMAIN_NAME")
+              if [ -n "$TERRAFORM_SES_FROM_EMAIL" ]; then args+=("-var=from_email=$TERRAFORM_SES_FROM_EMAIL"); fi
+              if [ -n "$TERRAFORM_ROUTE53_ZONE_ID" ]; then args+=("-var=route53_zone_id=$TERRAFORM_ROUTE53_ZONE_ID"); fi
+              ;;
+          esac
+
+          terraform plan -input=false -out=tfplan "${args[@]}"
+
+      - name: Apply
+        if: steps.selection.outputs.run == 'true' && steps.gate.outputs.apply_enabled == 'true'
+        working-directory: ${{ matrix.stack.path }}
+        run: terraform apply -input=false -auto-approve tfplan
+
+      - name: Summarize
+        if: always()
+        run: |
+          {
+            echo "## Terraform ${{ matrix.stack.name }}"
+            echo "Path: \`${{ matrix.stack.path }}\`"
+            echo "Plan enabled: \`${{ steps.gate.outputs.plan_enabled || 'false' }}\`"
+            echo "Apply enabled: \`${{ steps.gate.outputs.apply_enabled || 'false' }}\`"
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/docs/deployment/aws-baseline.md
+++ b/docs/deployment/aws-baseline.md
@@ -94,9 +94,11 @@ Terraform stacks use the S3 backend bucket `vrdex-terraform-state` in `us-east-1
 
 Current stacks:
 
+- `infra/terraform/state-mgmt`: local-state bootstrap stack for the shared S3 Terraform state bucket
 - `infra/terraform/ses`: SES domain identity, DKIM, MAIL FROM, Route 53 records, and optional IAM sender key
 - `infra/terraform/posthog`: hosted PostHog project metadata
 - `infra/terraform/vercel`: hosted Vercel PostHog client environment variables
+- `infra/terraform/docs-site`: hosted docs Vercel project/domain and Route 53 DNS
 
 Keep stack state, plans, local provider caches, and `terraform.tfvars` uncommitted.
 

--- a/docs/deployment/docs-site.md
+++ b/docs/deployment/docs-site.md
@@ -4,7 +4,7 @@
 
 Current deployment runbook for [#125](https://github.com/BASIC-BIT/VRDex/issues/125).
 
-The Docusaurus docs app exists and builds, but `https://docs.vrdex.net` is not live until the Vercel docs project, custom domain binding, GitHub secret, and Route 53 DNS record are configured.
+The Docusaurus docs app exists and builds. Provider setup is represented by `infra/terraform/docs-site`, and `https://docs.vrdex.net` is not live until that stack is imported or applied, the GitHub secret is set, and DNS propagates.
 
 ## Current State
 
@@ -12,11 +12,11 @@ The Docusaurus docs app exists and builds, but `https://docs.vrdex.net` is not l
 - Canonical markdown stays under `docs/`.
 - `pnpm verify:docs` runs `markdownlint-cli2` and `docusaurus build`.
 - `apps/docs/docusaurus.config.js` uses `url: "https://docs.vrdex.net"` and `baseUrl: "/"`.
-- `docs.vrdex.net` currently has no DNS record.
+- `infra/terraform/docs-site` owns the Vercel docs project, Vercel domain binding, and Route 53 DNS record.
 
 ## Target Hosted Shape
 
-Create or import a Vercel project for docs only:
+Create or import a Vercel project for docs only through `infra/terraform/docs-site`:
 
 | Setting | Value |
 | --- | --- |
@@ -33,6 +33,19 @@ Create or import a Vercel project for docs only:
 
 Use root-level `pnpm verify:docs` in CI before deployment, but keep the Vercel project build command relative to the docs app root.
 
+## Terraform Setup
+
+The provider setup stack lives at `infra/terraform/docs-site` and uses the shared S3 backend:
+
+- bucket: `vrdex-terraform-state`
+- key: `docs-site/terraform.tfstate`
+- region: `us-east-1`
+- locking: S3 native lockfile (`use_lockfile = true`)
+
+Before first apply, import any manually created Vercel docs project/domain resources into the stack state instead of creating duplicates. Review the stack plan before applying Route 53 changes.
+
+The Terraform CI/CD workflow plans this stack on pull requests when AWS and Vercel credentials are configured. After `Baseline Checks` succeeds on `main`, the workflow applies this stack automatically from CI. Use `workflow_dispatch` on the `Terraform` workflow for manual plan/apply operations.
+
 ## GitHub Actions Settings
 
 The `Docs Deploy` workflow runs after `Baseline Checks` succeeds on `main` and can also be run manually.
@@ -43,13 +56,13 @@ It deploys only when these repository secrets exist:
 - `VERCEL_ORG_ID`
 - `VERCEL_DOCS_PROJECT_ID`
 
-If any required setting is missing, the workflow writes a skip summary and exits successfully instead of partially deploying docs. `VERCEL_DOCS_PROJECT_ID` should point to the docs Vercel project, not the existing web app project.
+If any required setting is missing, the workflow writes a skip summary and exits successfully instead of partially deploying docs. `VERCEL_DOCS_PROJECT_ID` should point to the docs Vercel project, not the existing web app project. After Terraform import or apply, use `terraform output -raw vercel_docs_project_id` from `infra/terraform/docs-site` as the source value for this GitHub secret.
 
 ## DNS
 
-DNS for `docs.vrdex.net` should be managed in the Route 53 public hosted zone for `vrdex.net`.
+DNS for `docs.vrdex.net` is managed in the Route 53 public hosted zone for `vrdex.net` by `infra/terraform/docs-site`.
 
-After `docs.vrdex.net` is added to the Vercel docs project, copy the exact DNS record Vercel provides into Route 53. Do not commit provider-generated hosted zone IDs, project IDs, account IDs, or secret values into public docs.
+The hosted docs target is currently the Vercel `A` record value `76.76.21.21`. Do not commit secret values, local Terraform state, plans, or provider-generated private IDs into public docs.
 
 Expected validation after DNS propagation:
 
@@ -63,6 +76,9 @@ Before provider setup:
 
 - `pnpm verify:docs`
 - `pnpm verify`
+- `actionlint .github/workflows/terraform.yml`
+- `terraform fmt -check -recursive infra/terraform`
+- `terraform validate` for `infra/terraform/docs-site`
 - `Docs Deploy` workflow skips with a missing-settings summary if the docs project secret is not configured
 
 After provider setup:

--- a/docs/developers/self-hosting-and-iac.md
+++ b/docs/developers/self-hosting-and-iac.md
@@ -26,18 +26,19 @@ The BASIC BIT hosted deployment currently uses:
 - PostHog project `447783` for hosted product analytics
 - Terraform stacks under `infra/terraform/`
 - GitHub Actions for baseline checks, deployed health, CodeQL, and staging deploys
+- GitHub Actions Terraform CI/CD for provider-backed plan/apply after merge
 - Docusaurus scaffold under `apps/docs`, reading canonical markdown from `docs/`; [#125](https://github.com/BASIC-BIT/VRDex/issues/125) owns deployment to `docs.vrdex.net`
 
 ## IaC Ownership Table
 
 | Area | Current owner | Notes |
 | --- | --- | --- |
-| Terraform backend | S3 bucket `vrdex-terraform-state` | Stack-specific state keys with S3 native locking. |
+| Terraform backend | `infra/terraform/state-mgmt` | S3 bucket `vrdex-terraform-state`; stack-specific state keys with S3 native locking. |
 | SES auth email | `infra/terraform/ses` | Domain identity, DKIM, MAIL FROM, Route 53 records, and optional IAM sender key. |
 | PostHog project metadata | `infra/terraform/posthog` | Imports hosted project `447783`; sensitive project token output feeds Vercel stack locally. |
 | Hosted Vercel PostHog env vars | `infra/terraform/vercel` | Owns `NEXT_PUBLIC_POSTHOG_KEY` and `NEXT_PUBLIC_POSTHOG_HOST` for production, default preview, and configured staging custom environment IDs. |
 | Vercel project, staging environment, and E2E helper vars | manual bootstrap plus docs | Documented in `docs/deployment/vercel-preview.md`; not Terraform-owned yet. |
-| Docs Vercel project and `docs.vrdex.net` domain | planned manual bootstrap plus workflow | Runbook lives in `docs/deployment/docs-site.md`; [#125](https://github.com/BASIC-BIT/VRDex/issues/125) owns provider setup. |
+| Docs Vercel project and `docs.vrdex.net` domain | `infra/terraform/docs-site` plus workflow | Owns the docs Vercel project, Vercel domain binding, and Route 53 DNS record; runbook lives in `docs/deployment/docs-site.md`. |
 | Convex deployment keys and env vars | provider secret store plus docs | Documented in `docs/deployment/convex-environments.md` and `docs/deployment/ses-auth-email.md`. |
 | Convex custom domains | deferred manual provider setup | Runbook lives in `docs/deployment/convex-environments.md`; requires Convex Pro and dashboard-provided DNS records before Route 53 records. |
 | Profile asset storage | planned follow-up | Direction documented in `docs/deployment/aws-baseline.md`; [#115](https://github.com/BASIC-BIT/VRDex/issues/115) owns the S3 Terraform/runtime baseline. |
@@ -60,6 +61,7 @@ Self-hosting docs should distinguish required product configuration from BASIC B
 ## Reproducibility Rules
 
 - Prefer Terraform or checked-in workflows for infrastructure state when provider support is stable.
+- Prefer Terraform CI/CD for provider-backed stacks: plan on pull requests when credentials are present, apply after merge from CI, and keep manual dispatch as an operator fallback.
 - Prefer docs plus exact provider object names when provider APIs are awkward or risky for the first bootstrap.
 - Do not commit secret values, local Terraform state, local provider caches, or generated access-key secrets.
 - When a secret must be manually set, document the variable name, target provider, intended environment, and how to recreate or rotate it.

--- a/infra/terraform/README.md
+++ b/infra/terraform/README.md
@@ -23,7 +23,7 @@ Required CI settings by provider:
 
 | Setting | Type | Used by |
 | --- | --- | --- |
-| `AWS_TERRAFORM_ROLE_ARN` | repository variable or secret | `docs-site`, `ses` |
+| `AWS_TERRAFORM_ROLE_ARN` | repository variable or secret | all S3-backed stacks: `docs-site`, `ses`, `posthog`, `vercel` |
 | `VERCEL_TOKEN` or `VERCEL_API_TOKEN` | repository secret | `docs-site`, `vercel` |
 | `POSTHOG_API_KEY` | repository secret | `posthog` |
 | `TERRAFORM_POSTHOG_PUBLIC_KEY` | repository secret | `vercel` |

--- a/infra/terraform/README.md
+++ b/infra/terraform/README.md
@@ -31,7 +31,7 @@ Required CI settings by provider:
 | `TERRAFORM_SES_FROM_EMAIL` | optional repository variable | `ses` |
 | `TERRAFORM_ROUTE53_ZONE_ID` | optional repository variable | `docs-site`, `ses` |
 
-`state-mgmt/` is validation-only in CI because it intentionally uses local bootstrap state. Apply it manually when changing the shared state bucket.
+`state-mgmt/` is validation-only in CI because it intentionally uses local bootstrap state and owns the GitHub Actions AWS role used by the provider-backed stacks. Apply it manually when changing the shared state bucket or Terraform CI role, then store `terraform output -raw github_actions_terraform_role_arn` in GitHub variable `AWS_TERRAFORM_ROLE_ARN`.
 
 ## Stack Boundaries
 

--- a/infra/terraform/README.md
+++ b/infra/terraform/README.md
@@ -2,10 +2,44 @@
 
 VRDex keeps small infrastructure stacks separate so credentials, blast radius, and apply cadence stay clear.
 
+- `state-mgmt/`: local-state bootstrap stack for the shared S3 Terraform state bucket.
 - `ses/`: AWS SES sender identity and least-privilege Convex email credentials.
 - `posthog/`: hosted PostHog project metadata for product analytics.
 - `vercel/`: Vercel project environment variables for the hosted web app.
+- `docs-site/`: Vercel docs project/domain and Route 53 DNS for `docs.vrdex.net`.
 
-Each stack uses the shared S3 state bucket `vrdex-terraform-state` with a stack-specific state key and S3 native locking. Do not commit `terraform.tfvars`, local state, plans, or provider directories.
+Each non-bootstrap stack uses the shared S3 state bucket `vrdex-terraform-state` with a stack-specific state key and S3 native locking. `state-mgmt/` intentionally uses local state because it manages that bucket. Do not commit `terraform.tfvars`, local state, plans, or provider directories.
+
+## CI/CD
+
+`.github/workflows/terraform.yml` is the canonical CI/CD path for Terraform:
+
+- pull requests touching `infra/terraform/**` or the Terraform workflow run `terraform fmt`, stack init, and `terraform validate`
+- provider-backed plans run when the required repository settings are configured
+- after `Baseline Checks` succeeds on `main`, provider-backed stacks marked for auto-apply plan and apply from CI
+- `workflow_dispatch` can run one stack or all stacks, with optional apply, for manual infra operations
+
+Required CI settings by provider:
+
+| Setting | Type | Used by |
+| --- | --- | --- |
+| `AWS_TERRAFORM_ROLE_ARN` | repository variable or secret | `docs-site`, `ses` |
+| `VERCEL_TOKEN` or `VERCEL_API_TOKEN` | repository secret | `docs-site`, `vercel` |
+| `POSTHOG_API_KEY` | repository secret | `posthog` |
+| `TERRAFORM_POSTHOG_PUBLIC_KEY` | repository secret | `vercel` |
+| `TERRAFORM_SES_DOMAIN_NAME` | repository variable | `ses` |
+| `TERRAFORM_SES_FROM_EMAIL` | optional repository variable | `ses` |
+| `TERRAFORM_ROUTE53_ZONE_ID` | optional repository variable | `docs-site`, `ses` |
+
+`state-mgmt/` is validation-only in CI because it intentionally uses local bootstrap state. Apply it manually when changing the shared state bucket.
+
+## Stack Boundaries
+
+The stack count is intentional, but should stay small:
+
+- keep `state-mgmt/` separate because a stack cannot safely use the backend it creates
+- keep `vercel/` separate from `docs-site/` because `vercel/` requires the hosted PostHog client key while docs DNS should not depend on analytics secrets
+- keep `ses/` separate because it can create IAM access-key material and has a different blast radius from Vercel/PostHog metadata
+- combine future stacks only when they share provider credentials, state ownership, and apply cadence without widening secret exposure
 
 Current hosted-vs-self-hosted ownership guidance lives in `docs/developers/self-hosting-and-iac.md`. The first AWS service baseline, including SES and the planned private S3 asset-storage follow-up, lives in `docs/deployment/aws-baseline.md`.

--- a/infra/terraform/docs-site/.terraform.lock.hcl
+++ b/infra/terraform/docs-site/.terraform.lock.hcl
@@ -1,0 +1,47 @@
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
+
+provider "registry.terraform.io/hashicorp/aws" {
+  version     = "5.100.0"
+  constraints = "~> 5.0"
+  hashes = [
+    "h1:H3mU/7URhP0uCRGK8jeQRKxx2XFzEqLiOq/L2Bbiaxs=",
+    "zh:054b8dd49f0549c9a7cc27d159e45327b7b65cf404da5e5a20da154b90b8a644",
+    "zh:0b97bf8d5e03d15d83cc40b0530a1f84b459354939ba6f135a0086c20ebbe6b2",
+    "zh:1589a2266af699cbd5d80737a0fe02e54ec9cf2ca54e7e00ac51c7359056f274",
+    "zh:6330766f1d85f01ae6ea90d1b214b8b74cc8c1badc4696b165b36ddd4cc15f7b",
+    "zh:7c8c2e30d8e55291b86fcb64bdf6c25489d538688545eb48fd74ad622e5d3862",
+    "zh:99b1003bd9bd32ee323544da897148f46a527f622dc3971af63ea3e251596342",
+    "zh:9b12af85486a96aedd8d7984b0ff811a4b42e3d88dad1a3fb4c0b580d04fa425",
+    "zh:9f8b909d3ec50ade83c8062290378b1ec553edef6a447c56dadc01a99f4eaa93",
+    "zh:aaef921ff9aabaf8b1869a86d692ebd24fbd4e12c21205034bb679b9caf883a2",
+    "zh:ac882313207aba00dd5a76dbd572a0ddc818bb9cbf5c9d61b28fe30efaec951e",
+    "zh:bb64e8aff37becab373a1a0cc1080990785304141af42ed6aa3dd4913b000421",
+    "zh:dfe495f6621df5540d9c92ad40b8067376350b005c637ea6efac5dc15028add4",
+    "zh:f0ddf0eaf052766cfe09dea8200a946519f653c384ab4336e2a4a64fdd6310e9",
+    "zh:f1b7e684f4c7ae1eed272b6de7d2049bb87a0275cb04dbb7cda6636f600699c9",
+    "zh:ff461571e3f233699bf690db319dfe46aec75e58726636a0d97dd9ac6e32fb70",
+  ]
+}
+
+provider "registry.terraform.io/vercel/vercel" {
+  version     = "4.8.2"
+  constraints = ">= 4.8.0, < 5.0.0"
+  hashes = [
+    "h1:4AfiEduR1+vTSGNFJigogsLtNtxGVGJz1yBfm+lPZEs=",
+    "zh:02c745e21fd3dbd89fa6762a41339d40f499a4f49e413a01baf34315db95c26e",
+    "zh:0cd7daf928ffb6447ad9a0c92156b8fcdbb1bbd15c0dcf497ba5b27c64fb1806",
+    "zh:125d0a32363598faf2effe2e4c81603e582615b11ccf4be0e07d1fcb7be79b05",
+    "zh:190e44b3211aa286817e3d04301b18ead38378fa8a6ffa3a63785df24f5ea497",
+    "zh:37028b444ff3c08c34b2e2a1236678477be5a329983234d1c02b36333036198c",
+    "zh:3b222ce2c88e8f08b98966c210c488b763500bb4384df06016549bae19384141",
+    "zh:47bf7c0c521914bf831cdd1029558747937572d5d6523aa310d9a0072f5e37e2",
+    "zh:72df616ee40b5375bd50d7f14c0dbf0f878d19ed7ffe3ace3deca6c04f60f3fc",
+    "zh:846e374c91ebcbf55c0fe7d08465f1792e2d1839c42a428fdae1b11eb896f94d",
+    "zh:a05eb8730d248ab84581371e8f806b9dbe9691c63126c77a5f9b740df9792910",
+    "zh:ad733e43dd5f1605f6a4d850db8172895fe0860fe42b17cd3ff46ee8677a8cbe",
+    "zh:f184acbd8bf1c42b034f90593958efccd5341c21ba46139c008facb813096a8d",
+    "zh:f26e0763dbe6a6b2195c94b44696f2110f7f55433dc142839be16b9697fa5597",
+    "zh:f8287567ecf184695b2bab1974d31e1b20d78215c9408611aea6504910f719f9",
+  ]
+}

--- a/infra/terraform/docs-site/README.md
+++ b/infra/terraform/docs-site/README.md
@@ -1,0 +1,51 @@
+# Docs Site Terraform
+
+This stack manages provider-side infrastructure for the public Docusaurus docs site at `docs.vrdex.net`.
+
+It creates or imports:
+
+- Vercel project `vr-dex-docs`
+- Vercel project domain `docs.vrdex.net`
+- Route 53 `A` record `docs.vrdex.net -> 76.76.21.21`
+
+The docs build remains owned by `apps/docs/vercel.json` and `.github/workflows/docs-deploy.yml`. This stack only manages provider infrastructure and DNS.
+
+## Usage
+
+1. Copy `terraform.tfvars.example` to `terraform.tfvars` if overriding defaults.
+2. Export a Vercel token for Terraform: `VERCEL_API_TOKEN=<token>`. If reusing the GitHub secret value locally, set `VERCEL_API_TOKEN` to the same value as `VERCEL_TOKEN`.
+3. Run `terraform init`.
+4. Import existing provider objects before the first plan if they were created manually:
+
+```powershell
+terraform import vercel_project.docs <vercel_team_id>/<vercel_docs_project_id>
+terraform import vercel_project_domain.docs <vercel_team_id>/<vercel_docs_project_id>/<docs.vrdex.net>
+```
+
+- Run `terraform plan` and review Vercel and Route 53 changes.
+- Apply only after confirming the target Vercel project, Route 53 zone, and DNS record.
+- Store `terraform output -raw vercel_docs_project_id` in GitHub secret `VERCEL_DOCS_PROJECT_ID`.
+
+## State Backend
+
+Terraform state for this stack is stored in the S3 backend declared in `versions.tf`:
+
+- bucket: `vrdex-terraform-state`
+- key: `docs-site/terraform.tfstate`
+- region: `us-east-1`
+- locking: S3 native lockfile (`use_lockfile = true`)
+
+## Verification
+
+After apply and DNS propagation:
+
+```powershell
+Resolve-DnsName -Name "docs.vrdex.net"
+```
+
+Then verify:
+
+- `https://docs.vrdex.net/`
+- `https://docs.vrdex.net/docs/`
+- `https://docs.vrdex.net/docs/developers/`
+- `https://docs.vrdex.net/docs/engineering/`

--- a/infra/terraform/docs-site/main.tf
+++ b/infra/terraform/docs-site/main.tf
@@ -1,0 +1,39 @@
+data "aws_route53_zone" "docs" {
+  count = var.route53_zone_id == null ? 1 : 0
+
+  name         = var.hosted_zone_name
+  private_zone = false
+}
+
+locals {
+  route53_zone_id = var.route53_zone_id != null ? var.route53_zone_id : data.aws_route53_zone.docs[0].zone_id
+
+  tags = merge(
+    {
+      Project   = "VRDex"
+      ManagedBy = "Terraform"
+      Component = "docs-site"
+    },
+    var.tags,
+  )
+}
+
+resource "vercel_project" "docs" {
+  name            = var.vercel_docs_project_name
+  team_id         = var.vercel_team_id
+  skew_protection = "12 hours"
+}
+
+resource "vercel_project_domain" "docs" {
+  project_id = vercel_project.docs.id
+  team_id    = var.vercel_team_id
+  domain     = var.docs_domain
+}
+
+resource "aws_route53_record" "docs" {
+  zone_id = local.route53_zone_id
+  name    = var.docs_domain
+  type    = "A"
+  ttl     = var.docs_dns_record_ttl
+  records = [var.vercel_a_record_value]
+}

--- a/infra/terraform/docs-site/outputs.tf
+++ b/infra/terraform/docs-site/outputs.tf
@@ -1,0 +1,19 @@
+output "docs_domain" {
+  description = "Production domain for the public VRDex docs site."
+  value       = var.docs_domain
+}
+
+output "vercel_docs_project_id" {
+  description = "Vercel project ID for GitHub secret VERCEL_DOCS_PROJECT_ID."
+  value       = vercel_project.docs.id
+}
+
+output "route53_record_fqdn" {
+  description = "Fully qualified Route 53 record created for the docs site."
+  value       = aws_route53_record.docs.fqdn
+}
+
+output "route53_zone_id" {
+  description = "Route 53 public hosted zone ID used by this stack."
+  value       = local.route53_zone_id
+}

--- a/infra/terraform/docs-site/terraform.tfvars.example
+++ b/infra/terraform/docs-site/terraform.tfvars.example
@@ -1,0 +1,17 @@
+# BASIC BIT hosted example values. Self-hosted operators should replace these
+# with their own Vercel team/project and Route 53 zone values.
+
+aws_region                = "us-east-1"
+hosted_zone_name          = "vrdex.net"
+docs_domain               = "docs.vrdex.net"
+vercel_a_record_value     = "76.76.21.21"
+vercel_team_id            = "team_GoHh5xUc96fAIAqJoG55A71S"
+vercel_docs_project_name  = "vr-dex-docs"
+docs_dns_record_ttl       = 300
+
+# Set this when the hosted zone name is ambiguous.
+# route53_zone_id = "Z0000000000000000000"
+
+tags = {
+  Environment = "production"
+}

--- a/infra/terraform/docs-site/variables.tf
+++ b/infra/terraform/docs-site/variables.tf
@@ -1,0 +1,53 @@
+variable "aws_region" {
+  description = "AWS region for Route 53 API calls. Route 53 is global, but the provider still needs a region."
+  type        = string
+  default     = "us-east-1"
+}
+
+variable "hosted_zone_name" {
+  description = "Route 53 public hosted zone name for the docs domain."
+  type        = string
+  default     = "vrdex.net"
+}
+
+variable "route53_zone_id" {
+  description = "Route 53 public hosted zone ID. Set this when the hosted zone name is ambiguous."
+  type        = string
+  default     = null
+}
+
+variable "docs_domain" {
+  description = "Production domain for the public VRDex docs site."
+  type        = string
+  default     = "docs.vrdex.net"
+}
+
+variable "docs_dns_record_ttl" {
+  description = "TTL, in seconds, for the docs.vrdex.net Route 53 record."
+  type        = number
+  default     = 300
+}
+
+variable "vercel_a_record_value" {
+  description = "Vercel A record target for apex/subdomain custom domains."
+  type        = string
+  default     = "76.76.21.21"
+}
+
+variable "vercel_team_id" {
+  description = "Vercel team ID that owns the VRDex docs project."
+  type        = string
+  default     = "team_GoHh5xUc96fAIAqJoG55A71S"
+}
+
+variable "vercel_docs_project_name" {
+  description = "Vercel project name for the hosted docs site."
+  type        = string
+  default     = "vr-dex-docs"
+}
+
+variable "tags" {
+  description = "Additional resource tags."
+  type        = map(string)
+  default     = {}
+}

--- a/infra/terraform/docs-site/versions.tf
+++ b/infra/terraform/docs-site/versions.tf
@@ -1,0 +1,35 @@
+terraform {
+  required_version = ">= 1.10.0"
+
+  backend "s3" {
+    bucket       = "vrdex-terraform-state"
+    key          = "docs-site/terraform.tfstate"
+    region       = "us-east-1"
+    encrypt      = true
+    use_lockfile = true
+  }
+
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 5.0"
+    }
+
+    vercel = {
+      source  = "vercel/vercel"
+      version = ">= 4.8.0, < 5.0.0"
+    }
+  }
+}
+
+provider "aws" {
+  region = var.aws_region
+
+  default_tags {
+    tags = local.tags
+  }
+}
+
+provider "vercel" {
+  team = var.vercel_team_id
+}

--- a/infra/terraform/state-mgmt/.terraform.lock.hcl
+++ b/infra/terraform/state-mgmt/.terraform.lock.hcl
@@ -1,0 +1,25 @@
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
+
+provider "registry.terraform.io/hashicorp/aws" {
+  version     = "5.100.0"
+  constraints = "~> 5.0"
+  hashes = [
+    "h1:H3mU/7URhP0uCRGK8jeQRKxx2XFzEqLiOq/L2Bbiaxs=",
+    "zh:054b8dd49f0549c9a7cc27d159e45327b7b65cf404da5e5a20da154b90b8a644",
+    "zh:0b97bf8d5e03d15d83cc40b0530a1f84b459354939ba6f135a0086c20ebbe6b2",
+    "zh:1589a2266af699cbd5d80737a0fe02e54ec9cf2ca54e7e00ac51c7359056f274",
+    "zh:6330766f1d85f01ae6ea90d1b214b8b74cc8c1badc4696b165b36ddd4cc15f7b",
+    "zh:7c8c2e30d8e55291b86fcb64bdf6c25489d538688545eb48fd74ad622e5d3862",
+    "zh:99b1003bd9bd32ee323544da897148f46a527f622dc3971af63ea3e251596342",
+    "zh:9b12af85486a96aedd8d7984b0ff811a4b42e3d88dad1a3fb4c0b580d04fa425",
+    "zh:9f8b909d3ec50ade83c8062290378b1ec553edef6a447c56dadc01a99f4eaa93",
+    "zh:aaef921ff9aabaf8b1869a86d692ebd24fbd4e12c21205034bb679b9caf883a2",
+    "zh:ac882313207aba00dd5a76dbd572a0ddc818bb9cbf5c9d61b28fe30efaec951e",
+    "zh:bb64e8aff37becab373a1a0cc1080990785304141af42ed6aa3dd4913b000421",
+    "zh:dfe495f6621df5540d9c92ad40b8067376350b005c637ea6efac5dc15028add4",
+    "zh:f0ddf0eaf052766cfe09dea8200a946519f653c384ab4336e2a4a64fdd6310e9",
+    "zh:f1b7e684f4c7ae1eed272b6de7d2049bb87a0275cb04dbb7cda6636f600699c9",
+    "zh:ff461571e3f233699bf690db319dfe46aec75e58726636a0d97dd9ac6e32fb70",
+  ]
+}

--- a/infra/terraform/state-mgmt/README.md
+++ b/infra/terraform/state-mgmt/README.md
@@ -11,14 +11,17 @@ It intentionally uses local Terraform state. Do not configure this stack to use 
 - S3 default SSE-S3 encryption
 - S3 versioning
 - S3 bucket policy that denies non-TLS requests
+- GitHub Actions OIDC Terraform role `vrdex-github-terraform`
+- least-privilege inline policy for Terraform state, the `vrdex.net` Route 53 zone, hosted SES identity, and the Convex SES sender IAM user
 
 The application stacks use S3 native lockfiles through `use_lockfile = true`; no DynamoDB lock table is required.
 
 ## Usage
 
 1. Copy `terraform.tfvars.example` to `terraform.tfvars`.
-2. Run `terraform init`.
-3. If the bucket already exists, import the resources before the first plan:
+2. Set `route53_zone_id` to the hosted Route 53 public zone ID in local `terraform.tfvars`.
+3. Run `terraform init`.
+4. If the bucket already exists, import the resources before the first plan:
 
 ```powershell
 terraform import aws_s3_bucket.terraform_state vrdex-terraform-state
@@ -30,6 +33,14 @@ terraform import aws_s3_bucket_policy.terraform_state vrdex-terraform-state
 
 - Run `terraform plan` and review any drift.
 - Apply only after confirming the target bucket and AWS account.
+- Store `terraform output -raw github_actions_terraform_role_arn` in GitHub repository variable `AWS_TERRAFORM_ROLE_ARN`.
+
+If the GitHub Actions role already exists, import it before planning:
+
+```powershell
+terraform import aws_iam_role.github_actions_terraform vrdex-github-terraform
+terraform import aws_iam_role_policy.github_actions_terraform vrdex-github-terraform:vrdex-terraform-ci
+```
 
 ## State Boundary
 

--- a/infra/terraform/state-mgmt/README.md
+++ b/infra/terraform/state-mgmt/README.md
@@ -1,0 +1,36 @@
+# Terraform State Bootstrap
+
+This bootstrap stack manages the S3 bucket used by the other VRDex Terraform stacks for remote state.
+
+It intentionally uses local Terraform state. Do not configure this stack to use the S3 backend it manages.
+
+## Managed Resources
+
+- S3 bucket `vrdex-terraform-state`
+- S3 public access block
+- S3 default SSE-S3 encryption
+- S3 versioning
+- S3 bucket policy that denies non-TLS requests
+
+The application stacks use S3 native lockfiles through `use_lockfile = true`; no DynamoDB lock table is required.
+
+## Usage
+
+1. Copy `terraform.tfvars.example` to `terraform.tfvars`.
+2. Run `terraform init`.
+3. If the bucket already exists, import the resources before the first plan:
+
+```powershell
+terraform import aws_s3_bucket.terraform_state vrdex-terraform-state
+terraform import aws_s3_bucket_public_access_block.terraform_state vrdex-terraform-state
+terraform import aws_s3_bucket_server_side_encryption_configuration.terraform_state vrdex-terraform-state
+terraform import aws_s3_bucket_versioning.terraform_state vrdex-terraform-state
+terraform import aws_s3_bucket_policy.terraform_state vrdex-terraform-state
+```
+
+- Run `terraform plan` and review any drift.
+- Apply only after confirming the target bucket and AWS account.
+
+## State Boundary
+
+Do not commit local state, plans, or `terraform.tfvars`. The root `.gitignore` excludes them.

--- a/infra/terraform/state-mgmt/main.tf
+++ b/infra/terraform/state-mgmt/main.tf
@@ -1,0 +1,71 @@
+locals {
+  tags = merge(
+    {
+      Project   = "VRDex"
+      ManagedBy = "Terraform"
+      Component = "terraform-state"
+    },
+    var.tags,
+  )
+}
+
+resource "aws_s3_bucket" "terraform_state" {
+  bucket = var.state_bucket_name
+}
+
+resource "aws_s3_bucket_public_access_block" "terraform_state" {
+  bucket = aws_s3_bucket.terraform_state.id
+
+  block_public_acls       = true
+  block_public_policy     = true
+  ignore_public_acls      = true
+  restrict_public_buckets = true
+}
+
+resource "aws_s3_bucket_server_side_encryption_configuration" "terraform_state" {
+  bucket = aws_s3_bucket.terraform_state.id
+
+  rule {
+    apply_server_side_encryption_by_default {
+      sse_algorithm = "AES256"
+    }
+  }
+}
+
+resource "aws_s3_bucket_versioning" "terraform_state" {
+  bucket = aws_s3_bucket.terraform_state.id
+
+  versioning_configuration {
+    status = "Enabled"
+  }
+}
+
+data "aws_iam_policy_document" "terraform_state" {
+  statement {
+    sid    = "DenyInsecureTransport"
+    effect = "Deny"
+
+    principals {
+      type        = "*"
+      identifiers = ["*"]
+    }
+
+    actions = ["s3:*"]
+
+    resources = [
+      aws_s3_bucket.terraform_state.arn,
+      "${aws_s3_bucket.terraform_state.arn}/*",
+    ]
+
+    condition {
+      test     = "Bool"
+      variable = "aws:SecureTransport"
+      values   = ["false"]
+    }
+  }
+}
+
+resource "aws_s3_bucket_policy" "terraform_state" {
+  bucket = aws_s3_bucket.terraform_state.id
+  policy = data.aws_iam_policy_document.terraform_state.json
+}

--- a/infra/terraform/state-mgmt/main.tf
+++ b/infra/terraform/state-mgmt/main.tf
@@ -1,4 +1,6 @@
 locals {
+  state_bucket_arn = "arn:aws:s3:::${var.state_bucket_name}"
+
   tags = merge(
     {
       Project   = "VRDex"
@@ -9,8 +11,18 @@ locals {
   )
 }
 
+data "aws_caller_identity" "current" {}
+
+data "aws_iam_openid_connect_provider" "github_actions" {
+  url = "https://token.actions.githubusercontent.com"
+}
+
 resource "aws_s3_bucket" "terraform_state" {
   bucket = var.state_bucket_name
+
+  tags = {
+    ManagedBy = "manual-bootstrap"
+  }
 }
 
 resource "aws_s3_bucket_public_access_block" "terraform_state" {
@@ -26,6 +38,8 @@ resource "aws_s3_bucket_server_side_encryption_configuration" "terraform_state" 
   bucket = aws_s3_bucket.terraform_state.id
 
   rule {
+    bucket_key_enabled = true
+
     apply_server_side_encryption_by_default {
       sse_algorithm = "AES256"
     }
@@ -68,4 +82,137 @@ data "aws_iam_policy_document" "terraform_state" {
 resource "aws_s3_bucket_policy" "terraform_state" {
   bucket = aws_s3_bucket.terraform_state.id
   policy = data.aws_iam_policy_document.terraform_state.json
+}
+
+data "aws_iam_policy_document" "github_actions_terraform_assume_role" {
+  statement {
+    effect = "Allow"
+
+    principals {
+      type        = "Federated"
+      identifiers = [data.aws_iam_openid_connect_provider.github_actions.arn]
+    }
+
+    actions = ["sts:AssumeRoleWithWebIdentity"]
+
+    condition {
+      test     = "StringEquals"
+      variable = "token.actions.githubusercontent.com:aud"
+      values   = ["sts.amazonaws.com"]
+    }
+
+    condition {
+      test     = "StringLike"
+      variable = "token.actions.githubusercontent.com:sub"
+      values   = ["repo:${var.github_repository}:*"]
+    }
+  }
+}
+
+resource "aws_iam_role" "github_actions_terraform" {
+  name               = "vrdex-github-terraform"
+  assume_role_policy = data.aws_iam_policy_document.github_actions_terraform_assume_role.json
+}
+
+data "aws_iam_policy_document" "github_actions_terraform" {
+  statement {
+    sid = "TerraformStateAccess"
+
+    actions = [
+      "s3:ListBucket",
+      "s3:GetBucketLocation",
+    ]
+
+    resources = [local.state_bucket_arn]
+  }
+
+  statement {
+    sid = "TerraformStateObjectAccess"
+
+    actions = [
+      "s3:GetObject",
+      "s3:PutObject",
+      "s3:DeleteObject",
+    ]
+
+    resources = ["${local.state_bucket_arn}/*"]
+  }
+
+  statement {
+    sid = "Route53ZoneChanges"
+
+    actions = [
+      "route53:ChangeResourceRecordSets",
+      "route53:GetHostedZone",
+      "route53:ListResourceRecordSets",
+    ]
+
+    resources = ["arn:aws:route53:::hostedzone/${var.route53_zone_id}"]
+  }
+
+  statement {
+    sid = "Route53ZoneDiscovery"
+
+    actions = [
+      "route53:ListHostedZones",
+      "route53:ListHostedZonesByName",
+    ]
+
+    resources = ["*"]
+  }
+
+  statement {
+    sid = "SesDomainIdentityManagement"
+
+    actions = [
+      "ses:DeleteIdentity",
+      "ses:GetIdentityDkimAttributes",
+      "ses:GetIdentityMailFromDomainAttributes",
+      "ses:GetIdentityVerificationAttributes",
+      "ses:SetIdentityMailFromDomain",
+      "ses:VerifyDomainDkim",
+      "ses:VerifyDomainIdentity",
+    ]
+
+    resources = ["arn:aws:ses:${var.aws_region}:${data.aws_caller_identity.current.account_id}:identity/${var.ses_domain_name}"]
+  }
+
+  statement {
+    sid = "SesIdentityDiscovery"
+
+    actions = [
+      "ses:ListIdentities",
+    ]
+
+    resources = ["*"]
+  }
+
+  statement {
+    sid = "ConvexSesSenderIamManagement"
+
+    actions = [
+      "iam:CreateAccessKey",
+      "iam:CreateUser",
+      "iam:DeleteAccessKey",
+      "iam:DeleteUser",
+      "iam:DeleteUserPolicy",
+      "iam:GetUser",
+      "iam:GetUserPolicy",
+      "iam:ListAccessKeys",
+      "iam:ListGroupsForUser",
+      "iam:ListUserPolicies",
+      "iam:PutUserPolicy",
+      "iam:TagUser",
+      "iam:UntagUser",
+      "iam:UpdateAccessKey",
+    ]
+
+    resources = ["arn:aws:iam::${data.aws_caller_identity.current.account_id}:user/service/vrdex-convex-ses-sender"]
+  }
+}
+
+resource "aws_iam_role_policy" "github_actions_terraform" {
+  name   = "vrdex-terraform-ci"
+  role   = aws_iam_role.github_actions_terraform.id
+  policy = data.aws_iam_policy_document.github_actions_terraform.json
 }

--- a/infra/terraform/state-mgmt/main.tf
+++ b/infra/terraform/state-mgmt/main.tf
@@ -144,6 +144,7 @@ data "aws_iam_policy_document" "github_actions_terraform" {
     actions = [
       "route53:ChangeResourceRecordSets",
       "route53:GetHostedZone",
+      "route53:ListTagsForResource",
       "route53:ListResourceRecordSets",
     ]
 

--- a/infra/terraform/state-mgmt/outputs.tf
+++ b/infra/terraform/state-mgmt/outputs.tf
@@ -7,3 +7,8 @@ output "state_bucket_region" {
   description = "AWS region for the Terraform state bucket."
   value       = var.aws_region
 }
+
+output "github_actions_terraform_role_arn" {
+  description = "IAM role ARN for GitHub Actions Terraform plan/apply. Store this in GitHub variable AWS_TERRAFORM_ROLE_ARN."
+  value       = aws_iam_role.github_actions_terraform.arn
+}

--- a/infra/terraform/state-mgmt/outputs.tf
+++ b/infra/terraform/state-mgmt/outputs.tf
@@ -1,0 +1,9 @@
+output "state_bucket_name" {
+  description = "S3 bucket name used by VRDex Terraform stacks for remote state."
+  value       = aws_s3_bucket.terraform_state.id
+}
+
+output "state_bucket_region" {
+  description = "AWS region for the Terraform state bucket."
+  value       = var.aws_region
+}

--- a/infra/terraform/state-mgmt/terraform.tfvars.example
+++ b/infra/terraform/state-mgmt/terraform.tfvars.example
@@ -3,6 +3,9 @@
 
 aws_region        = "us-east-1"
 state_bucket_name = "vrdex-terraform-state"
+github_repository = "BASIC-BIT/VRDex"
+route53_zone_id   = "Z0000000000000000000"
+ses_domain_name   = "vrdex.net"
 
 tags = {
   Environment = "production"

--- a/infra/terraform/state-mgmt/terraform.tfvars.example
+++ b/infra/terraform/state-mgmt/terraform.tfvars.example
@@ -1,0 +1,9 @@
+# BASIC BIT hosted example values. Self-hosted operators should replace these
+# with their own state bucket name and AWS region.
+
+aws_region        = "us-east-1"
+state_bucket_name = "vrdex-terraform-state"
+
+tags = {
+  Environment = "production"
+}

--- a/infra/terraform/state-mgmt/variables.tf
+++ b/infra/terraform/state-mgmt/variables.tf
@@ -10,6 +10,23 @@ variable "state_bucket_name" {
   default     = "vrdex-terraform-state"
 }
 
+variable "github_repository" {
+  description = "GitHub repository allowed to assume the Terraform CI role, in owner/name form."
+  type        = string
+  default     = "BASIC-BIT/VRDex"
+}
+
+variable "route53_zone_id" {
+  description = "Route 53 public hosted zone ID that Terraform CI may manage."
+  type        = string
+}
+
+variable "ses_domain_name" {
+  description = "SES domain identity that Terraform CI may manage."
+  type        = string
+  default     = "vrdex.net"
+}
+
 variable "tags" {
   description = "Additional resource tags."
   type        = map(string)

--- a/infra/terraform/state-mgmt/variables.tf
+++ b/infra/terraform/state-mgmt/variables.tf
@@ -1,0 +1,17 @@
+variable "aws_region" {
+  description = "AWS region for the Terraform state bucket."
+  type        = string
+  default     = "us-east-1"
+}
+
+variable "state_bucket_name" {
+  description = "S3 bucket name used by VRDex Terraform stacks for remote state."
+  type        = string
+  default     = "vrdex-terraform-state"
+}
+
+variable "tags" {
+  description = "Additional resource tags."
+  type        = map(string)
+  default     = {}
+}

--- a/infra/terraform/state-mgmt/versions.tf
+++ b/infra/terraform/state-mgmt/versions.tf
@@ -1,0 +1,18 @@
+terraform {
+  required_version = ">= 1.10.0"
+
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 5.0"
+    }
+  }
+}
+
+provider "aws" {
+  region = var.aws_region
+
+  default_tags {
+    tags = local.tags
+  }
+}


### PR DESCRIPTION
## Summary
- Add Terraform stacks for `docs.vrdex.net` provider setup and the shared Terraform state bucket bootstrap.
- Add a Terraform GitHub Actions workflow for stack validation, credential-gated plans, post-merge apply, and manual dispatch.
- Add the AWS GitHub Actions OIDC role for Terraform CI to the bootstrap stack.
- Update deployment/IaC docs with stack boundaries, CI/CD settings, and docs-site DNS ownership.

## Terraform state and provider setup
- Existing Vercel docs project and `docs.vrdex.net` domain were imported into `infra/terraform/docs-site` remote state before this PR.
- The bootstrap stack imported the existing state bucket resources into local state.
- Applied `infra/terraform/state-mgmt` once to create only the AWS role `vrdex-github-terraform` and inline policy: `2 added, 0 changed, 0 destroyed`.
- Set GitHub repository variable `AWS_TERRAFORM_ROLE_ARN` from the Terraform output.
- Existing GitHub secrets `VERCEL_TOKEN` and `VERCEL_DOCS_PROJECT_ID` are present.
- Latest local plan for `infra/terraform/docs-site`: `1 to add, 0 to change, 0 to destroy`, only `aws_route53_record.docs` for `A docs.vrdex.net -> 76.76.21.21`.
- No docs-site `terraform apply` was run locally.

## Verification
- `actionlint .github/workflows/terraform.yml`
- `terraform fmt -check -recursive infra/terraform`
- `terraform validate` across Terraform stacks
- `terraform plan` in `infra/terraform/docs-site`
- `terraform plan -var route53_zone_id=<local value>` in `infra/terraform/state-mgmt` after bootstrap apply: no changes
- `pnpm verify`
- `pnpm verify:docs` after the OIDC role follow-up

## Rollout
After merge, the new Terraform workflow should apply eligible provider-backed stacks after `Baseline Checks` succeeds on `main`. Manual `workflow_dispatch` remains available for targeted stack operations.