### PR TITLE
Polish docs dark theme and copy

### DIFF
--- a/apps/docs/src/css/custom.css
+++ b/apps/docs/src/css/custom.css
@@ -11,21 +11,176 @@
 }
 
 [data-theme="dark"] {
-  --ifm-color-primary: #9aa4ff;
-  --ifm-color-primary-dark: #7c88ff;
-  --ifm-color-primary-darker: #6d7aff;
-  --ifm-color-primary-darkest: #4d5eff;
-  --ifm-color-primary-light: #b8c0ff;
-  --ifm-color-primary-lighter: #c7cdff;
-  --ifm-color-primary-lightest: #e4e7ff;
-  --ifm-background-color: #10111a;
+  --vrdex-dark-page-background:
+    radial-gradient(circle at 8% -8%, rgba(91, 124, 255, 0.18), transparent 28rem),
+    radial-gradient(circle at 88% 0%, rgba(139, 92, 246, 0.14), transparent 30rem),
+    linear-gradient(180deg, #0d1424 0%, #0a1020 44%, #090e1a 100%);
+  --ifm-color-primary: #aeb8ff;
+  --ifm-color-primary-dark: #8fa0ff;
+  --ifm-color-primary-darker: #7b8fff;
+  --ifm-color-primary-darkest: #6077ff;
+  --ifm-color-primary-light: #c7cdff;
+  --ifm-color-primary-lighter: #d8dcff;
+  --ifm-color-primary-lightest: #eef0ff;
+  --ifm-background-color: #0d1424;
+  --ifm-background-surface-color: rgba(20, 29, 49, 0.9);
+  --ifm-card-background-color: rgba(21, 31, 53, 0.82);
+  --ifm-color-content: #e7ecff;
+  --ifm-color-content-secondary: #aab7d6;
+  --ifm-heading-color: #f3f6ff;
+  --ifm-navbar-background-color: rgba(10, 16, 29, 0.92);
+  --ifm-navbar-link-color: #d9e3ff;
+  --ifm-navbar-link-hover-color: #c9b8ff;
+  --ifm-footer-background-color: #080d18;
+  --ifm-link-color: #b9c3ff;
+  --ifm-menu-color: #c7d2f3;
+  --ifm-menu-color-active: #f3f6ff;
+  --ifm-toc-link-color: #aab7d6;
+  --ifm-code-background: rgba(168, 189, 255, 0.13);
+  --ifm-table-border-color: rgba(184, 199, 255, 0.18);
+  --ifm-button-color: #f7f8ff;
 }
 
 .hero--primary {
-  background: radial-gradient(circle at top left, rgba(154, 164, 255, 0.28), transparent 32rem), #11131f;
+  background:
+    radial-gradient(circle at 18% 10%, rgba(146, 171, 255, 0.28), transparent 28rem),
+    radial-gradient(circle at 82% 8%, rgba(157, 108, 255, 0.24), transparent 26rem),
+    linear-gradient(135deg, #101827 0%, #101326 48%, #15112d 100%);
   color: #f7f7ff;
+  overflow: hidden;
+  position: relative;
+}
+
+.hero--primary::before {
+  background-image:
+    linear-gradient(rgba(255, 255, 255, 0.045) 1px, transparent 1px),
+    linear-gradient(90deg, rgba(255, 255, 255, 0.035) 1px, transparent 1px);
+  background-size: 44px 44px;
+  content: "";
+  inset: 0;
+  mask-image: linear-gradient(to bottom, black, transparent 75%);
+  opacity: 0.28;
+  pointer-events: none;
+  position: absolute;
+}
+
+.hero--primary .container {
+  position: relative;
+}
+
+.hero--primary .button--secondary {
+  --ifm-button-background-color: #edf2ff;
+  --ifm-button-border-color: rgba(255, 255, 255, 0.92);
+  --ifm-button-color: #0d1424;
+  box-shadow: 0 16px 36px rgba(46, 71, 141, 0.22);
+}
+
+.hero--primary .button-group {
+  gap: 0.9rem;
+}
+
+.hero--primary .button-group .button {
+  margin: 0;
+}
+
+.hero--primary .button--outline.button--secondary {
+  --ifm-button-background-color: rgba(255, 255, 255, 0.04);
+  --ifm-button-border-color: rgba(225, 232, 255, 0.78);
+  --ifm-button-color: #edf2ff;
+  backdrop-filter: blur(12px);
+}
+
+.hero--primary .button--outline.button--secondary:hover {
+  --ifm-button-background-color: rgba(185, 195, 255, 0.15);
+  --ifm-button-border-color: #c9b8ff;
+  --ifm-button-color: #ffffff;
 }
 
 .markdown h2 {
   margin-top: 2.25rem;
+}
+
+html[data-theme="dark"] {
+  background: #090e1a;
+}
+
+html[data-theme="dark"] body {
+  background: var(--vrdex-dark-page-background);
+  background-attachment: fixed;
+}
+
+html[data-theme="dark"],
+html[data-theme="dark"] body,
+html[data-theme="dark"] #__docusaurus {
+  min-height: 100%;
+}
+
+html[data-theme="dark"] #__docusaurus,
+[data-theme="dark"] .main-wrapper,
+[data-theme="dark"] .theme-doc-root,
+[data-theme="dark"] [class*="docPage"],
+[data-theme="dark"] [class*="docMainContainer"] {
+  background: transparent;
+}
+
+[data-theme="dark"] .navbar {
+  border-bottom: 1px solid rgba(185, 195, 255, 0.14);
+  backdrop-filter: blur(18px);
+  box-shadow: 0 16px 44px rgba(3, 7, 18, 0.22);
+}
+
+[data-theme="dark"] .footer,
+[data-theme="dark"] .theme-doc-sidebar-container {
+  border-color: rgba(185, 195, 255, 0.12);
+}
+
+[data-theme="dark"] .footer--dark {
+  background: linear-gradient(180deg, rgba(12, 19, 34, 0.95), #080d18);
+  border-top: 1px solid rgba(185, 195, 255, 0.14);
+}
+
+[data-theme="dark"] .theme-doc-markdown,
+[data-theme="dark"] .theme-doc-toc-desktop,
+[data-theme="dark"] .table-of-contents,
+[data-theme="dark"] .breadcrumbs,
+[data-theme="dark"] .pagination-nav__label,
+[data-theme="dark"] .pagination-nav__sublabel {
+  color: var(--ifm-color-content);
+}
+
+[data-theme="dark"] .theme-doc-markdown a:not(.button),
+[data-theme="dark"] .table-of-contents__link--active,
+[data-theme="dark"] .menu__link--active {
+  color: #c9b8ff;
+}
+
+[data-theme="dark"] .pagination-nav__link,
+[data-theme="dark"] .card,
+[data-theme="dark"] .theme-admonition,
+[data-theme="dark"] .docs-lane {
+  background: linear-gradient(145deg, rgba(24, 36, 61, 0.9), rgba(19, 27, 48, 0.74));
+  border: 1px solid rgba(186, 201, 255, 0.14);
+  box-shadow: 0 18px 50px rgba(3, 7, 18, 0.24);
+}
+
+.docs-lanes .row {
+  gap: 1rem 0;
+}
+
+.docs-lane {
+  border-radius: 1.15rem;
+  padding: 1.35rem;
+}
+
+.docs-lane h2 {
+  font-size: 1.35rem;
+}
+
+.docs-lane p {
+  color: var(--ifm-color-content-secondary);
+}
+
+[data-theme="dark"] .docs-lane a {
+  color: #c9b8ff;
+  font-weight: 700;
 }

--- a/apps/docs/src/css/custom.css
+++ b/apps/docs/src/css/custom.css
@@ -58,6 +58,7 @@
   background-size: 44px 44px;
   content: "";
   inset: 0;
+  -webkit-mask-image: linear-gradient(to bottom, black, transparent 75%);
   mask-image: linear-gradient(to bottom, black, transparent 75%);
   opacity: 0.28;
   pointer-events: none;
@@ -87,6 +88,7 @@
   --ifm-button-background-color: rgba(255, 255, 255, 0.04);
   --ifm-button-border-color: rgba(225, 232, 255, 0.78);
   --ifm-button-color: #edf2ff;
+  -webkit-backdrop-filter: blur(12px);
   backdrop-filter: blur(12px);
 }
 
@@ -125,6 +127,7 @@ html[data-theme="dark"] #__docusaurus,
 
 [data-theme="dark"] .navbar {
   border-bottom: 1px solid rgba(185, 195, 255, 0.14);
+  -webkit-backdrop-filter: blur(18px);
   backdrop-filter: blur(18px);
   box-shadow: 0 16px 44px rgba(3, 7, 18, 0.22);
 }
@@ -156,10 +159,14 @@ html[data-theme="dark"] #__docusaurus,
 
 [data-theme="dark"] .pagination-nav__link,
 [data-theme="dark"] .card,
-[data-theme="dark"] .theme-admonition,
 [data-theme="dark"] .docs-lane {
   background: linear-gradient(145deg, rgba(24, 36, 61, 0.9), rgba(19, 27, 48, 0.74));
   border: 1px solid rgba(186, 201, 255, 0.14);
+  box-shadow: 0 18px 50px rgba(3, 7, 18, 0.24);
+}
+
+[data-theme="dark"] .theme-admonition {
+  background: linear-gradient(145deg, rgba(24, 36, 61, 0.9), rgba(19, 27, 48, 0.74));
   box-shadow: 0 18px 50px rgba(3, 7, 18, 0.24);
 }
 

--- a/apps/docs/src/pages/index.js
+++ b/apps/docs/src/pages/index.js
@@ -9,7 +9,7 @@ export default function Home() {
           <div className="container">
             <h1 className="hero__title">VRDex Docs</h1>
             <p className="hero__subtitle">
-              Public, developer, and engineering docs for a self-hostable VRChat scene identity platform.
+              Docs for VRDex: a self-hostable identity, profiles, and events platform for the VRChat scene.
             </p>
             <div className="button-group">
               <Link className="button button--secondary button--lg" to="/docs/">
@@ -21,21 +21,21 @@ export default function Home() {
             </div>
           </div>
         </section>
-        <section className="container margin-vert--lg">
+        <section className="container margin-vert--lg docs-lanes">
           <div className="row">
-            <div className="col col--4">
+            <div className="col col--4 docs-lane">
               <h2>Public</h2>
-              <p>Plain-language product docs for people, communities, trust, claims, and current user-facing behavior.</p>
+              <p>Product behavior, trust labels, claims, privacy, and opt-outs.</p>
               <Link to="/docs/public/">Public docs</Link>
             </div>
-            <div className="col col--4">
+            <div className="col col--4 docs-lane">
               <h2>Developers</h2>
-              <p>Integration and operator docs for the public API, self-hosting, deployments, and agent-facing tools.</p>
+              <p>API direction, self-hosting, deployments, and agent integration.</p>
               <Link to="/docs/developers/public-api">Public API posture</Link>
             </div>
-            <div className="col col--4">
+            <div className="col col--4 docs-lane">
               <h2>Engineering</h2>
-              <p>Architecture, planning, backend, testing, and agentic operating notes for maintainers and implementation agents.</p>
+              <p>Architecture, backend, testing, planning, and maintainer workflow notes.</p>
               <Link to="/docs/engineering/">Engineering docs</Link>
             </div>
           </div>

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,6 +1,6 @@
 # Docs
 
-This repo keeps durable markdown under `docs/` so product, developer, engineering, and agentic knowledge stays structured and discoverable.
+This repo keeps durable markdown under `docs/` so product, developer, engineering, and agent workflow knowledge stays structured and discoverable.
 
 ## Lanes
 

--- a/docs/agentic/contributor-workflow.md
+++ b/docs/agentic/contributor-workflow.md
@@ -77,7 +77,7 @@ Then read the issue-specific and area-specific docs that actually apply to the t
 - enforce the repo contract consistently without becoming tool-prescriptive
 - prefer pointing contributors to canonical docs over inventing one-off expectations in review comments
 - when rejecting or recycling work, explain which contract item is missing: readiness, docs, verification, rollout posture, or closeout quality
-- use follow-up issues for intentional gaps instead of forcing every change into one giant scope blob
+- use follow-up issues for intentional gaps instead of forcing every change into one oversized scope
 
 ## Verification expectations
 

--- a/docs/agentic/definition-of-done.md
+++ b/docs/agentic/definition-of-done.md
@@ -4,7 +4,7 @@
 
 This document is the canonical repo-level definition of done for feature work.
 
-Use it to decide whether work is actually finished, not just coded.
+Use it to decide whether work is finished, not merely coded.
 
 ## Locked decision
 

--- a/docs/agentic/definition-of-ready.md
+++ b/docs/agentic/definition-of-ready.md
@@ -4,7 +4,7 @@
 
 This document is the canonical repo-level definition of ready for feature work.
 
-Use it before starting non-trivial implementation so contributors and agents do not skip rollout, verification, or success-thinking by accident.
+Use it before starting non-trivial implementation so contributors and agents do not accidentally skip rollout, verification, or success criteria.
 
 ## Locked decision
 
@@ -32,7 +32,7 @@ Common examples:
 
 ## Lightweight path for trivial work
 
-Do not require the full ready check for small changes where extra process would be pure drag.
+Do not require the full ready check for small changes where extra process adds no value.
 
 Common examples:
 

--- a/docs/agentic/software-factory.md
+++ b/docs/agentic/software-factory.md
@@ -2,7 +2,7 @@
 
 ## Status note
 
-This is an engineering operating note, not public product documentation and not a universal contributor mandate. It captures repo-specific agent, review, and verification patterns that are already shaping how maintainers deliver VRDex.
+This engineering note captures repo-specific agent, review, and verification patterns shaping VRDex delivery. It is not public product documentation or a universal contributor mandate.
 
 Promote only proven reusable patterns into `basics-agentic-dogfooding` or global agent context. Keep speculative workflow ideas here until they have repeated value.
 
@@ -18,7 +18,7 @@ Promote only proven reusable patterns into `basics-agentic-dogfooding` or global
 ## Current recommendation
 
 - treat product design and software-factory design as parallel workstreams
-- when the agent behaves badly or asks a low-value question, finish the immediate task and then capture the process fix before moving on
+- when an agent takes a poor path or asks a low-value question, finish the immediate task and then capture the process fix before moving on
 - bias toward stronger human and agent onboarding so new sessions converge quickly on repo norms
 - prefer discoverable, cross-linked artifacts over chat-only decisions
 - avoid turning local process experiments into public product promises
@@ -33,7 +33,7 @@ Promote only proven reusable patterns into `basics-agentic-dogfooding` or global
 ### Current recommendation
 
 - optimize for compatibility with multiple agents so long as they can operate inside the repo's review and verification system
-- use the repo's review/recycle loops to catch slop and train quality without over-policing how people work locally
+- use the repo's review/recycle loops to catch slop and improve quality without over-policing how people work locally
 
 ## Global vs local context model
 

--- a/docs/backend/community-submissions.md
+++ b/docs/backend/community-submissions.md
@@ -53,9 +53,9 @@ The schema supports these owner-authored presentation fields for public pages:
 - `avatarImageUrl`
 - `bannerImageUrl`
 
-Ordinary community submissions do not set those fields in this slice. Future owner, concierge, moderation, import, or claim flows can populate them with stricter validation and audit behavior.
+Ordinary community submissions do not set those fields in this slice. Owner, concierge, moderation, import, or claim flows can populate them only with stricter validation and audit behavior.
 
-## Follow-On Boundaries
+## Implementation Boundaries
 
 - `#25` should make community-submitted and unverified labels consistent across cards and pages
 - `#26` expands attribution into a first rollback-capable moderation trail

--- a/docs/backend/event-schema.md
+++ b/docs/backend/event-schema.md
@@ -10,7 +10,7 @@ Events are the primary scheduling object. They are not modeled as appearances, s
 
 Current event fields include:
 
-- editable readable slug for `/e/<slug>` public routes
+- human-readable editable slug for `/e/<slug>` public routes
 - title and sort title
 - start time and optional end time
 - optional time zone

--- a/docs/backend/profile-access-and-claims.md
+++ b/docs/backend/profile-access-and-claims.md
@@ -2,7 +2,7 @@
 
 ## Status Note
 
-This doc captures the permission and claim-state baseline for `#12` and `#13`, extended by the first auth, ownership, field-visibility, Discord claim, and VRChat proof-code slice.
+This doc captures the permission and claim-state baseline for `#12` and `#13`, plus later auth, ownership, field-visibility, Discord claim, and VRChat proof-code slices.
 
 It intentionally does not add moderation UI, role delegation, ownership transfer, contested-claim resolution, or a hard-coded VRCLinking API integration.
 

--- a/docs/backend/profile-schema.md
+++ b/docs/backend/profile-schema.md
@@ -2,7 +2,7 @@
 
 ## Status Note
 
-This doc captures the durable profile schema foundation started in `#9` and extended through `#10`, `#11`, `#12`, `#13`, `#22`, `#23`, `#25`, `#26`, `#30`, `#31`, `#32`, `#33`, `#82`, and `#90`.
+This doc captures the durable profile schema foundation from `#9` through `#13`, plus later extensions in `#22`, `#23`, `#25`, `#26`, `#30`, `#31`, `#32`, `#33`, `#82`, and `#90`.
 
 The schema is intentionally narrow. It establishes one shared `profiles` table for people and communities plus first-slice account ownership, claim request, verification attempt, and field visibility tables without introducing normalized link tables, asset tables, or advanced moderation workflows.
 
@@ -141,7 +141,7 @@ Deploy-time migrations use `@convex-dev/migrations` and are run by `migrations:r
 - `profileClaimRequests.by_profileId_state`: profile claim review lookup
 - `profileVerificationAttempts.by_state_expiresAt`: pending proof attempt expiry scans
 
-## Follow-On Boundaries
+## Implementation Boundaries
 
 - `#10` adds canonical slugs, validation, and uniqueness rules
 - `#11` adds type-aware person/community fields and documents shared vs type-specific data

--- a/docs/backend/profile-slugs.md
+++ b/docs/backend/profile-slugs.md
@@ -45,9 +45,9 @@ Convex does not enforce unique indexes at the schema layer. Profile slug uniquen
 - query `by_slug` to reject collisions outside the current profile
 - patch `updatedAt` with the slug write
 
-## Follow-On Boundaries
+## Out of Scope
 
-- slug history and redirects are deferred
-- custom domains are deferred
-- SEO metadata is deferred
-- public pages and API routes that consume slugs are deferred
+- slug history and redirects
+- custom domains
+- SEO metadata
+- public pages and API routes that consume slugs

--- a/docs/backend/search-discovery.md
+++ b/docs/backend/search-discovery.md
@@ -2,7 +2,7 @@
 
 ## Status Note
 
-Current recommendation and first implementation for the expanded public discovery engine bundle covering `#25`, `#30`, `#31`, `#32`, `#33`, `#95`, `#96`, and `#97`.
+Current recommendation and first implementation for expanded public discovery, covering `#25`, `#30`, `#31`, `#32`, `#33`, `#95`, `#96`, and `#97`.
 
 ## Locked Decisions
 
@@ -97,7 +97,7 @@ Optional PostHog instrumentation emits:
 
 Missing PostHog configuration must not break local, preview, self-hosted, or production reads.
 
-## Follow-On Work
+## Out of Scope
 
 - choose the long-term semantic/vector provider after real query testing
 - add personalized ranking once auth, consent, and analytics history exist

--- a/docs/backend/vocabulary-model.md
+++ b/docs/backend/vocabulary-model.md
@@ -6,7 +6,7 @@ Current recommendation and first implementation for `#90`.
 
 ## Purpose
 
-VRDex needs flexible scene language without forcing everyone into one rigid taxonomy. The vocabulary model normalizes and remembers terms that appear in profiles, worlds, events, and discovery facets.
+VRDex needs flexible scene language without forcing everyone into one rigid taxonomy. The vocabulary model normalizes and stores terms that appear in profiles, worlds, events, and discovery facets.
 
 ## Scopes
 
@@ -51,7 +51,7 @@ Vocabulary terms feed:
 - weighted search document fields
 - browse chips on discovery surfaces
 - future typeahead suggestions
-- future moderation/merge workflows
+- moderation and merge workflows outside the first slice
 
 ## Non-Goals
 
@@ -60,7 +60,7 @@ Vocabulary terms feed:
 - broad ad hoc language-to-intent mappings in code
 - moderation dashboard for vocabulary abuse in the first slice
 
-## Follow-On Work
+## Out of Scope
 
 - reviewed aliases and merges
 - admin curation UI

--- a/docs/deployment/aws-baseline.md
+++ b/docs/deployment/aws-baseline.md
@@ -106,4 +106,4 @@ Keep stack state, plans, local provider caches, and `terraform.tfvars` uncommitt
 
 Self-hosted AWS usage is limited to the values this repo documents by name: SES sender identity, DNS zone, Terraform state location, and the S3 asset bucket tracked by [#115](https://github.com/BASIC-BIT/VRDex/issues/115).
 
-This baseline does not claim complete self-hosting support. Alternative S3-compatible stores are out of scope until [#115](https://github.com/BASIC-BIT/VRDex/issues/115) creates the first asset abstraction and a follow-up issue or ADR evaluates provider portability.
+This baseline does not claim complete self-hosting support. Alternative S3-compatible stores are out of scope until [#115](https://github.com/BASIC-BIT/VRDex/issues/115) creates the first asset abstraction and a follow-up issue or ADR covers provider portability.

--- a/docs/deployment/convex-environments.md
+++ b/docs/deployment/convex-environments.md
@@ -64,7 +64,7 @@ The browser-facing token stays in the web host and GitHub Actions as `VRDEX_E2E_
 
 The shared development deployment `scrupulous-corgi-247` is the current hosted E2E backend for Vercel `staging`. The `Staging Deploy` GitHub Actions workflow deploys Convex development functions with `CONVEX_DEPLOY_KEY_DEV` before deploying Vercel `staging` and running hosted data-flow health.
 
-Current recommendation: generate Convex Auth JWT keys through a non-printing command path and set them with `convex env set -- NAME VALUE`, because PEM values begin with dashes and can be parsed as CLI options if passed in the wrong position.
+Generate Convex Auth JWT keys through a non-printing command path and set them with `convex env set -- NAME VALUE`, because PEM values begin with dashes and can be parsed as CLI options if passed in the wrong position.
 
 Manual fallback if the workflow is unavailable:
 

--- a/docs/deployment/docs-site.md
+++ b/docs/deployment/docs-site.md
@@ -4,7 +4,7 @@
 
 Current deployment runbook for [#125](https://github.com/BASIC-BIT/VRDex/issues/125).
 
-The Docusaurus docs app exists and builds. Provider setup is represented by `infra/terraform/docs-site`, and `https://docs.vrdex.net` is not live until that stack is imported or applied, the GitHub secret is set, and DNS propagates.
+The Docusaurus docs app builds and deploys to `https://docs.vrdex.net`. `infra/terraform/docs-site` owns the Vercel docs project, domain binding, and Route 53 DNS record.
 
 ## Current State
 
@@ -16,7 +16,7 @@ The Docusaurus docs app exists and builds. Provider setup is represented by `inf
 
 ## Target Hosted Shape
 
-Create or import a Vercel project for docs only through `infra/terraform/docs-site`:
+Create or import the docs-only Vercel project through `infra/terraform/docs-site`:
 
 | Setting | Value |
 | --- | --- |
@@ -86,8 +86,8 @@ After provider setup:
 - `Docs Deploy` workflow succeeds on `main`
 - `https://docs.vrdex.net/` loads the Docusaurus landing page
 - `https://docs.vrdex.net/docs/` loads the canonical docs index
-- `https://docs.vrdex.net/docs/developers/` loads the developer lane
-- `https://docs.vrdex.net/docs/engineering/` loads the engineering lane
+- `https://docs.vrdex.net/docs/developers/` loads the developer docs
+- `https://docs.vrdex.net/docs/engineering/` loads the engineering docs
 
 ## Safety Rules
 

--- a/docs/deployment/docs-site.md
+++ b/docs/deployment/docs-site.md
@@ -4,7 +4,7 @@
 
 Current deployment runbook for [#125](https://github.com/BASIC-BIT/VRDex/issues/125).
 
-The Docusaurus docs app builds and deploys to `https://docs.vrdex.net`. `infra/terraform/docs-site` owns the Vercel docs project, domain binding, and Route 53 DNS record.
+The Docusaurus docs app builds and the hosted docs site has been confirmed live at `https://docs.vrdex.net`. `infra/terraform/docs-site` owns the Vercel docs project, domain binding, and Route 53 DNS record.
 
 ## Current State
 
@@ -13,6 +13,7 @@ The Docusaurus docs app builds and deploys to `https://docs.vrdex.net`. `infra/t
 - `pnpm verify:docs` runs `markdownlint-cli2` and `docusaurus build`.
 - `apps/docs/docusaurus.config.js` uses `url: "https://docs.vrdex.net"` and `baseUrl: "/"`.
 - `infra/terraform/docs-site` owns the Vercel docs project, Vercel domain binding, and Route 53 DNS record.
+- `https://docs.vrdex.net` has been verified live after Terraform stack application and DNS propagation.
 
 ## Target Hosted Shape
 

--- a/docs/deployment/vercel-preview.md
+++ b/docs/deployment/vercel-preview.md
@@ -1,6 +1,6 @@
 # Vercel preview deployment
 
-This is the first hosted deployment path for `apps/web`. It is intentionally narrow: get a live Vercel URL for every pull request and keep unsafe public states locked. Production-hardening work needs explicit follow-up issues before it belongs in this doc.
+This is the first hosted deployment path for `apps/web`. It is intentionally narrow: get a live Vercel URL for every pull request and keep unsafe public states locked. Production hardening belongs here only after an explicit follow-up issue owns it.
 
 ## Vercel project
 
@@ -17,7 +17,7 @@ Create or import one Vercel project for this repository:
 
 Run Vercel CLI commands from the repository root once the project root directory is set to `apps/web`; running from `apps/web` will make Vercel resolve the app root twice.
 
-## Repository secrets
+## Repository variables and secrets
 
 Current recommendation: keep repository Actions variables and secrets reproducible through checked-in workflows/docs first, and provider APIs or CLI scripts where practical. Secret values still belong in GitHub/Vercel/Convex secret stores, but their names, scopes, and recreation path should be documented here.
 
@@ -63,7 +63,7 @@ Production should keep `VRDEX_ENABLE_E2E_HELPERS=false` or unset, should keep `V
 
 Preview deployment protection must allow unauthenticated reads if the PR preview is meant to be reviewed outside the Vercel dashboard.
 
-## Staging Hosted E2E Environment
+## Hosted staging E2E environment
 
 Locked decision: `staging` is the shared non-production Vercel custom environment for deployed mutation-backed Playwright health checks.
 

--- a/docs/developers/README.md
+++ b/docs/developers/README.md
@@ -2,7 +2,7 @@
 
 ## Purpose
 
-Developer docs explain how external developers, self-hosted operators, and partner agents integrate with or run VRDex.
+Developer docs explain how external developers, self-hosted operators, and partner agents integrate with VRDex or run it themselves.
 
 Audience:
 
@@ -36,7 +36,7 @@ Audience:
 - [VRDex MCP read tools](./vrdex-mcp-read-tools.md)
 - [Service cross-link map](../engineering/service-map.md)
 
-Source paths:
+Files:
 
 - `docs/developers/partner-agent-skill.md`
 - `docs/developers/opencode-skill-adapter.md`
@@ -46,4 +46,4 @@ Source paths:
 - `docs/engineering/service-map.md`
 - `skills/vrdex/SKILL.md`, compatibility pointer only
 
-Deployment docs under `docs/deployment/` are currently developer/operator docs too. Move or mirror only when that improves clarity instead of creating duplicated maintenance.
+Deployment docs under `docs/deployment/` also serve developers and operators today. Move or mirror them only when that improves clarity without creating duplicated maintenance.

--- a/docs/developers/opencode-skill-adapter.md
+++ b/docs/developers/opencode-skill-adapter.md
@@ -1,4 +1,4 @@
-# OpenCode Adapter For The VRDex Partner Agent Skill
+# OpenCode adapter for the VRDex partner-agent skill
 
 ## Reference Pattern
 
@@ -10,7 +10,7 @@ When integrating with VRDex, read the VRDex partner-agent guidance first. Treat 
 
 Canonical guidance lives in [VRDex Partner Agent Skill](./partner-agent-skill.md).
 
-## Install / Reference Options
+## Reference options
 
 - Preferred: add a short local `AGENTS.md` or project instruction that links to the canonical VRDex partner-agent guidance.
 - Compatibility mode: vendor `skills/vrdex/SKILL.md` when the agent tool expects a skill file, but keep that file pointer-heavy.

--- a/docs/developers/partner-agent-skill.md
+++ b/docs/developers/partner-agent-skill.md
@@ -12,7 +12,7 @@ This is the canonical Docusaurus-visible version of the portable partner-agent s
 - [Profile schema](../backend/profile-schema.md) for profile fields, trust states, visibility, and source attribution
 - [Profile access and claims](../backend/profile-access-and-claims.md) for claim, ownership, and field-visibility rules
 - [Search discovery](../backend/search-discovery.md) for public discovery behavior
-- [Public API posture](./public-api.md) for API posture and rate-limit expectations
+- [Public API posture](./public-api.md) for API direction and rate-limit expectations
 - [VRDex MCP read tools](./vrdex-mcp-read-tools.md) for planned read-only MCP tools
 - [Seed import model](../planning/seed-import-model.md) for partner seed-import boundaries
 
@@ -45,7 +45,7 @@ This is the canonical Docusaurus-visible version of the portable partner-agent s
 4. Keep partner imports as reviewed candidate data until VRDex explicitly publishes or links them.
 5. Ask for a product decision before adding a new trust state, provider-specific sync path, or public write behavior.
 
-## Reference Options
+## How to reference this guidance
 
 - Read the Docusaurus page when working inside VRDex or when the public docs site is reachable.
 - Vendor `skills/vrdex/SKILL.md` only as a thin compatibility entry point for agent tools that expect a skill file.

--- a/docs/developers/public-api.md
+++ b/docs/developers/public-api.md
@@ -18,7 +18,7 @@ Current direction for [#39](https://github.com/BASIC-BIT/VRDex/issues/39).
 
 ## First Public Read Surface
 
-Candidate first public API endpoints remain:
+Candidate first public API endpoints:
 
 - `GET /api/v0/profiles/:slug`
 - `GET /api/v0/people/:slug`
@@ -35,7 +35,7 @@ The first public API should be read-only unless a specific write flow has an aut
 
 ## Client Classes
 
-Use client classes to avoid one blunt limit model:
+Use client classes instead of one global rate-limit model:
 
 - first-party web app: normal product traffic, protected by app/session behavior and platform controls
 - anonymous public clients: conservative unauthenticated read limits and cache-friendly responses
@@ -78,7 +78,7 @@ The first implementation issue for the public API should add:
 - task-oriented examples for profile lookup, search, event lookup, profile cards, and partner-safe seed validation
 - clear guidance to use API or MCP for structured reads instead of scraping public pages
 
-## Non-Goals For This Direction Pass
+## Non-goals for this pass
 
 - implementing the public API now
 - finalizing every endpoint

--- a/docs/developers/self-hosting-and-iac.md
+++ b/docs/developers/self-hosting-and-iac.md
@@ -1,4 +1,4 @@
-# Self-Hosting And Infrastructure As Code
+# Self-hosting and infrastructure as code
 
 ## Status
 
@@ -11,12 +11,12 @@ VRDex should be open-source, self-hostable, and reproducible from the repo. The 
 - Infrastructure and provider configuration should be represented as code or checked-in documentation whenever the platform supports it.
 - Secret values belong in provider secret stores, not in git.
 - The repo should commit expected variable names, scopes, owners, and recreation paths so hosted deployment state does not become dashboard-only tribal knowledge.
-- Manual dashboard changes are acceptable for bootstrap or emergency work, but they need a follow-up docs, script, Terraform, or workflow artifact.
+- Manual dashboard changes are acceptable for bootstrap or emergencies, but must be followed by docs, scripts, Terraform, or workflow updates.
 - Self-hosting should stay real, but it does not mean v0.5 needs one-click automation for every provider.
 
 ## Current Hosted Deployment Shape
 
-The BASIC BIT hosted deployment currently uses:
+The hosted BASIC BIT deployment uses:
 
 - `Next.js` web app in `apps/web`
 - Vercel project `vr-dex-web` for web hosting and staging deploys

--- a/docs/developers/vrdex-mcp-read-tools.md
+++ b/docs/developers/vrdex-mcp-read-tools.md
@@ -142,6 +142,6 @@ Candidate direction:
 - local MCP remains useful for self-hosted deployments and development
 - authenticated write/claim tools, if ever added, need normal VRDex auth, scoped tokens, approvals, and audit trails
 
-## Follow-On Implementation Gate
+## Implementation Gate
 
-Do not implement the standalone package until the public API/query shape can support these tools without scraping. [#78](https://github.com/BASIC-BIT/VRDex/issues/78) remains the prototype issue and should choose package name, transport, auth posture, API dependencies, test fixtures, and distribution path.
+Do not implement the standalone package until the public API/query shape supports these tools without scraping. [#78](https://github.com/BASIC-BIT/VRDex/issues/78) remains the prototype issue and should choose package name, transport, auth posture, API dependencies, test fixtures, and distribution path.

--- a/docs/engineering/README.md
+++ b/docs/engineering/README.md
@@ -22,7 +22,7 @@ Audience:
 
 ## What Does Not Belong Here
 
-- normie user docs that should be stable and concise
+- end-user docs that should be stable and concise
 - developer-facing API contracts that outside consumers should follow directly
 - private secrets or raw partner data
 

--- a/docs/engineering/service-map.md
+++ b/docs/engineering/service-map.md
@@ -2,7 +2,7 @@
 
 ## Purpose
 
-Use this page as the high-level map between VRDex services, docs, and implementation surfaces. Cross-link aggressively from service-specific pages back to this map when a reader needs to understand how one area affects another.
+Use this page as the high-level map between VRDex services, docs, and implementation surfaces. Link from service-specific pages back to this map when readers need to understand how one area affects another.
 
 ## Public Product Surfaces
 

--- a/docs/planning/README.md
+++ b/docs/planning/README.md
@@ -1,5 +1,7 @@
 # Planning Docs
 
+Planning docs capture product, architecture, roadmap, and backlog decisions before they are promoted into stable public, developer, or engineering docs.
+
 ## Core planning set
 
 - `docs/planning/research.md` - ecosystem scan and adjacent-code notes

--- a/docs/planning/agent-integration-surface.md
+++ b/docs/planning/agent-integration-surface.md
@@ -2,7 +2,7 @@
 
 ## Purpose
 
-Define how VRDex should become easy for other people's AI coding agents to understand and integrate with, without forcing every partner to reverse-engineer the website, API, or product model from scratch.
+Define how VRDex helps external AI coding agents understand and integrate with the product without reverse-engineering the website, API, or product model.
 
 Tracking issue: `#73`.
 

--- a/docs/planning/docs-strategy.md
+++ b/docs/planning/docs-strategy.md
@@ -6,11 +6,10 @@ Use documentation as a real product asset from day one, for both humans and agen
 
 ## Why Docusaurus
 
-- good for structured docs
-- works well in-repo
-- supports multiple doc sections
-- easy for humans to browse
-- easy for agents to cite and revisit
+- serves repo-root markdown through a browsable docs site
+- supports separate public, developer, and engineering sections
+- keeps docs easy for humans to browse and agents to cite
+- fits the current in-repo source-of-truth model
 
 ## Recommended split
 

--- a/docs/planning/epics.md
+++ b/docs/planning/epics.md
@@ -20,7 +20,7 @@ Goal: a real public release with stronger ownership, club operations basics, and
 
 ### v1.5
 
-Goal: immediate follow-on improvements that make the system smarter, more integrated, and more operationally useful.
+Goal: immediate follow-on improvements for stronger discovery, integrations, and operational workflows.
 
 ## v0.5 epics
 

--- a/docs/planning/product-spec.md
+++ b/docs/planning/product-spec.md
@@ -8,7 +8,9 @@ Working domain: `vrdex.net`
 
 ## Product thesis
 
-VRChat scene participants need one canonical, public, claimable profile system for both people and communities that other people can trust and reuse, with enough customization and link depth to replace ad-hoc link pages. World discovery extends that identity graph by showing where events happen, who built those spaces, and how creators can link to their work.
+VRChat scene participants need one canonical, public, claimable profile system for people and communities. VRDex should make those profiles trustworthy and reusable, with enough customization and link depth to replace ad-hoc link pages.
+
+World discovery extends that identity graph by showing where events happen, who built those spaces, and how creators can link to their work.
 
 ## Primary users
 

--- a/docs/planning/research.md
+++ b/docs/planning/research.md
@@ -43,7 +43,7 @@ Observed from `https://vrcpop.com/partners/decked-out`:
 
 Important detail: the bot appears to be distributed manually through direct Discord contact, which suggests it is powerful but not an open public directory by itself.
 
-Implication: your product should probably integrate with Decked Out instead of copying its booking flow first.
+Implication: VRDex should probably integrate with Decked Out instead of copying its booking flow first.
 
 ### VRCLinking / VRify class tools
 
@@ -55,7 +55,7 @@ Observed from `https://vrclinking.com/` and `https://buddelbubi.xyz/vrify/`:
 
 Important detail: VRCLinking markets itself around creators, groups, role sync, age verification, and API access. VRify also describes linking Discord users to VRChat accounts and exposing user/world lookups.
 
-Implication: your claim-and-verify flow is normal for this community, not weird. The real opportunity is to apply that pattern to performer identity and booking metadata.
+Implication: VRDex's claim-and-verify flow is normal for this community, not weird. The real opportunity is to apply that pattern to performer identity and booking metadata.
 
 Stronger implication: VRCLinking is not just adjacent infrastructure; it may be a key moat if it can act as a trusted identity attestation layer for profile claims, club ownership, and reduced re-verification friction.
 

--- a/docs/public/README.md
+++ b/docs/public/README.md
@@ -1,8 +1,8 @@
-# Public Docs
+# Public Product Docs
 
 ## Purpose
 
-Public docs explain the current user-facing VRDex product surface in plain language.
+Public product docs explain current user-facing VRDex behavior in plain language.
 
 Audience:
 
@@ -30,4 +30,4 @@ Audience:
 
 ## Current State
 
-Most existing docs are still planning or engineering-heavy. Move material into this lane only when it describes current behavior that a normal user or public partner should rely on.
+Most existing docs are still planning or engineering-heavy. Move material here only when it describes behavior a normal user or public partner can rely on.

--- a/docs/testing/playwright-image-diffing.md
+++ b/docs/testing/playwright-image-diffing.md
@@ -96,7 +96,7 @@ pnpm --filter web exec playwright test --grep @snapshot --update-snapshots
 `Playwright Image Diff`:
 
 1. Runs `pnpm test:e2e:snapshots` without `--update-snapshots`.
-2. Upload the Playwright report and `test-results` artifacts on success or failure.
+2. Uploads the Playwright report and `test-results` artifacts on success or failure.
 3. If the test passes, find added/modified PNG baselines in the PR diff.
 4. Post or update a single PR comment with inline images for those added/modified baselines.
 5. If no baseline PNGs changed, say that no baseline images changed instead of listing every route.
@@ -156,4 +156,4 @@ Preview screenshots are still useful before baselines exist for every route and 
 4. Added the `Playwright Image Diff` CI job.
 5. Added a `github-script` step that comments inline changed/added baseline PNGs.
 6. Kept the current preview job artifact-only.
-7. Tune `maxDiffPixelRatio` only if CI noise appears after real PR traffic.
+7. Keep `maxDiffPixelRatio` unchanged unless CI noise appears after real PR traffic.

--- a/docs/testing/playwright-visual-preview.md
+++ b/docs/testing/playwright-visual-preview.md
@@ -146,7 +146,7 @@ Each data-flow run uses a unique `VRDEX_E2E_RUN_ID` prefix and creates only `e2e
 
 The required pull-request Playwright jobs are:
 
-The `Playwright Public Preview` job:
+The required `Playwright Public Preview` job:
 
 - runs `pnpm test:e2e:visual`
 - uploads `apps/web/playwright-report`, `apps/web/test-results`, and `apps/web/playwright-artifacts`, failing if no artifact files are found
@@ -154,9 +154,9 @@ The `Playwright Public Preview` job:
 
 This blocks PRs when public route rendering or screenshot capture fails. Pixel review is still artifact-based until committed baseline snapshots and a separate diff gate are added.
 
-The `Playwright Image Diff` job runs the `@snapshot` suite against committed PNG baselines under `apps/web/e2e/__screenshots__`, uploads expected/actual/diff artifacts on failure, and comments with only the added or modified committed baseline images.
+The required `Playwright Image Diff` job runs the `@snapshot` suite against committed PNG baselines under `apps/web/e2e/__screenshots__`, uploads expected/actual/diff artifacts on failure, and comments with only the added or modified committed baseline images.
 
-The `Playwright Data Flow` job runs the `@flow` test against local Convex and the local Next dev server with `PLAYWRIGHT_RECORD_VIDEO=true`, then uploads screenshots, traces, and videos as the `playwright-data-flow` artifact and posts a PR comment with the artifact link.
+The required `Playwright Data Flow` job runs the `@flow` test against local Convex and the local Next dev server with `PLAYWRIGHT_RECORD_VIDEO=true`, then uploads screenshots, traces, and videos as the `playwright-data-flow` artifact and posts a PR comment with the artifact link.
 
 The optional `Playwright Hosted Data Flow` job runs on pull requests only when both repository settings are present:
 

--- a/docs/testing/playwright-visual-preview.md
+++ b/docs/testing/playwright-visual-preview.md
@@ -50,7 +50,13 @@ POSIX shell hosted production smoke run:
 PLAYWRIGHT_BASE_URL=https://vrdex.net PLAYWRIGHT_SKIP_WEBSERVERS=true pnpm test:e2e:hosted:smoke
 ```
 
-The local Playwright suite starts a local Convex backend and Next dev server by default. Setting `PLAYWRIGHT_BASE_URL` switches Playwright to hosted mode and disables local web servers. Local webserver runs set token-gated E2E helper defaults so `pnpm test:e2e` includes the mutation-backed `@flow` journey without additional env setup. Profile screenshots use deterministic Next-server fixtures when `VRDEX_ENABLE_PLAYWRIGHT_FIXTURES=true`, while `/server-status` still exercises the real local Convex health query. Fixture profiles are disabled when `NODE_ENV=production`.
+The local Playwright suite starts a local Convex backend and Next dev server by default.
+
+Setting `PLAYWRIGHT_BASE_URL` switches Playwright to hosted mode and disables local web servers.
+
+Local webserver runs set token-gated E2E helper defaults so `pnpm test:e2e` includes the mutation-backed `@flow` journey without additional env setup.
+
+Profile screenshots use deterministic Next-server fixtures when `VRDEX_ENABLE_PLAYWRIGHT_FIXTURES=true`. `/server-status` still exercises the real local Convex health query. Fixture profiles are disabled when `NODE_ENV=production`.
 
 ## Captured routes
 
@@ -138,7 +144,9 @@ Each data-flow run uses a unique `VRDEX_E2E_RUN_ID` prefix and creates only `e2e
 
 ## CI behavior
 
-The `Playwright Public Preview` job is required on pull requests. It:
+The required pull-request Playwright jobs are:
+
+The `Playwright Public Preview` job:
 
 - runs `pnpm test:e2e:visual`
 - uploads `apps/web/playwright-report`, `apps/web/test-results`, and `apps/web/playwright-artifacts`, failing if no artifact files are found
@@ -146,9 +154,9 @@ The `Playwright Public Preview` job is required on pull requests. It:
 
 This blocks PRs when public route rendering or screenshot capture fails. Pixel review is still artifact-based until committed baseline snapshots and a separate diff gate are added.
 
-The `Playwright Image Diff` job is also required on pull requests. It runs the `@snapshot` suite against committed PNG baselines under `apps/web/e2e/__screenshots__`, uploads expected/actual/diff artifacts on failure, and comments with only the added or modified committed baseline images.
+The `Playwright Image Diff` job runs the `@snapshot` suite against committed PNG baselines under `apps/web/e2e/__screenshots__`, uploads expected/actual/diff artifacts on failure, and comments with only the added or modified committed baseline images.
 
-The `Playwright Data Flow` job is also required on pull requests. It runs the `@flow` test against local Convex and the local Next dev server with `PLAYWRIGHT_RECORD_VIDEO=true`, then uploads screenshots, traces, and videos as the `playwright-data-flow` artifact and posts a PR comment with the artifact link.
+The `Playwright Data Flow` job runs the `@flow` test against local Convex and the local Next dev server with `PLAYWRIGHT_RECORD_VIDEO=true`, then uploads screenshots, traces, and videos as the `playwright-data-flow` artifact and posts a PR comment with the artifact link.
 
 The optional `Playwright Hosted Data Flow` job runs on pull requests only when both repository settings are present:
 


### PR DESCRIPTION
## Summary
- Improve Docusaurus dark mode with slate/blue/purple full-page backgrounds, hero/card/footer surfaces, and high-contrast docs text.
- Remove the homepage eyebrow copy and tighten homepage docs-lane cards.
- Simplify copy across public, developer, engineering, deployment, backend, testing, agentic, and planning docs.

## Verification
- pnpm verify:docs
- Desktop Playwright dark-mode checks for homepage spacing, footer coverage, developer docs contrast, and no black text samples.
- Mobile Playwright smoke checks for homepage and developer docs with no horizontal overflow.
- Screenshot evidence captured locally but not committed: vrdex-docs-dark-home-final.png and vrdex-docs-dark-developers.png.

## Risk
- CSS-only theme polish and copy-only docs edits; no app/backend behavior changes.