### PR TITLE
Add profile asset storage baseline

### DIFF
--- a/.github/workflows/terraform.yml
+++ b/.github/workflows/terraform.yml
@@ -24,6 +24,7 @@ on:
           - state-mgmt
           - docs-site
           - web-domains
+          - profile-assets
           - ses
           - posthog
           - vercel
@@ -52,6 +53,7 @@ env:
   TERRAFORM_SES_DOMAIN_NAME: ${{ vars.TERRAFORM_SES_DOMAIN_NAME }}
   TERRAFORM_SES_FROM_EMAIL: ${{ vars.TERRAFORM_SES_FROM_EMAIL }}
   TERRAFORM_ROUTE53_ZONE_ID: ${{ vars.TERRAFORM_ROUTE53_ZONE_ID }}
+  TERRAFORM_PROFILE_ASSETS_ENABLED: ${{ vars.TERRAFORM_PROFILE_ASSETS_ENABLED }}
 
 jobs:
   terraform-fmt:
@@ -95,6 +97,7 @@ jobs:
             requires_posthog: "false"
             requires_posthog_public_key: "false"
             requires_ses_domain: "false"
+            requires_profile_assets_enabled: "false"
           - name: docs-site
             path: infra/terraform/docs-site
             backend: "true"
@@ -106,6 +109,7 @@ jobs:
             requires_posthog: "false"
             requires_posthog_public_key: "false"
             requires_ses_domain: "false"
+            requires_profile_assets_enabled: "false"
           - name: web-domains
             path: infra/terraform/web-domains
             backend: "true"
@@ -117,6 +121,19 @@ jobs:
             requires_posthog: "false"
             requires_posthog_public_key: "false"
             requires_ses_domain: "false"
+            requires_profile_assets_enabled: "false"
+          - name: profile-assets
+            path: infra/terraform/profile-assets
+            backend: "true"
+            plan: "true"
+            auto_apply: "true"
+            manual_apply: "true"
+            requires_aws: "true"
+            requires_vercel: "true"
+            requires_posthog: "false"
+            requires_posthog_public_key: "false"
+            requires_ses_domain: "false"
+            requires_profile_assets_enabled: "true"
           - name: ses
             path: infra/terraform/ses
             backend: "true"
@@ -128,6 +145,7 @@ jobs:
             requires_posthog: "false"
             requires_posthog_public_key: "false"
             requires_ses_domain: "true"
+            requires_profile_assets_enabled: "false"
           - name: posthog
             path: infra/terraform/posthog
             backend: "true"
@@ -139,6 +157,7 @@ jobs:
             requires_posthog: "true"
             requires_posthog_public_key: "false"
             requires_ses_domain: "false"
+            requires_profile_assets_enabled: "false"
           - name: vercel
             path: infra/terraform/vercel
             backend: "true"
@@ -150,6 +169,7 @@ jobs:
             requires_posthog: "false"
             requires_posthog_public_key: "true"
             requires_ses_domain: "false"
+            requires_profile_assets_enabled: "false"
           - name: restream-worker
             path: infra/terraform/restream-worker
             backend: "true"
@@ -161,6 +181,7 @@ jobs:
             requires_posthog: "false"
             requires_posthog_public_key: "false"
             requires_ses_domain: "false"
+            requires_profile_assets_enabled: "false"
 
     steps:
       - name: Checkout
@@ -229,6 +250,7 @@ jobs:
           if [ "${{ matrix.stack.requires_posthog }}" = "true" ] && [ -z "$POSTHOG_API_KEY" ]; then missing+=("POSTHOG_API_KEY"); fi
           if [ "${{ matrix.stack.requires_posthog_public_key }}" = "true" ] && [ -z "$TERRAFORM_POSTHOG_PUBLIC_KEY" ]; then missing+=("TERRAFORM_POSTHOG_PUBLIC_KEY"); fi
           if [ "${{ matrix.stack.requires_ses_domain }}" = "true" ] && [ -z "$TERRAFORM_SES_DOMAIN_NAME" ]; then missing+=("TERRAFORM_SES_DOMAIN_NAME"); fi
+          if [ "${{ matrix.stack.requires_profile_assets_enabled }}" = "true" ] && [ "$TERRAFORM_PROFILE_ASSETS_ENABLED" != "true" ]; then missing+=("TERRAFORM_PROFILE_ASSETS_ENABLED=true"); fi
 
           if [ "${#missing[@]}" -gt 0 ]; then
             echo "plan_enabled=false" >> "$GITHUB_OUTPUT"

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -28,6 +28,7 @@
   "dependencies": {
     "@aws-sdk/client-s3": "^3.1068.0",
     "@convex-dev/auth": "^0.0.92",
+    "@vercel/oidc-aws-credentials-provider": "^3.1.4",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
     "convex": "^1.32.0",

--- a/apps/web/src/lib/server/profile-asset-storage.ts
+++ b/apps/web/src/lib/server/profile-asset-storage.ts
@@ -14,12 +14,8 @@ type StoredObject = {
 
 const cachedClients = new Map<string, S3Client>();
 
-function isVercelRuntime(): boolean {
-  return process.env.VERCEL === "1" || process.env.VERCEL === "true" || Boolean(process.env.VERCEL_OIDC_TOKEN);
-}
-
 function vercelOidcRoleArn(): string | undefined {
-  const roleArn = process.env.VRDEX_PROFILE_ASSET_ROLE_ARN ?? (isVercelRuntime() ? process.env.AWS_ROLE_ARN : undefined);
+  const roleArn = process.env.VRDEX_PROFILE_ASSET_ROLE_ARN;
   const normalized = roleArn?.trim();
 
   return normalized ? normalized : undefined;

--- a/apps/web/src/lib/server/profile-asset-storage.ts
+++ b/apps/web/src/lib/server/profile-asset-storage.ts
@@ -1,4 +1,5 @@
 import { GetObjectCommand, PutObjectCommand, S3Client } from "@aws-sdk/client-s3";
+import { awsCredentialsProvider } from "@vercel/oidc-aws-credentials-provider";
 
 type StorageConfig = {
   bucket: string;
@@ -13,6 +14,17 @@ type StoredObject = {
 
 const cachedClients = new Map<string, S3Client>();
 
+function isVercelRuntime(): boolean {
+  return process.env.VERCEL === "1" || process.env.VERCEL === "true" || Boolean(process.env.VERCEL_OIDC_TOKEN);
+}
+
+function vercelOidcRoleArn(): string | undefined {
+  const roleArn = process.env.VRDEX_PROFILE_ASSET_ROLE_ARN ?? (isVercelRuntime() ? process.env.AWS_ROLE_ARN : undefined);
+  const normalized = roleArn?.trim();
+
+  return normalized ? normalized : undefined;
+}
+
 function storageConfig(): StorageConfig | null {
   const bucket = process.env.VRDEX_PROFILE_ASSET_BUCKET ?? process.env.VRDEX_ASSET_BUCKET;
   const region =
@@ -25,15 +37,20 @@ function storageConfig(): StorageConfig | null {
   return { bucket, region };
 }
 
-function s3Client(region: string): S3Client {
-  const cachedClient = cachedClients.get(region);
+function s3Client(config: StorageConfig): S3Client {
+  const roleArn = vercelOidcRoleArn();
+  const cacheKey = `${config.region}:${roleArn ?? "default"}`;
+  const cachedClient = cachedClients.get(cacheKey);
 
   if (cachedClient !== undefined) {
     return cachedClient;
   }
 
-  const client = new S3Client({ region });
-  cachedClients.set(region, client);
+  const client = new S3Client({
+    region: config.region,
+    ...(roleArn !== undefined ? { credentials: awsCredentialsProvider({ roleArn }) } : {}),
+  });
+  cachedClients.set(cacheKey, client);
 
   return client;
 }
@@ -53,7 +70,7 @@ export async function putProfileAssetObject(input: {
     throw new Error("Profile asset storage is not configured.");
   }
 
-  await s3Client(config.region).send(
+  await s3Client(config).send(
     new PutObjectCommand({
       Bucket: config.bucket,
       Key: input.storageKey,
@@ -72,7 +89,7 @@ export async function getProfileAssetObject(storageKey: string): Promise<StoredO
   }
 
   try {
-    const object = await s3Client(config.region).send(
+    const object = await s3Client(config).send(
       new GetObjectCommand({
         Bucket: config.bucket,
         Key: storageKey,

--- a/docs/README.md
+++ b/docs/README.md
@@ -18,7 +18,7 @@ This repo keeps durable markdown under `docs/` so product, developer, engineerin
 - `docs/developers/public-api.md` - public API posture, versioning, client classes, and rate-limiting direction
 - `docs/developers/vrdex-mcp-read-tools.md` - documentation-only first pass for standalone read-only VRDex MCP tools
 - `docs/engineering/service-map.md` - cross-link map for services, docs, and implementation surfaces
-- `docs/deployment/aws-baseline.md` - first-pass AWS service baseline for SES and future S3 assets
+- `docs/deployment/aws-baseline.md` - first-pass AWS service baseline for SES and private S3 profile assets
 - `docs/deployment/docs-site.md` - Docusaurus docs deployment runbook for `docs.vrdex.net`
 - `docs/developers/self-hosting-and-iac.md` - self-hosting, hosted deployment, and IaC ownership direction
 - `docs/deployment/vercel-preview.md` - initial Vercel hosted-preview setup and validation path

--- a/docs/deployment/aws-baseline.md
+++ b/docs/deployment/aws-baseline.md
@@ -13,7 +13,7 @@ The first AWS baseline covers:
 - Amazon SES for Convex Auth password and email verification messages
 - Route 53 DNS records for the SES sender domain
 - IAM credentials scoped to SES sending for Convex
-- a planned S3 private asset bucket for owner-authored profile assets, tracked by [#115](https://github.com/BASIC-BIT/VRDex/issues/115)
+- a private S3 asset bucket for owner-authored profile assets, tracked by [#115](https://github.com/BASIC-BIT/VRDex/issues/115)
 - Terraform state in S3 for checked-in infrastructure stacks
 - a validation-only hosted restream worker benchmark foundation for ECR, ECS/Fargate, task roles, logs, metrics, secret references, limits, and kill-switch concepts
 
@@ -74,9 +74,15 @@ The first asset-storage implementation uses:
 
 Do not make profile asset buckets public. Public profile pages should render through a controlled URL path that can enforce profile visibility, moderation suppression, replacement, and deletion behavior.
 
+Terraform/runtime baseline:
+
+- Terraform stack: `infra/terraform/profile-assets`
+- Terraform state key: `profile-assets/terraform.tfstate`
+- Hosted bucket name default: `vrdex-profile-assets-${account_id}`
+- Hosted runtime auth: Vercel OIDC, scoped to the `vr-dex-web` project and the allowed production/staging environments
+
 Deferred follow-on work:
 
-- [#115](https://github.com/BASIC-BIT/VRDex/issues/115) S3 bucket Terraform/runtime baseline
 - moderation or malware scanning
 - CloudFront or image optimization
 - lifecycle rules and deletion/retention policy
@@ -85,6 +91,7 @@ Runtime environment/config names:
 
 - `VRDEX_PROFILE_ASSET_BUCKET` or fallback `VRDEX_ASSET_BUCKET`
 - `VRDEX_PROFILE_ASSET_REGION`, fallback `AWS_REGION`, or fallback `AWS_DEFAULT_REGION`
+- `VRDEX_PROFILE_ASSET_ROLE_ARN` for hosted Vercel OIDC role-based auth
 - AWS runtime credentials through the hosting provider, role-based auth, or a narrow access key only if the runtime cannot use role-based auth
 - `VRDEX_ASSET_PUBLIC_BASE_URL` only after a controlled public delivery layer exists
 
@@ -98,6 +105,7 @@ Current stacks:
 - `infra/terraform/ses`: SES domain identity, DKIM, MAIL FROM, Route 53 records, and optional IAM sender key
 - `infra/terraform/posthog`: hosted PostHog project metadata
 - `infra/terraform/vercel`: hosted Vercel PostHog client environment variables
+- `infra/terraform/profile-assets`: private S3 asset bucket, Vercel OIDC IAM role, and hosted profile asset env vars
 - `infra/terraform/docs-site`: hosted docs Vercel project/domain and Route 53 DNS
 - `infra/terraform/restream-worker`: validation-only hosted worker benchmark foundation; CI validates it but does not plan or apply it
 
@@ -119,4 +127,4 @@ Fargate remains the first benchmark path. ECS on EC2 with GPU/NVENC is a measure
 
 Self-hosted AWS usage is limited to the values this repo documents by name: SES sender identity, DNS zone, Terraform state location, and the S3 asset bucket tracked by [#115](https://github.com/BASIC-BIT/VRDex/issues/115).
 
-This baseline does not claim complete self-hosting support. Alternative S3-compatible stores are out of scope until [#115](https://github.com/BASIC-BIT/VRDex/issues/115) creates the first asset abstraction and a follow-up issue or ADR covers provider portability.
+This baseline does not claim complete self-hosting support. Alternative S3-compatible stores are out of scope until a follow-up issue or ADR covers provider portability.

--- a/docs/developers/self-hosting-and-iac.md
+++ b/docs/developers/self-hosting-and-iac.md
@@ -42,7 +42,7 @@ The hosted BASIC BIT deployment uses:
 | Docs Vercel project and `docs.vrdex.net` domain | `infra/terraform/docs-site` plus workflow | Owns the docs Vercel project, Vercel domain binding, and Route 53 DNS record; runbook lives in `docs/deployment/docs-site.md`. |
 | Convex deployment keys and env vars | provider secret store plus docs | Documented in `docs/deployment/convex-environments.md` and `docs/deployment/ses-auth-email.md`. |
 | Convex custom domains | deferred manual provider setup | Runbook lives in `docs/deployment/convex-environments.md`; requires Convex Pro and dashboard-provided DNS records before Route 53 records. |
-| Profile asset storage | app runtime plus planned Terraform baseline | Runtime variable names and private S3 behavior are documented in `docs/deployment/aws-baseline.md`; [#115](https://github.com/BASIC-BIT/VRDex/issues/115) still owns fuller Terraform/lifecycle hardening. |
+| Profile asset storage | `infra/terraform/profile-assets` plus app runtime | Private S3 behavior, hosted Vercel OIDC auth, and runtime variable names are documented in `docs/deployment/aws-baseline.md`; lifecycle, deletion, CDN, and scanning remain follow-up work. |
 
 ## Self-Hosted Minimum Components
 
@@ -52,7 +52,7 @@ A self-hosted operator should expect to provide:
 - a Convex deployment or compatible backend path supported by the repo at that time
 - a domain and DNS host
 - an SES sender identity or documented transactional email substitute once supported
-- an asset object store once profile uploads are implemented by [#115](https://github.com/BASIC-BIT/VRDex/issues/115)
+- an asset object store compatible with the profile asset runtime configuration
 - OAuth provider applications for enabled login providers
 - a product analytics choice, with BASIC BIT hosted PostHog keys intentionally omitted from committed defaults
 - secret storage for provider tokens, deploy keys, OAuth secrets, and email credentials

--- a/docs/engineering/service-map.md
+++ b/docs/engineering/service-map.md
@@ -20,7 +20,7 @@ Use this page as the high-level map between VRDex services, docs, and implementa
 | Vercel | Hosted web deployments, preview deployments, staging helpers. | [Vercel preview deployment](../deployment/vercel-preview.md), [Self-hosting and IaC](../developers/self-hosting-and-iac.md) |
 | Convex | Application data, functions, auth integration, local backend verification. | [Convex bootstrap](../backend/convex-bootstrap.md), [Convex environments](../deployment/convex-environments.md) |
 | AWS SES | Auth email sender and domain email verification. | [SES auth email](../deployment/ses-auth-email.md), [AWS service baseline](../deployment/aws-baseline.md) |
-| AWS S3 | Planned private profile asset storage baseline. | [AWS service baseline](../deployment/aws-baseline.md) |
+| AWS S3 | Private profile asset storage baseline. | [AWS service baseline](../deployment/aws-baseline.md) |
 | Route 53 | DNS records for hosted domains, SES, and future provider-owned records. | [AWS service baseline](../deployment/aws-baseline.md), [Self-hosting and IaC](../developers/self-hosting-and-iac.md) |
 | PostHog | Hosted product analytics and feature-flag direction. | [Product analytics and feature flags](../agentic/product-analytics-and-feature-flags.md), [Self-hosting and IaC](../developers/self-hosting-and-iac.md) |
 | GitHub Actions | Baseline checks, CodeQL, hosted health checks, and deployment automation. | [Contributor workflow](../agentic/contributor-workflow.md), [Definition of done](../agentic/definition-of-done.md) |

--- a/docs/planning/docs-strategy.md
+++ b/docs/planning/docs-strategy.md
@@ -95,7 +95,7 @@ Any docs statement that says work is deferred, planned, future, or blocked on so
 
 Examples:
 
-- `planned S3 private asset bucket ([#115](https://github.com/BASIC-BIT/VRDex/issues/115))`
+- `private S3 profile asset bucket ([#115](https://github.com/BASIC-BIT/VRDex/issues/115))`
 - `public API route once the v0 API issue lands ([#39](https://github.com/BASIC-BIT/VRDex/issues/39))`
 
 If there is no owning artifact, either create one or rewrite the sentence so it is clearly an uncommitted candidate direction rather than a silent obligation.

--- a/docs/planning/engineering-strategy.md
+++ b/docs/planning/engineering-strategy.md
@@ -37,7 +37,7 @@ Important planning note:
 Likely adjacent service use:
 
 - AWS email capabilities for verification and transactional mail
-- AWS S3 for private profile media-kit assets, with [#115](https://github.com/BASIC-BIT/VRDex/issues/115) still owning fuller Terraform/lifecycle hardening
+- AWS S3 for private profile media-kit assets, with [#115](https://github.com/BASIC-BIT/VRDex/issues/115) owning the first Terraform/runtime baseline and later issues owning lifecycle hardening
 
 Status: locked stack direction.
 
@@ -130,7 +130,7 @@ Infra direction:
 - for secrets that must remain in provider secret stores, commit the expected variable name, environment scope, owning service, and rotation/recreation path instead of relying on dashboard-only tribal knowledge
 - treat manual dashboard changes as bootstrap or emergency operations that need a follow-up reproducibility artifact
 - use `docs/developers/self-hosting-and-iac.md` as the current hosted vs self-hosted deployment reference
-- use `docs/deployment/aws-baseline.md` as the current SES and future S3 asset-storage baseline
+- use `docs/deployment/aws-baseline.md` as the current SES and S3 asset-storage baseline
 - keep profile asset storage narrow: private S3, Block Public Access, server-side encryption, and app-generated presigned URLs before any CDN or image-processing layer
 
 ## Follow-on integration ideas

--- a/infra/terraform/README.md
+++ b/infra/terraform/README.md
@@ -6,6 +6,7 @@ VRDex keeps small infrastructure stacks separate so credentials, blast radius, a
 - `ses/`: AWS SES sender identity and least-privilege Convex email credentials.
 - `posthog/`: hosted PostHog project metadata for product analytics.
 - `vercel/`: Vercel project environment variables for the hosted web app.
+- `profile-assets/`: private S3 profile media-kit asset bucket, Vercel OIDC runtime role, and hosted web env vars for profile asset storage.
 - `docs-site/`: Vercel docs project/domain and Route 53 DNS for `docs.vrdex.net`.
 - `web-domains/`: Vercel web project-domain bindings and Route 53 DNS for `vrdex.net` and `www.vrdex.net`.
 - `restream-worker/`: validation-only hosted restream worker benchmark foundation for ECR, ECS/Fargate, logs, roles, secret references, and the disabled kill switch.
@@ -25,13 +26,14 @@ Required CI settings by provider:
 
 | Setting | Type | Used by |
 | --- | --- | --- |
-| `AWS_TERRAFORM_ROLE_ARN` | repository variable or secret | all S3-backed stacks: `docs-site`, `ses`, `posthog`, `vercel` |
-| `VERCEL_TOKEN` or `VERCEL_API_TOKEN` | repository secret | `docs-site`, `vercel` |
+| `AWS_TERRAFORM_ROLE_ARN` | repository variable or secret | all S3-backed stacks: `docs-site`, `ses`, `posthog`, `vercel`, `profile-assets` |
+| `VERCEL_TOKEN` or `VERCEL_API_TOKEN` | repository secret | `docs-site`, `vercel`, `profile-assets` |
 | `POSTHOG_API_KEY` | repository secret | `posthog` |
 | `TERRAFORM_POSTHOG_PUBLIC_KEY` | repository secret | `vercel` |
 | `TERRAFORM_SES_DOMAIN_NAME` | repository variable | `ses` |
 | `TERRAFORM_SES_FROM_EMAIL` | optional repository variable | `ses` |
 | `TERRAFORM_ROUTE53_ZONE_ID` | optional repository variable | `docs-site`, `ses` |
+| `TERRAFORM_PROFILE_ASSETS_ENABLED=true` | repository variable | `profile-assets` after `state-mgmt` has been applied with profile asset permissions |
 
 `state-mgmt/` is validation-only in CI because it intentionally uses local bootstrap state and owns the GitHub Actions AWS role used by the provider-backed stacks. Apply it manually when changing the shared state bucket or Terraform CI role, then store `terraform output -raw github_actions_terraform_role_arn` in GitHub variable `AWS_TERRAFORM_ROLE_ARN`.
 
@@ -42,6 +44,7 @@ The stack count is intentional, but should stay small:
 - keep `state-mgmt/` separate because a stack cannot safely use the backend it creates
 - keep `vercel/` separate from `docs-site/` because `vercel/` requires the hosted PostHog client key while docs DNS should not depend on analytics secrets
 - keep `ses/` separate because it can create IAM access-key material and has a different blast radius from Vercel/PostHog metadata
+- keep `profile-assets/` separate because it owns an AWS S3 bucket, AWS IAM OIDC role, and the Vercel env vars that expose that role to the web runtime
 - keep `restream-worker/` validation-only until the local `1080p60` media proof and a human-approved AWS benchmark window exist
 - combine future stacks only when they share provider credentials, state ownership, and apply cadence without widening secret exposure
 

--- a/infra/terraform/profile-assets/.terraform.lock.hcl
+++ b/infra/terraform/profile-assets/.terraform.lock.hcl
@@ -1,0 +1,68 @@
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
+
+provider "registry.terraform.io/hashicorp/aws" {
+  version     = "5.100.0"
+  constraints = "~> 5.0"
+  hashes = [
+    "h1:H3mU/7URhP0uCRGK8jeQRKxx2XFzEqLiOq/L2Bbiaxs=",
+    "zh:054b8dd49f0549c9a7cc27d159e45327b7b65cf404da5e5a20da154b90b8a644",
+    "zh:0b97bf8d5e03d15d83cc40b0530a1f84b459354939ba6f135a0086c20ebbe6b2",
+    "zh:1589a2266af699cbd5d80737a0fe02e54ec9cf2ca54e7e00ac51c7359056f274",
+    "zh:6330766f1d85f01ae6ea90d1b214b8b74cc8c1badc4696b165b36ddd4cc15f7b",
+    "zh:7c8c2e30d8e55291b86fcb64bdf6c25489d538688545eb48fd74ad622e5d3862",
+    "zh:99b1003bd9bd32ee323544da897148f46a527f622dc3971af63ea3e251596342",
+    "zh:9b12af85486a96aedd8d7984b0ff811a4b42e3d88dad1a3fb4c0b580d04fa425",
+    "zh:9f8b909d3ec50ade83c8062290378b1ec553edef6a447c56dadc01a99f4eaa93",
+    "zh:aaef921ff9aabaf8b1869a86d692ebd24fbd4e12c21205034bb679b9caf883a2",
+    "zh:ac882313207aba00dd5a76dbd572a0ddc818bb9cbf5c9d61b28fe30efaec951e",
+    "zh:bb64e8aff37becab373a1a0cc1080990785304141af42ed6aa3dd4913b000421",
+    "zh:dfe495f6621df5540d9c92ad40b8067376350b005c637ea6efac5dc15028add4",
+    "zh:f0ddf0eaf052766cfe09dea8200a946519f653c384ab4336e2a4a64fdd6310e9",
+    "zh:f1b7e684f4c7ae1eed272b6de7d2049bb87a0275cb04dbb7cda6636f600699c9",
+    "zh:ff461571e3f233699bf690db319dfe46aec75e58726636a0d97dd9ac6e32fb70",
+  ]
+}
+
+provider "registry.terraform.io/hashicorp/tls" {
+  version     = "4.3.0"
+  constraints = "~> 4.0"
+  hashes = [
+    "h1:7QWrBlzkkFAFyDl9UsfC0tdfNFquFx03miHwZcta33Q=",
+    "zh:0ab58d6f8991d436c7d2dbd89ed814709b949b07ac5a54ee53b0aec1fa772a8b",
+    "zh:60b347abcb56f45d97c56f14d895069cd15a83993f199777f571b79fea3642ee",
+    "zh:6889be32640349230de3f23856e6f04e0e9ced4a84a27d3f552fa54684448218",
+    "zh:73f8e1ecf7135033165fb14b7e8bf4d656f3ce13065ec35762ea0481975328c7",
+    "zh:94ce25ee253eca0b42cae9c856b36bca8103b6453012d1b279c3623c805f2d42",
+    "zh:96bc6de9fd67bc446fd11257872e1ffb1029a996ed1d65a3f6b43f6d408ad9ab",
+    "zh:97c609a310a51bfd504d704e036d72064a84bf0bdb36cc08cd4cc66098212b41",
+    "zh:a12c16e94533c5bd123f75032576b9dc91dd5d5ccd5f7cf331d0f2e1adc55cf8",
+    "zh:c4f014f876adf7af57188795050bda5b0029d8c7d7773031102b6c36dcf1fc21",
+    "zh:d9b0a21583aaa3df3a95394fb949a3c515ff71c2ff5a1fc4a73d364aa90bfca5",
+    "zh:da510d22f0c6d71ad19a76406f106b782448f512375787ecfabb338ed1e311a7",
+    "zh:f0e9447a9ce3a24cdaa113089e65663c836d8b9bfdb915a1c0284e0112cab5c0",
+    "zh:f569b65999264a9416862bca5cd2a6177d94ccb0424f3a4ef424428912b9cb3c",
+  ]
+}
+
+provider "registry.terraform.io/vercel/vercel" {
+  version     = "4.8.2"
+  constraints = "~> 4.0"
+  hashes = [
+    "h1:4AfiEduR1+vTSGNFJigogsLtNtxGVGJz1yBfm+lPZEs=",
+    "zh:02c745e21fd3dbd89fa6762a41339d40f499a4f49e413a01baf34315db95c26e",
+    "zh:0cd7daf928ffb6447ad9a0c92156b8fcdbb1bbd15c0dcf497ba5b27c64fb1806",
+    "zh:125d0a32363598faf2effe2e4c81603e582615b11ccf4be0e07d1fcb7be79b05",
+    "zh:190e44b3211aa286817e3d04301b18ead38378fa8a6ffa3a63785df24f5ea497",
+    "zh:37028b444ff3c08c34b2e2a1236678477be5a329983234d1c02b36333036198c",
+    "zh:3b222ce2c88e8f08b98966c210c488b763500bb4384df06016549bae19384141",
+    "zh:47bf7c0c521914bf831cdd1029558747937572d5d6523aa310d9a0072f5e37e2",
+    "zh:72df616ee40b5375bd50d7f14c0dbf0f878d19ed7ffe3ace3deca6c04f60f3fc",
+    "zh:846e374c91ebcbf55c0fe7d08465f1792e2d1839c42a428fdae1b11eb896f94d",
+    "zh:a05eb8730d248ab84581371e8f806b9dbe9691c63126c77a5f9b740df9792910",
+    "zh:ad733e43dd5f1605f6a4d850db8172895fe0860fe42b17cd3ff46ee8677a8cbe",
+    "zh:f184acbd8bf1c42b034f90593958efccd5341c21ba46139c008facb813096a8d",
+    "zh:f26e0763dbe6a6b2195c94b44696f2110f7f55433dc142839be16b9697fa5597",
+    "zh:f8287567ecf184695b2bab1974d31e1b20d78215c9408611aea6504910f719f9",
+  ]
+}

--- a/infra/terraform/profile-assets/README.md
+++ b/infra/terraform/profile-assets/README.md
@@ -1,0 +1,55 @@
+# Profile Assets Terraform
+
+This stack provisions private S3-backed profile media-kit storage and the Vercel runtime configuration needed by `apps/web`.
+
+It creates:
+
+- a private S3 bucket for profile assets under `profile-assets/`
+- S3 Block Public Access
+- S3 Object Ownership with ACLs disabled through `BucketOwnerEnforced`
+- default SSE-S3 bucket encryption
+- an S3 bucket policy that denies non-TLS requests
+- a Vercel OIDC identity provider in AWS IAM
+- a least-privilege IAM role for Vercel functions
+- Vercel environment variables for production and the hosted staging custom environment
+
+## Managed Environment Variables
+
+- `VRDEX_PROFILE_ASSET_BUCKET`
+- `VRDEX_PROFILE_ASSET_REGION`
+- `VRDEX_PROFILE_ASSET_ROLE_ARN`
+
+The role ARN is not a secret, but it is stored as a sensitive Vercel environment variable so hosted runtime configuration stays consistently masked.
+
+## Bootstrap Gate
+
+Provider-backed CI plan/apply for this stack is gated by repository variable `TERRAFORM_PROFILE_ASSETS_ENABLED=true`.
+
+Before enabling that gate, apply `infra/terraform/state-mgmt` so the GitHub Actions Terraform role can manage this stack's S3, IAM, and Vercel OIDC resources.
+
+## Usage
+
+1. Apply the updated `infra/terraform/state-mgmt` bootstrap stack from a trusted local operator machine.
+2. Set GitHub repository variable `TERRAFORM_PROFILE_ASSETS_ENABLED=true`.
+3. Run the Terraform workflow for stack `profile-assets` with `apply=true`, or let the next successful `main` baseline apply it.
+4. Redeploy the Vercel production and staging environments so functions receive the new environment variables.
+5. Probe `/api/v0/profile-assets/upload-intents/probe`; a configured environment should no longer return `501`.
+
+## State Backend
+
+Terraform state for this stack is stored in the S3 backend declared in `versions.tf`:
+
+- bucket: `vrdex-terraform-state`
+- key: `profile-assets/terraform.tfstate`
+- region: `us-east-1`
+- locking: S3 native lockfile (`use_lockfile = true`)
+
+## Import Notes
+
+If the Vercel OIDC provider or runtime role already exists in AWS, import it before planning rather than creating duplicates.
+
+If any managed Vercel variable already exists, import it before applying. The Vercel provider import ID is:
+
+```text
+<team_id>/<project_id>/<environment_variable_id>
+```

--- a/infra/terraform/profile-assets/main.tf
+++ b/infra/terraform/profile-assets/main.tf
@@ -1,0 +1,195 @@
+data "aws_caller_identity" "current" {}
+
+data "vercel_project" "web" {
+  name    = var.vercel_project_name
+  team_id = var.vercel_team_id
+}
+
+locals {
+  asset_bucket_name = var.asset_bucket_name != null ? var.asset_bucket_name : "vrdex-profile-assets-${data.aws_caller_identity.current.account_id}"
+  object_prefix     = "profile-assets/"
+
+  vercel_oidc_issuer_path = "oidc.vercel.com/${var.vercel_team_slug}"
+  vercel_oidc_issuer_url  = "https://${local.vercel_oidc_issuer_path}"
+  vercel_oidc_audience    = "https://vercel.com/${var.vercel_team_slug}"
+  vercel_oidc_subjects = [
+    for environment in var.vercel_runtime_environments : "owner:${var.vercel_team_slug}:project:${var.vercel_project_name}:environment:${environment}"
+  ]
+
+  runtime_env_comment = "VRDex private profile asset storage managed by infra/terraform/profile-assets."
+  runtime_env_values = {
+    VRDEX_PROFILE_ASSET_BUCKET   = aws_s3_bucket.profile_assets.bucket
+    VRDEX_PROFILE_ASSET_REGION   = var.aws_region
+    VRDEX_PROFILE_ASSET_ROLE_ARN = aws_iam_role.vercel_profile_assets.arn
+  }
+
+  standard_vercel_targets = var.manage_production_environment ? { production = ["production"] } : {}
+
+  tags = merge(
+    {
+      Project   = "VRDex"
+      ManagedBy = "Terraform"
+      Component = "profile-assets"
+    },
+    var.tags,
+  )
+}
+
+data "tls_certificate" "vercel_oidc" {
+  url = local.vercel_oidc_issuer_url
+}
+
+resource "aws_s3_bucket" "profile_assets" {
+  bucket = local.asset_bucket_name
+  tags   = local.tags
+}
+
+resource "aws_s3_bucket_public_access_block" "profile_assets" {
+  bucket = aws_s3_bucket.profile_assets.id
+
+  block_public_acls       = true
+  block_public_policy     = true
+  ignore_public_acls      = true
+  restrict_public_buckets = true
+}
+
+resource "aws_s3_bucket_ownership_controls" "profile_assets" {
+  bucket = aws_s3_bucket.profile_assets.id
+
+  rule {
+    object_ownership = "BucketOwnerEnforced"
+  }
+}
+
+resource "aws_s3_bucket_server_side_encryption_configuration" "profile_assets" {
+  bucket = aws_s3_bucket.profile_assets.id
+
+  rule {
+    apply_server_side_encryption_by_default {
+      sse_algorithm = "AES256"
+    }
+  }
+}
+
+data "aws_iam_policy_document" "profile_assets_bucket" {
+  statement {
+    sid    = "DenyInsecureTransport"
+    effect = "Deny"
+
+    principals {
+      type        = "*"
+      identifiers = ["*"]
+    }
+
+    actions = ["s3:*"]
+
+    resources = [
+      aws_s3_bucket.profile_assets.arn,
+      "${aws_s3_bucket.profile_assets.arn}/*",
+    ]
+
+    condition {
+      test     = "Bool"
+      variable = "aws:SecureTransport"
+      values   = ["false"]
+    }
+  }
+}
+
+resource "aws_s3_bucket_policy" "profile_assets" {
+  bucket = aws_s3_bucket.profile_assets.id
+  policy = data.aws_iam_policy_document.profile_assets_bucket.json
+}
+
+resource "aws_iam_openid_connect_provider" "vercel" {
+  url             = local.vercel_oidc_issuer_url
+  client_id_list  = [local.vercel_oidc_audience]
+  thumbprint_list = [data.tls_certificate.vercel_oidc.certificates[0].sha1_fingerprint]
+
+  tags = local.tags
+}
+
+data "aws_iam_policy_document" "vercel_profile_assets_assume_role" {
+  statement {
+    effect = "Allow"
+
+    principals {
+      type        = "Federated"
+      identifiers = [aws_iam_openid_connect_provider.vercel.arn]
+    }
+
+    actions = ["sts:AssumeRoleWithWebIdentity"]
+
+    condition {
+      test     = "StringEquals"
+      variable = "${local.vercel_oidc_issuer_path}:aud"
+      values   = [local.vercel_oidc_audience]
+    }
+
+    condition {
+      test     = "StringEquals"
+      variable = "${local.vercel_oidc_issuer_path}:sub"
+      values   = local.vercel_oidc_subjects
+    }
+  }
+}
+
+resource "aws_iam_role" "vercel_profile_assets" {
+  name               = var.runtime_role_name
+  assume_role_policy = data.aws_iam_policy_document.vercel_profile_assets_assume_role.json
+  tags               = local.tags
+}
+
+data "aws_iam_policy_document" "vercel_profile_assets" {
+  statement {
+    sid = "ReadAndWriteProfileAssets"
+    actions = [
+      "s3:GetObject",
+      "s3:PutObject",
+    ]
+
+    resources = ["${aws_s3_bucket.profile_assets.arn}/${local.object_prefix}*"]
+  }
+}
+
+resource "aws_iam_role_policy" "vercel_profile_assets" {
+  name   = "profile-assets-s3-access"
+  role   = aws_iam_role.vercel_profile_assets.id
+  policy = data.aws_iam_policy_document.vercel_profile_assets.json
+}
+
+resource "vercel_project_environment_variable" "profile_assets_standard" {
+  for_each = {
+    for pair in setproduct(keys(local.runtime_env_values), keys(local.standard_vercel_targets)) : "${pair[0]}_${pair[1]}" => {
+      key    = pair[0]
+      target = local.standard_vercel_targets[pair[1]]
+      value  = local.runtime_env_values[pair[0]]
+    }
+  }
+
+  project_id = data.vercel_project.web.id
+  team_id    = var.vercel_team_id
+  key        = each.value.key
+  value      = each.value.value
+  target     = each.value.target
+  sensitive  = true
+  comment    = local.runtime_env_comment
+}
+
+resource "vercel_project_environment_variable" "profile_assets_staging_custom" {
+  for_each = {
+    for pair in setproduct(keys(local.runtime_env_values), var.staging_custom_environment_ids) : "${pair[0]}_${pair[1]}" => {
+      key                   = pair[0]
+      custom_environment_id = pair[1]
+      value                 = local.runtime_env_values[pair[0]]
+    }
+  }
+
+  project_id             = data.vercel_project.web.id
+  team_id                = var.vercel_team_id
+  key                    = each.value.key
+  value                  = each.value.value
+  custom_environment_ids = [each.value.custom_environment_id]
+  sensitive              = true
+  comment                = local.runtime_env_comment
+}

--- a/infra/terraform/profile-assets/outputs.tf
+++ b/infra/terraform/profile-assets/outputs.tf
@@ -1,0 +1,19 @@
+output "profile_asset_bucket_name" {
+  description = "Private S3 bucket for VRDex profile media-kit assets."
+  value       = aws_s3_bucket.profile_assets.bucket
+}
+
+output "profile_asset_bucket_region" {
+  description = "AWS region for the private profile asset bucket."
+  value       = var.aws_region
+}
+
+output "profile_asset_runtime_role_arn" {
+  description = "IAM role ARN Vercel functions assume through OIDC for profile asset S3 access."
+  value       = aws_iam_role.vercel_profile_assets.arn
+}
+
+output "managed_profile_asset_environment_keys" {
+  description = "Vercel environment variable names managed by this stack for profile asset storage."
+  value       = keys(local.runtime_env_values)
+}

--- a/infra/terraform/profile-assets/terraform.tfvars.example
+++ b/infra/terraform/profile-assets/terraform.tfvars.example
@@ -1,0 +1,9 @@
+aws_region        = "us-east-1"
+vercel_team_slug  = "basic-bit"
+vercel_project_name = "vr-dex-web"
+
+# Optional override. Defaults to vrdex-profile-assets-${account_id}.
+# asset_bucket_name = "vrdex-profile-assets-123456789012"
+
+# Production is managed by default. Staging uses the hosted custom environment ID below.
+staging_custom_environment_ids = ["env_1iR8Tk53UMEhsbEgONsgGhzl9hX9"]

--- a/infra/terraform/profile-assets/variables.tf
+++ b/infra/terraform/profile-assets/variables.tf
@@ -1,0 +1,59 @@
+variable "aws_region" {
+  description = "AWS region for the private profile asset bucket. Vercel must set VRDEX_PROFILE_ASSET_REGION to the same value."
+  type        = string
+  default     = "us-east-1"
+}
+
+variable "asset_bucket_name" {
+  description = "Optional S3 bucket name for private profile media-kit assets. Defaults to vrdex-profile-assets plus account id."
+  type        = string
+  default     = null
+}
+
+variable "runtime_role_name" {
+  description = "IAM role name assumed by Vercel functions through OIDC for profile asset S3 access."
+  type        = string
+  default     = "vrdex-vercel-profile-assets"
+}
+
+variable "vercel_team_id" {
+  description = "Vercel team ID that owns the VRDex web project."
+  type        = string
+  default     = "team_GoHh5xUc96fAIAqJoG55A71S"
+}
+
+variable "vercel_team_slug" {
+  description = "Vercel team slug used in team-mode OIDC issuer and audience claims."
+  type        = string
+  default     = "basic-bit"
+}
+
+variable "vercel_project_name" {
+  description = "Existing Vercel project name for apps/web. OIDC trust is scoped to this project name."
+  type        = string
+  default     = "vr-dex-web"
+}
+
+variable "vercel_runtime_environments" {
+  description = "Vercel deployment environment names allowed to assume the profile asset runtime role."
+  type        = set(string)
+  default     = ["production", "staging"]
+}
+
+variable "manage_production_environment" {
+  description = "Whether to manage production profile asset env vars on the Vercel project."
+  type        = bool
+  default     = true
+}
+
+variable "staging_custom_environment_ids" {
+  description = "Vercel custom environment IDs for staging-like environments that should receive profile asset env vars. Empty leaves custom environments unmanaged."
+  type        = set(string)
+  default     = ["env_1iR8Tk53UMEhsbEgONsgGhzl9hX9"]
+}
+
+variable "tags" {
+  description = "Additional resource tags."
+  type        = map(string)
+  default     = {}
+}

--- a/infra/terraform/profile-assets/variables.tf
+++ b/infra/terraform/profile-assets/variables.tf
@@ -49,7 +49,7 @@ variable "manage_production_environment" {
 variable "staging_custom_environment_ids" {
   description = "Vercel custom environment IDs for staging-like environments that should receive profile asset env vars. Empty leaves custom environments unmanaged."
   type        = set(string)
-  default     = ["env_1iR8Tk53UMEhsbEgONsgGhzl9hX9"]
+  default     = []
 }
 
 variable "tags" {

--- a/infra/terraform/profile-assets/versions.tf
+++ b/infra/terraform/profile-assets/versions.tf
@@ -1,0 +1,38 @@
+terraform {
+  required_version = ">= 1.10.0"
+
+  backend "s3" {
+    bucket       = "vrdex-terraform-state"
+    key          = "profile-assets/terraform.tfstate"
+    region       = "us-east-1"
+    encrypt      = true
+    use_lockfile = true
+  }
+
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 5.0"
+    }
+
+    tls = {
+      source  = "hashicorp/tls"
+      version = "~> 4.0"
+    }
+
+    vercel = {
+      source  = "vercel/vercel"
+      version = "~> 4.0"
+    }
+  }
+}
+
+provider "aws" {
+  region = var.aws_region
+
+  default_tags {
+    tags = local.tags
+  }
+}
+
+provider "vercel" {}

--- a/infra/terraform/state-mgmt/README.md
+++ b/infra/terraform/state-mgmt/README.md
@@ -12,7 +12,7 @@ It intentionally uses local Terraform state. Do not configure this stack to use 
 - S3 versioning
 - S3 bucket policy that denies non-TLS requests
 - GitHub Actions OIDC Terraform role `vrdex-github-terraform`
-- least-privilege inline policy for Terraform state, the `vrdex.net` Route 53 zone, hosted SES identity, and the Convex SES sender IAM user
+- least-privilege inline policy for Terraform state, the `vrdex.net` Route 53 zone, hosted SES identity, the Convex SES sender IAM user, and the profile asset storage baseline
 
 The application stacks use S3 native lockfiles through `use_lockfile = true`; no DynamoDB lock table is required.
 
@@ -41,6 +41,8 @@ If the GitHub Actions role already exists, import it before planning:
 terraform import aws_iam_role.github_actions_terraform vrdex-github-terraform
 terraform import aws_iam_role_policy.github_actions_terraform vrdex-github-terraform:vrdex-terraform-ci
 ```
+
+Apply this stack before enabling provider-backed CI plan/apply for `infra/terraform/profile-assets`. That stack needs the GitHub Actions role to manage the private profile asset S3 bucket, the Vercel OIDC identity provider, and the Vercel profile asset runtime role.
 
 ## State Boundary
 

--- a/infra/terraform/state-mgmt/main.tf
+++ b/infra/terraform/state-mgmt/main.tf
@@ -1,5 +1,9 @@
 locals {
-  state_bucket_arn = "arn:aws:s3:::${var.state_bucket_name}"
+  state_bucket_arn         = "arn:aws:s3:::${var.state_bucket_name}"
+  profile_asset_bucket     = var.profile_asset_bucket_name != null ? var.profile_asset_bucket_name : "vrdex-profile-assets-${data.aws_caller_identity.current.account_id}"
+  profile_asset_bucket_arn = "arn:aws:s3:::${local.profile_asset_bucket}"
+  vercel_oidc_provider_arn = "arn:aws:iam::${data.aws_caller_identity.current.account_id}:oidc-provider/oidc.vercel.com/${var.vercel_team_slug}"
+  profile_asset_role_arn   = "arn:aws:iam::${data.aws_caller_identity.current.account_id}:role/${var.profile_asset_runtime_role_name}"
 
   tags = merge(
     {
@@ -219,6 +223,83 @@ data "aws_iam_policy_document" "github_actions_terraform" {
     ]
 
     resources = ["arn:aws:iam::${data.aws_caller_identity.current.account_id}:user/service/vrdex-convex-ses-sender"]
+  }
+
+  statement {
+    sid = "ProfileAssetBucketManagement"
+
+    actions = [
+      "s3:CreateBucket",
+      "s3:DeleteBucket",
+      "s3:GetBucketLocation",
+      "s3:GetBucketPolicy",
+      "s3:GetBucketTagging",
+      "s3:GetBucketPublicAccessBlock",
+      "s3:GetBucketOwnershipControls",
+      "s3:GetEncryptionConfiguration",
+      "s3:ListBucket",
+      "s3:PutBucketPolicy",
+      "s3:PutBucketTagging",
+      "s3:PutBucketPublicAccessBlock",
+      "s3:PutBucketOwnershipControls",
+      "s3:PutEncryptionConfiguration",
+      "s3:DeleteBucketPolicy",
+      "s3:DeleteBucketTagging",
+      "s3:DeleteBucketPublicAccessBlock",
+      "s3:DeleteBucketOwnershipControls",
+      "s3:DeleteBucketEncryption",
+    ]
+
+    resources = [local.profile_asset_bucket_arn]
+  }
+
+  statement {
+    sid = "ProfileAssetBucketDiscovery"
+
+    actions = [
+      "s3:ListAllMyBuckets",
+    ]
+
+    resources = ["*"]
+  }
+
+  statement {
+    sid = "VercelProfileAssetOidcProviderManagement"
+
+    actions = [
+      "iam:AddClientIDToOpenIDConnectProvider",
+      "iam:CreateOpenIDConnectProvider",
+      "iam:DeleteOpenIDConnectProvider",
+      "iam:GetOpenIDConnectProvider",
+      "iam:ListOpenIDConnectProviderTags",
+      "iam:RemoveClientIDFromOpenIDConnectProvider",
+      "iam:TagOpenIDConnectProvider",
+      "iam:UntagOpenIDConnectProvider",
+      "iam:UpdateOpenIDConnectProviderThumbprint",
+    ]
+
+    resources = [local.vercel_oidc_provider_arn]
+  }
+
+  statement {
+    sid = "VercelProfileAssetRoleManagement"
+
+    actions = [
+      "iam:CreateRole",
+      "iam:DeleteRole",
+      "iam:DeleteRolePolicy",
+      "iam:GetRole",
+      "iam:GetRolePolicy",
+      "iam:ListAttachedRolePolicies",
+      "iam:ListInstanceProfilesForRole",
+      "iam:ListRolePolicies",
+      "iam:PutRolePolicy",
+      "iam:TagRole",
+      "iam:UntagRole",
+      "iam:UpdateAssumeRolePolicy",
+    ]
+
+    resources = [local.profile_asset_role_arn]
   }
 }
 

--- a/infra/terraform/state-mgmt/main.tf
+++ b/infra/terraform/state-mgmt/main.tf
@@ -292,6 +292,7 @@ data "aws_iam_policy_document" "github_actions_terraform" {
       "iam:GetRolePolicy",
       "iam:ListAttachedRolePolicies",
       "iam:ListInstanceProfilesForRole",
+      "iam:ListRoleTags",
       "iam:ListRolePolicies",
       "iam:PutRolePolicy",
       "iam:TagRole",

--- a/infra/terraform/state-mgmt/variables.tf
+++ b/infra/terraform/state-mgmt/variables.tf
@@ -27,6 +27,24 @@ variable "ses_domain_name" {
   default     = "vrdex.net"
 }
 
+variable "profile_asset_bucket_name" {
+  description = "S3 bucket name Terraform CI may manage for private profile media-kit assets. Defaults to vrdex-profile-assets plus account id."
+  type        = string
+  default     = null
+}
+
+variable "profile_asset_runtime_role_name" {
+  description = "IAM role name Terraform CI may manage for Vercel profile asset runtime access."
+  type        = string
+  default     = "vrdex-vercel-profile-assets"
+}
+
+variable "vercel_team_slug" {
+  description = "Vercel team slug used by the profile asset OIDC provider Terraform CI may manage."
+  type        = string
+  default     = "basic-bit"
+}
+
 variable "tags" {
   description = "Additional resource tags."
   type        = map(string)

--- a/infra/terraform/vercel/README.md
+++ b/infra/terraform/vercel/README.md
@@ -1,6 +1,6 @@
 # Vercel Web Terraform
 
-This stack manages Vercel project environment variables for the hosted VRDex web app.
+This stack manages PostHog Vercel project environment variables for the hosted VRDex web app.
 
 It currently manages PostHog analytics variables for the existing Vercel project:
 
@@ -15,6 +15,8 @@ It currently manages PostHog analytics variables for the existing Vercel project
 - `NEXT_PUBLIC_POSTHOG_HOST`
 
 The PostHog project key is client-exposed once deployed, but keep the value out of git so forks and self-hosted installs do not accidentally send analytics into the BASIC BIT project.
+
+Profile asset storage variables are owned by `infra/terraform/profile-assets`, not this stack, because that stack owns the paired S3 bucket and Vercel OIDC runtime role.
 
 ## Usage
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -107,6 +107,9 @@ importers:
       '@convex-dev/auth':
         specifier: ^0.0.92
         version: 0.0.92(@auth/core@0.37.4)(convex@1.32.0(react@19.2.3))(react@19.2.3)
+      '@vercel/oidc-aws-credentials-provider':
+        specifier: ^3.1.4
+        version: 3.1.4
       class-variance-authority:
         specifier: ^0.7.1
         version: 0.7.1
@@ -3650,6 +3653,21 @@ packages:
     cpu: [x64]
     os: [win32]
 
+  '@vercel/cli-config@0.2.0':
+    resolution: {integrity: sha512-fJRRRB7734BDuXZ89yBEaA2ncYhH7bWX30mk04W80J6VAfQc+4iB8lyzAdaGpFV3/vNlkt9VZt+/uoQoWX6UsQ==}
+
+  '@vercel/cli-exec@0.1.1':
+    resolution: {integrity: sha512-LMRMEai3Z+BODyxGcU9+KiWrS/UElNiOLKiNRfGNt2Vu3NTEmXgFeXG9wBfocAnTe5yJCX/DY6k3k7S/LkPp/g==}
+    engines: {node: '>= 18'}
+
+  '@vercel/oidc-aws-credentials-provider@3.1.4':
+    resolution: {integrity: sha512-JYfZSGs/losKgsT5Xtt4szmcoGi5HYgQmr4WUUK4fDYW9XPb5tPRAn8B/UpGNsFEBQuOwI+pRGSGI4OaxndbVg==}
+    engines: {node: '>= 20'}
+
+  '@vercel/oidc@3.6.1':
+    resolution: {integrity: sha512-8ipTFoiX3WBRrvXLjSrmgAiwtMDQk3EgSxe8N7v2rXBz39NBIIyoGXeVbJRoBcP8WEuVnvjvIQsggbGU7ZKrMw==}
+    engines: {node: '>= 20'}
+
   '@vitest/expect@3.2.4':
     resolution: {integrity: sha512-Io0yyORnB6sikFlt8QW5K7slY4OjqNX9jmJQ02QDda8lyM6B5oNgVWoSoKPac8/kgnCUzuHQKrSLtu/uOqqrig==}
 
@@ -6581,6 +6599,10 @@ packages:
     resolution: {integrity: sha512-6IpQ7mKUxRcZNLIObR0hz7lxsapSSIYNZJwXPGeF0mTVqGKFIXj1DQcMoT22S3ROcLyY/rz0PWaWZ9ayWmad9g==}
     engines: {node: '>= 0.8.0'}
 
+  os-paths@4.4.0:
+    resolution: {integrity: sha512-wrAwOeXp1RRMFfQY8Sy7VaGVmPocaLwSFOYCGKSyo8qmJ+/yaafCl5BCA1IQZWqFSRBrKDYFeR9d/VyQzfH/jg==}
+    engines: {node: '>= 6.0'}
+
   own-keys@1.0.1:
     resolution: {integrity: sha512-qFOyK5PjiWZd+QQIh+1jhdb9LpxTF0qs7Pm8o5QHYZ0M3vKqSqzsZaEB6oWlxZ+q2sJBMI/Ktgd2N5ZwQoRHfg==}
     engines: {node: '>= 0.4'}
@@ -8495,9 +8517,17 @@ packages:
     resolution: {integrity: sha512-h3Fbisa2nKGPxCpm89Hk33lBLsnaGBvctQopaBSOW/uIs6FTe1ATyAnKFJrzVs9vpGdsTe73WF3V4lIsk4Gacw==}
     engines: {node: '>=18'}
 
+  xdg-app-paths@5.5.1:
+    resolution: {integrity: sha512-hI3flOB4PLZIy5prbtTpirobtPE2ZtZ52szO+2mM9Efp6ErM398La+C1lIpNWDfNoQk+6Lsi6nMcCwVB7pxeMQ==}
+    engines: {node: '>= 6.0'}
+
   xdg-basedir@5.1.0:
     resolution: {integrity: sha512-GCPAHLvrIH13+c0SuacwvRYj2SxJXQ4kaVTT5xgL3kPrz56XxkF21IGhjSE1+W0aw7gpBWRGXLCPnPby6lSpmQ==}
     engines: {node: '>=12'}
+
+  xdg-portable@7.3.0:
+    resolution: {integrity: sha512-sqMMuL1rc0FmMBOzCpd0yuy9trqF2yTTVe+E9ogwCSWQCdDEtQUwrZPT6AxqtsFGRNxycgncbP/xmOOSPw5ZUw==}
+    engines: {node: '>= 6.0'}
 
   xml-js@1.6.11:
     resolution: {integrity: sha512-7rVi2KMfwfWFl+GpPg6m80IVMWXLRjO+PxTq7V2CDhoGak0wzYzFgUY2m4XJ47OGdXd8eLE8EmwfAmdjw7lC1g==}
@@ -8528,6 +8558,9 @@ packages:
     engines: {node: '>=18.0.0'}
     peerDependencies:
       zod: ^3.25.0 || ^4.0.0
+
+  zod@4.1.11:
+    resolution: {integrity: sha512-WPsqwxITS2tzx1bzhIKsEs19ABD5vmCVa4xBo2tq/SrV4RNZtfws1EnCWQXM6yh8bD08a1idvkB5MZSBiZsjwg==}
 
   zod@4.3.6:
     resolution: {integrity: sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==}
@@ -8811,7 +8844,7 @@ snapshots:
       '@aws-sdk/credential-provider-login': 3.972.44
       '@aws-sdk/credential-provider-process': 3.972.40
       '@aws-sdk/credential-provider-sso': 3.972.44
-      '@aws-sdk/credential-provider-web-identity': 3.972.44
+      '@aws-sdk/credential-provider-web-identity': 3.972.52
       '@aws-sdk/nested-clients': 3.997.12
       '@aws-sdk/types': 3.973.9
       '@smithy/core': 3.24.5
@@ -8837,11 +8870,11 @@ snapshots:
 
   '@aws-sdk/credential-provider-login@3.972.44':
     dependencies:
-      '@aws-sdk/core': 3.974.14
-      '@aws-sdk/nested-clients': 3.997.12
-      '@aws-sdk/types': 3.973.9
-      '@smithy/core': 3.24.5
-      '@smithy/types': 4.14.2
+      '@aws-sdk/core': 3.974.20
+      '@aws-sdk/nested-clients': 3.997.20
+      '@aws-sdk/types': 3.973.12
+      '@smithy/core': 3.25.0
+      '@smithy/types': 4.15.0
       tslib: 2.8.1
 
   '@aws-sdk/credential-provider-login@3.972.52':
@@ -8953,13 +8986,13 @@ snapshots:
     dependencies:
       '@aws-crypto/sha256-browser': 5.2.0
       '@aws-crypto/sha256-js': 5.2.0
-      '@aws-sdk/core': 3.974.14
+      '@aws-sdk/core': 3.974.20
       '@aws-sdk/signature-v4-multi-region': 3.996.29
-      '@aws-sdk/types': 3.973.9
-      '@smithy/core': 3.24.5
+      '@aws-sdk/types': 3.973.12
+      '@smithy/core': 3.25.0
       '@smithy/fetch-http-handler': 5.4.5
       '@smithy/node-http-handler': 4.7.5
-      '@smithy/types': 4.14.2
+      '@smithy/types': 4.15.0
       tslib: 2.8.1
 
   '@aws-sdk/nested-clients@3.997.20':
@@ -8977,9 +9010,9 @@ snapshots:
 
   '@aws-sdk/signature-v4-multi-region@3.996.29':
     dependencies:
-      '@aws-sdk/types': 3.973.9
+      '@aws-sdk/types': 3.973.12
       '@smithy/signature-v4': 5.4.5
-      '@smithy/types': 4.14.2
+      '@smithy/types': 4.15.0
       tslib: 2.8.1
 
   '@aws-sdk/signature-v4-multi-region@3.996.34':
@@ -8991,11 +9024,11 @@ snapshots:
 
   '@aws-sdk/token-providers@3.1054.0':
     dependencies:
-      '@aws-sdk/core': 3.974.14
-      '@aws-sdk/nested-clients': 3.997.12
-      '@aws-sdk/types': 3.973.9
-      '@smithy/core': 3.24.5
-      '@smithy/types': 4.14.2
+      '@aws-sdk/core': 3.974.20
+      '@aws-sdk/nested-clients': 3.997.20
+      '@aws-sdk/types': 3.973.12
+      '@smithy/core': 3.25.0
+      '@smithy/types': 4.15.0
       tslib: 2.8.1
 
   '@aws-sdk/token-providers@3.1066.0':
@@ -13168,6 +13201,26 @@ snapshots:
   '@unrs/resolver-binding-win32-x64-msvc@1.11.1':
     optional: true
 
+  '@vercel/cli-config@0.2.0':
+    dependencies:
+      xdg-app-paths: 5.5.1
+      zod: 4.1.11
+
+  '@vercel/cli-exec@0.1.1':
+    dependencies:
+      execa: 5.1.1
+
+  '@vercel/oidc-aws-credentials-provider@3.1.4':
+    dependencies:
+      '@aws-sdk/credential-provider-web-identity': 3.972.52
+      '@vercel/oidc': 3.6.1
+
+  '@vercel/oidc@3.6.1':
+    dependencies:
+      '@vercel/cli-config': 0.2.0
+      '@vercel/cli-exec': 0.1.1
+      jose: 5.10.0
+
   '@vitest/expect@3.2.4':
     dependencies:
       '@types/chai': 5.2.3
@@ -16768,6 +16821,8 @@ snapshots:
       type-check: 0.4.0
       word-wrap: 1.2.5
 
+  os-paths@4.4.0: {}
+
   own-keys@1.0.1:
     dependencies:
       get-intrinsic: 1.3.0
@@ -19218,7 +19273,16 @@ snapshots:
     dependencies:
       is-wsl: 3.1.1
 
+  xdg-app-paths@5.5.1:
+    dependencies:
+      os-paths: 4.4.0
+      xdg-portable: 7.3.0
+
   xdg-basedir@5.1.0: {}
+
+  xdg-portable@7.3.0:
+    dependencies:
+      os-paths: 4.4.0
 
   xml-js@1.6.11:
     dependencies:
@@ -19237,6 +19301,8 @@ snapshots:
   zod-validation-error@4.0.2(zod@4.3.6):
     dependencies:
       zod: 4.3.6
+
+  zod@4.1.11: {}
 
   zod@4.3.6: {}
 


### PR DESCRIPTION
## Summary
- Adds a `profile-assets` Terraform stack for the private S3 asset bucket, Vercel OIDC runtime role, and hosted Vercel profile asset env vars.
- Gates provider-backed CI plan/apply until the updated `state-mgmt` bootstrap role has been applied.
- Teaches the web S3 client to use Vercel OIDC credentials when `VRDEX_PROFILE_ASSET_ROLE_ARN` is configured.

## Rollout
After merge, apply the updated `state-mgmt` stack, set `TERRAFORM_PROFILE_ASSETS_ENABLED=true`, apply the `profile-assets` stack, redeploy Vercel, then re-probe the profile asset upload route for a non-`501` response.

## Validation
Local validation passed: `pnpm verify:web`, `pnpm lint:markdown`, `terraform fmt -check -recursive infra/terraform`, and `terraform validate` for `profile-assets` and `state-mgmt`.