### PR TITLE
Fix hosted auth redirect origin

### DIFF
--- a/convex/_authRedirects.ts
+++ b/convex/_authRedirects.ts
@@ -9,5 +9,17 @@ export function siteRelativeRedirectUrl(redirectTo: string, siteUrl = process.en
     throw new Error("SITE_URL must be configured before auth redirects.");
   }
 
+  let parsedBaseUrl: URL;
+
+  try {
+    parsedBaseUrl = new URL(baseUrl);
+  } catch {
+    throw new Error("SITE_URL must be an absolute http/https URL.");
+  }
+
+  if (parsedBaseUrl.protocol !== "http:" && parsedBaseUrl.protocol !== "https:") {
+    throw new Error("SITE_URL must be an absolute http/https URL.");
+  }
+
   return `${baseUrl}${redirectTo}`;
 }

--- a/convex/_authRedirects.ts
+++ b/convex/_authRedirects.ts
@@ -1,0 +1,13 @@
+export function siteRelativeRedirectUrl(redirectTo: string, siteUrl = process.env.SITE_URL) {
+  if (!redirectTo.startsWith("/") || redirectTo.startsWith("//")) {
+    throw new Error("Only relative redirects are allowed.");
+  }
+
+  const baseUrl = siteUrl?.trim().replace(/\/$/, "");
+
+  if (!baseUrl) {
+    throw new Error("SITE_URL must be configured before auth redirects.");
+  }
+
+  return `${baseUrl}${redirectTo}`;
+}

--- a/convex/_generated/api.d.ts
+++ b/convex/_generated/api.d.ts
@@ -8,6 +8,7 @@
  * @module
  */
 
+import type * as _authRedirects from "../_authRedirects.js";
 import type * as _communityAuthority from "../_communityAuthority.js";
 import type * as _discordTimestamps from "../_discordTimestamps.js";
 import type * as _eventInputs from "../_eventInputs.js";
@@ -52,6 +53,7 @@ import type {
 } from "convex/server";
 
 declare const fullApi: ApiFromModules<{
+  _authRedirects: typeof _authRedirects;
   _communityAuthority: typeof _communityAuthority;
   _discordTimestamps: typeof _discordTimestamps;
   _eventInputs: typeof _eventInputs;

--- a/convex/auth.ts
+++ b/convex/auth.ts
@@ -6,6 +6,7 @@ import { Password } from "@convex-dev/auth/providers/Password";
 import { convexAuth } from "@convex-dev/auth/server";
 
 import { internal } from "./_generated/api";
+import { siteRelativeRedirectUrl } from "./_authRedirects";
 
 function requiredEnv(name: string): string {
   const value = process.env[name]?.trim();
@@ -137,11 +138,7 @@ export const { auth, signIn, signOut, store, isAuthenticated } = convexAuth({
   ],
   callbacks: {
     async redirect({ redirectTo }) {
-      if (redirectTo.startsWith("/") && !redirectTo.startsWith("//")) {
-        return redirectTo;
-      }
-
-      throw new Error("Only relative redirects are allowed.");
+      return siteRelativeRedirectUrl(redirectTo);
     },
   },
 });

--- a/docs/deployment/convex-environments.md
+++ b/docs/deployment/convex-environments.md
@@ -51,7 +51,9 @@ Development/staging Convex env names:
 - `VRDEX_E2E_CONVEX_SECRET`: non-empty sentinel also configured in the hosted app environment
 - `VRDEX_ENABLE_E2E_AUTH_HELPERS=true`: optional, only when hosted auth/claim E2E is intentionally enabled
 - `VRDEX_ENABLE_E2E_ADAPTER_HELPERS=true`: optional, only when hosted adapter E2E is intentionally enabled
-- `SITE_URL=https://staging.vrdex.net`: required by Convex Auth email/password redirects for hosted auth E2E
+- `SITE_URL=https://staging.vrdex.net`: required by Convex Auth OAuth and email/password redirects back to the hosted web app
+- `AUTH_DISCORD_ID` and `AUTH_DISCORD_SECRET`: staging Discord OAuth application credentials; the Discord redirect URI must include `https://scrupulous-corgi-247.convex.site/api/auth/callback/discord`
+- `AUTH_GOOGLE_ID` and `AUTH_GOOGLE_SECRET`: staging Google OAuth application credentials; the Google redirect URI must include `https://scrupulous-corgi-247.convex.site/api/auth/callback/google`
 - `JWT_PRIVATE_KEY`: Convex Auth RS256 private key, generated for the shared development deployment and never printed
 - `JWKS`: Convex Auth public key set matching `JWT_PRIVATE_KEY`
 - `DISCORD_API_BASE_URL`: optional hosted adapter stub base URL, usually `https://staging.vrdex.net/api/e2e/adapters/discord`

--- a/tests/backend/auth-redirect.test.ts
+++ b/tests/backend/auth-redirect.test.ts
@@ -16,5 +16,13 @@ describe("auth redirects", () => {
 
   it("requires SITE_URL for relative redirects", () => {
     assert.throws(() => siteRelativeRedirectUrl("/account", ""), /SITE_URL/);
+    assert.throws(() => siteRelativeRedirectUrl("/account", undefined), /SITE_URL/);
+    assert.throws(() => siteRelativeRedirectUrl("/account"), /SITE_URL/);
+  });
+
+  it("requires SITE_URL to be an absolute http or https URL", () => {
+    assert.throws(() => siteRelativeRedirectUrl("/account", "ftp://staging.vrdex.net"), /SITE_URL/);
+    assert.throws(() => siteRelativeRedirectUrl("/account", "javascript:void"), /SITE_URL/);
+    assert.throws(() => siteRelativeRedirectUrl("/account", "https://"), /SITE_URL/);
   });
 });

--- a/tests/backend/auth-redirect.test.ts
+++ b/tests/backend/auth-redirect.test.ts
@@ -1,0 +1,20 @@
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+
+import { siteRelativeRedirectUrl } from "../../convex/_authRedirects";
+
+describe("auth redirects", () => {
+  it("expands relative redirects under SITE_URL", () => {
+    assert.equal(siteRelativeRedirectUrl("/account", "https://staging.vrdex.net"), "https://staging.vrdex.net/account");
+    assert.equal(siteRelativeRedirectUrl("/account", "https://staging.vrdex.net/"), "https://staging.vrdex.net/account");
+  });
+
+  it("rejects protocol-relative and absolute redirects", () => {
+    assert.throws(() => siteRelativeRedirectUrl("//evil.example", "https://staging.vrdex.net"), /Only relative redirects/);
+    assert.throws(() => siteRelativeRedirectUrl("https://evil.example", "https://staging.vrdex.net"), /Only relative redirects/);
+  });
+
+  it("requires SITE_URL for relative redirects", () => {
+    assert.throws(() => siteRelativeRedirectUrl("/account", ""), /SITE_URL/);
+  });
+});


### PR DESCRIPTION
Fixes the hosted Convex Auth OAuth callback redirect so relative app redirects land back on the configured web origin instead of the Convex site host. Documents the staging OAuth env contract.