### PR TITLE
Fix hosted search smoke expectations

### DIFF
--- a/apps/web/e2e/public-routes.smoke.spec.ts
+++ b/apps/web/e2e/public-routes.smoke.spec.ts
@@ -18,5 +18,12 @@ for (const route of routes) {
 test("legacy discovery query redirects to search", async ({ page }) => {
   await page.goto("/discover?q=aurora");
   await expect(page).toHaveURL(/\/search\?q=aurora$/);
+
+  if (process.env.PLAYWRIGHT_BASE_URL) {
+    await expect(page.getByRole("heading", { name: /Results for aurora/i })).toBeVisible();
+    await expect(page.getByRole("button", { name: /Search VRDex/i })).toBeVisible();
+    return;
+  }
+
   await expectSearchPage(page);
 });


### PR DESCRIPTION
Hosted production smoke should not require local Playwright fixtures. This keeps the legacy discovery redirect health check while avoiding seeded search-result assertions when `PLAYWRIGHT_BASE_URL` is set.