### PR TITLE
Fix hosted lookup smoke coverage

### DIFF
--- a/apps/web/e2e/public-routes.smoke.spec.ts
+++ b/apps/web/e2e/public-routes.smoke.spec.ts
@@ -28,7 +28,18 @@ test("legacy discovery query redirects to search", async ({ page }) => {
   await expectSearchPage(page);
 });
 
-test("lookup suggestions select a public person row", async ({ page }) => {
+test("lookup route renders on hosted deployments", async ({ page }) => {
+  test.skip(!process.env.PLAYWRIGHT_BASE_URL, "Hosted-only smoke coverage.");
+
+  await page.goto("/lookup");
+  await expect(page.getByRole("heading", { name: /DJ link lookup/i })).toBeVisible();
+  await expect(page.getByLabel("DJ name")).toBeVisible();
+  await expect(page.getByRole("button", { name: "Lookup", exact: true })).toBeVisible();
+});
+
+test("lookup suggestions select a fixture public person row", async ({ page }) => {
+  test.skip(Boolean(process.env.PLAYWRIGHT_BASE_URL), "Fixture-specific lookup suggestions are local-only.");
+
   await page.goto("/lookup");
   await page.getByLabel("DJ name").fill("bas");
   await expect(page.getByRole("option", { name: /BASICBIT/i })).toBeVisible();

--- a/apps/web/e2e/public-routes.smoke.spec.ts
+++ b/apps/web/e2e/public-routes.smoke.spec.ts
@@ -3,6 +3,7 @@ import { expect, test } from "@playwright/test";
 import { capturedRoutes, expectSearchPage, prepareVisualPage, productionSmokeRoutes } from "./public-routes";
 
 const routes = process.env.PLAYWRIGHT_BASE_URL ? productionSmokeRoutes : capturedRoutes;
+const isHostedRun = Boolean(process.env.PLAYWRIGHT_BASE_URL);
 
 test.beforeEach(async ({ page }) => {
   await prepareVisualPage(page);
@@ -28,40 +29,49 @@ test("legacy discovery query redirects to search", async ({ page }) => {
   await expectSearchPage(page);
 });
 
-test("lookup route renders on hosted deployments", async ({ page }) => {
-  test.skip(!process.env.PLAYWRIGHT_BASE_URL, "Hosted-only smoke coverage.");
+test.describe("hosted lookup smoke", () => {
+  test.skip(!isHostedRun, "Hosted-only smoke coverage.");
 
-  await page.goto("/lookup");
-  await expect(page.getByRole("heading", { name: /DJ link lookup/i })).toBeVisible();
-  await expect(page.getByLabel("DJ name")).toBeVisible();
-  await expect(page.getByRole("button", { name: "Lookup", exact: true })).toBeVisible();
+  test("lookup route and suggest endpoint render", async ({ page }) => {
+    await page.goto("/lookup");
+    await expect(page.getByRole("heading", { name: /DJ link lookup/i })).toBeVisible();
+    await expect(page.getByLabel("DJ name")).toBeVisible();
+    await expect(page.getByRole("button", { name: "Lookup", exact: true })).toBeVisible();
+
+    const suggestResponse = await page.request.get("/lookup/suggest?q=a");
+    expect(suggestResponse.ok()).toBe(true);
+    const suggestBody = await suggestResponse.json();
+    expect(Array.isArray(suggestBody.results)).toBe(true);
+  });
 });
 
-test("lookup suggestions select a fixture public person row", async ({ page }) => {
-  test.skip(Boolean(process.env.PLAYWRIGHT_BASE_URL), "Fixture-specific lookup suggestions are local-only.");
+test.describe("fixture lookup smoke", () => {
+  test.skip(isHostedRun, "Fixture-specific lookup suggestions are local-only.");
 
-  await page.goto("/lookup");
-  await page.getByLabel("DJ name").fill("bas");
-  await expect(page.getByRole("option", { name: /BASICBIT/i })).toBeVisible();
-  await page.getByRole("option", { name: /BASICBIT/i }).click();
-  await expect(page).toHaveURL(/\/lookup\?q=BASICBIT$/);
-  await expect(page.getByRole("link", { name: "BASICBIT", exact: true })).toBeVisible();
-  await expect(page.getByRole("link", { name: "Website: basicbit.net", exact: true })).toBeVisible();
-  await expect(page.getByRole("link", { name: "VRCDN preview", exact: true })).toBeVisible();
-  await expect(page.locator('input[value="https://stream.vrcdn.live/live/basicbit.live.ts"]')).toHaveCount(2);
-  await expect(page.locator('input[value="rtspt://stream.vrcdn.live/live/basicbit"]')).toHaveCount(2);
-  await expect(page.locator('input[value="https://www.twitch.tv/basic_bit"]')).toHaveCount(0);
-  await expect(page.getByRole("link", { name: "Twitch: twitch.tv", exact: true })).toBeVisible();
-  await expect(page.getByText("BASIC", { exact: true })).toHaveCount(2);
-  const copyButton = page.getByRole("button", { name: "Copy" }).first();
-  const copyButtonWidth = await copyButton.evaluate((element) => element.getBoundingClientRect().width);
-  await copyButton.click();
-  const copiedButton = page.getByRole("button", { name: "Copied" }).first();
-  await expect(copiedButton).toBeVisible();
-  const copiedButtonWidth = await copiedButton.evaluate((element) => element.getBoundingClientRect().width);
-  expect(Math.abs(copiedButtonWidth - copyButtonWidth)).toBeLessThan(0.5);
-  await expect.poll(async () => await page.evaluate(() => JSON.parse(window.localStorage.getItem("vrdex.lookup.recentSearches") ?? "[]")[0])).toBe("BASICBIT");
-  await page.getByRole("button", { name: "Clear lookup" }).click();
-  await page.getByLabel("DJ name").focus();
-  await expect(page.getByRole("option", { name: /BASICBIT/i })).toBeVisible();
+  test("lookup suggestions select a public person row", async ({ page }) => {
+    await page.goto("/lookup");
+    await page.getByLabel("DJ name").fill("bas");
+    await expect(page.getByRole("option", { name: /BASICBIT/i })).toBeVisible();
+    await page.getByRole("option", { name: /BASICBIT/i }).click();
+    await expect(page).toHaveURL(/\/lookup\?q=BASICBIT$/);
+    await expect(page.getByRole("link", { name: "BASICBIT", exact: true })).toBeVisible();
+    await expect(page.getByRole("link", { name: "Website: basicbit.net", exact: true })).toBeVisible();
+    await expect(page.getByRole("link", { name: "VRCDN preview", exact: true })).toBeVisible();
+    await expect(page.locator('input[value="https://stream.vrcdn.live/live/basicbit.live.ts"]')).toHaveCount(2);
+    await expect(page.locator('input[value="rtspt://stream.vrcdn.live/live/basicbit"]')).toHaveCount(2);
+    await expect(page.locator('input[value="https://www.twitch.tv/basic_bit"]')).toHaveCount(0);
+    await expect(page.getByRole("link", { name: "Twitch: twitch.tv", exact: true })).toBeVisible();
+    await expect(page.getByText("BASIC", { exact: true })).toHaveCount(2);
+    const copyButton = page.getByRole("button", { name: "Copy" }).first();
+    const copyButtonWidth = await copyButton.evaluate((element) => element.getBoundingClientRect().width);
+    await copyButton.click();
+    const copiedButton = page.getByRole("button", { name: "Copied" }).first();
+    await expect(copiedButton).toBeVisible();
+    const copiedButtonWidth = await copiedButton.evaluate((element) => element.getBoundingClientRect().width);
+    expect(Math.abs(copiedButtonWidth - copyButtonWidth)).toBeLessThan(0.5);
+    await expect.poll(async () => await page.evaluate(() => JSON.parse(window.localStorage.getItem("vrdex.lookup.recentSearches") ?? "[]")[0])).toBe("BASICBIT");
+    await page.getByRole("button", { name: "Clear lookup" }).click();
+    await page.getByLabel("DJ name").focus();
+    await expect(page.getByRole("option", { name: /BASICBIT/i })).toBeVisible();
+  });
 });


### PR DESCRIPTION
## Summary
- Split lookup smoke coverage between hosted route rendering and local fixture-only suggestion selection.
- Keep BASICBIT suggestion assertions out of production smoke runs where fixture data is not available.

## Validation
- Hosted smoke passed against the Vercel production deployment URL.
- Local fixture lookup smoke passed against a fixture-backed local server.