### PR TITLE
[codex] add calendar workflow foundations

### DIFF
--- a/apps/web/src/lib/calendar/ics.ts
+++ b/apps/web/src/lib/calendar/ics.ts
@@ -16,6 +16,13 @@ type CreatePublicEventIcsOptions = {
   now?: number;
 };
 
+type CreatePublicEventFeedIcsOptions = {
+  feedName: string;
+  feedUrl: string;
+  eventUrl: (event: PublicCalendarEvent) => string;
+  now?: number;
+};
+
 const ICS_PRODUCT_ID = "-//VRDex//Public Event Calendar//EN";
 const ICS_LINE_OCTET_LIMIT = 75;
 
@@ -113,6 +120,57 @@ export function createPublicEventIcs(event: PublicCalendarEvent, options: Create
   ];
 
   return `${lines.map(foldIcsLine).join("\r\n")}\r\n`;
+}
+
+export function createPublicEventFeedIcs(
+  events: PublicCalendarEvent[],
+  options: CreatePublicEventFeedIcsOptions,
+): string {
+  const feedUrl = safeHttpUrl(options.feedUrl);
+
+  if (feedUrl === null) {
+    throw new Error("Calendar feed URL must be an absolute HTTP URL.");
+  }
+
+  const now = options.now ?? Date.now();
+  const lines = [
+    "BEGIN:VCALENDAR",
+    "VERSION:2.0",
+    property("PRODID", ICS_PRODUCT_ID),
+    "CALSCALE:GREGORIAN",
+    "METHOD:PUBLISH",
+    property("X-WR-CALNAME", options.feedName),
+    property("URL", feedUrl, { escapeValue: false }),
+    ...events.flatMap((event) => publicEventLines(event, options.eventUrl(event), now)),
+    "END:VCALENDAR",
+  ];
+
+  return `${lines.map(foldIcsLine).join("\r\n")}\r\n`;
+}
+
+function publicEventLines(event: PublicCalendarEvent, rawCanonicalUrl: string, now: number): string[] {
+  const canonicalUrl = safeHttpUrl(rawCanonicalUrl);
+
+  if (canonicalUrl === null) {
+    throw new Error("Calendar event URLs must be absolute HTTP URLs.");
+  }
+
+  const location = event.worlds.map((world) => world.displayName).filter(Boolean).join(", ") || event.communityName;
+  const description = event.summary ? `${event.summary}\n\n${canonicalUrl}` : canonicalUrl;
+
+  return [
+    "BEGIN:VEVENT",
+    property("UID", `${event.id}@${new URL(canonicalUrl).host}`, { escapeValue: false }),
+    property("DTSTAMP", formatIcsUtcTimestamp(now), { escapeValue: false }),
+    property("DTSTART", formatIcsUtcTimestamp(event.startAt), { escapeValue: false }),
+    ...optionalEndAtLine(event),
+    "STATUS:CONFIRMED",
+    property("SUMMARY", event.title),
+    property("DESCRIPTION", description),
+    ...optionalTextProperty("LOCATION", location),
+    property("URL", canonicalUrl, { escapeValue: false }),
+    "END:VEVENT",
+  ];
 }
 
 function optionalEndAtLine(event: PublicCalendarEvent): string[] {

--- a/convex/_eventCalendarImports.ts
+++ b/convex/_eventCalendarImports.ts
@@ -1,0 +1,562 @@
+import { v } from "convex/values";
+
+import type { Doc, Id } from "./_generated/dataModel";
+import type { DatabaseWriter } from "./_generated/server";
+import type { AuthSubject } from "./_communityAuthority";
+
+export const eventImportProviderValidator = v.literal("google_calendar");
+export const eventImportBatchReviewStateValidator = v.union(
+  v.literal("draft"),
+  v.literal("ready_for_review"),
+  v.literal("approved"),
+  v.literal("rejected"),
+  v.literal("superseded"),
+);
+export const eventImportCandidateReviewStateValidator = v.union(
+  v.literal("unreviewed"),
+  v.literal("accepted"),
+  v.literal("rejected"),
+  v.literal("needs_correction"),
+);
+export const eventImportCandidatePublicationStateValidator = v.union(
+  v.literal("draft_private"),
+  v.literal("review_pending"),
+  v.literal("published_event"),
+  v.literal("rejected"),
+  v.literal("superseded"),
+);
+export const eventImportFieldConfidenceValidator = v.union(
+  v.literal("low"),
+  v.literal("medium"),
+  v.literal("high"),
+  v.literal("owner_confirmed"),
+);
+export const eventImportFieldReviewStateValidator = v.union(
+  v.literal("unreviewed"),
+  v.literal("accepted"),
+  v.literal("rejected"),
+  v.literal("needs_correction"),
+);
+export const eventImportFieldVisibilityValidator = v.union(
+  v.literal("public"),
+  v.literal("private"),
+);
+export const eventImportCancellationStateValidator = v.union(
+  v.literal("active"),
+  v.literal("cancelled"),
+);
+
+export type EventImportProvider = "google_calendar";
+export type EventImportBatchReviewState =
+  | "draft"
+  | "ready_for_review"
+  | "approved"
+  | "rejected"
+  | "superseded";
+export type EventImportCandidateReviewState =
+  | "unreviewed"
+  | "accepted"
+  | "rejected"
+  | "needs_correction";
+export type EventImportCandidatePublicationState =
+  | "draft_private"
+  | "review_pending"
+  | "published_event"
+  | "rejected"
+  | "superseded";
+export type EventImportFieldConfidence =
+  | "low"
+  | "medium"
+  | "high"
+  | "owner_confirmed";
+export type EventImportFieldReviewState =
+  | "unreviewed"
+  | "accepted"
+  | "rejected"
+  | "needs_correction";
+export type EventImportFieldVisibility = "public" | "private";
+export type EventImportCancellationState = "active" | "cancelled";
+
+export type GoogleCalendarDateValue = {
+  date?: string;
+  dateTime?: string;
+  timeZone?: string;
+};
+
+export type GoogleCalendarEventInput = {
+  id: string;
+  iCalUID?: string;
+  status?: "confirmed" | "cancelled" | "tentative" | string;
+  htmlLink?: string;
+  summary?: string;
+  description?: string;
+  location?: string;
+  start?: GoogleCalendarDateValue;
+  end?: GoogleCalendarDateValue;
+  updated?: string;
+  recurringEventId?: string;
+  recurrence?: string[];
+  attendees?: unknown;
+  reminders?: unknown;
+  extendedProperties?: unknown;
+};
+
+export type GoogleCalendarImportInput = {
+  batchId: string;
+  calendarId: string;
+  calendarSummary?: string;
+  calendarTimeZone?: string;
+  syncJobId?: string;
+  receivedAt: string;
+  notes?: string;
+  events: GoogleCalendarEventInput[];
+};
+
+export type EventImportCandidateField = {
+  fieldKey: string;
+  value: unknown;
+  sourceLabel: string;
+  sourceUrl?: string;
+  confidence: EventImportFieldConfidence;
+  reviewState: EventImportFieldReviewState;
+  visibility: EventImportFieldVisibility;
+};
+
+export type NormalizedGoogleCalendarImportCandidate = {
+  externalEventId: string;
+  externalICalUid?: string;
+  sourceUpdatedAt?: number;
+  sourceUrl?: string;
+  title: string;
+  startAt: number;
+  endAt?: number;
+  timezone?: string;
+  allDay: boolean;
+  location?: string;
+  description?: string;
+  recurrenceRules: string[];
+  recurringEventId?: string;
+  cancellationState: EventImportCancellationState;
+  reviewState: EventImportCandidateReviewState;
+  publicationState: EventImportCandidatePublicationState;
+  fields: EventImportCandidateField[];
+};
+
+export type NormalizedGoogleCalendarImport = {
+  externalBatchId: string;
+  provider: EventImportProvider;
+  sourceName: string;
+  sourceCalendarId: string;
+  sourceCalendarSummary?: string;
+  sourceCalendarTimeZone?: string;
+  syncJobId?: string;
+  receivedAt: number;
+  reviewState: EventImportBatchReviewState;
+  notes?: string;
+  candidates: NormalizedGoogleCalendarImportCandidate[];
+};
+
+type EventImportWriter = Pick<DatabaseWriter, "insert">;
+
+const EVENT_TITLE_FALLBACK = "Untitled calendar event";
+const EVENT_DESCRIPTION_MAX_LENGTH = 2_000;
+const EVENT_LOCATION_MAX_LENGTH = 500;
+const EVENT_TEXT_MAX_LENGTH = 240;
+const EVENT_SOURCE_URL_MAX_LENGTH = 2_048;
+const MAX_EXTRACTED_LINKS = 8;
+const HTTPS_URL_PATTERN = /\bhttps:\/\/[^\s<>"')]+/gi;
+
+function optionalRecord<T>(key: string, value: T | undefined): Record<string, T> {
+  return value === undefined ? {} : { [key]: value };
+}
+
+function normalizeInlineText(value: string | undefined, fallback: string, maxLength: number): string {
+  const normalized = value?.trim().replace(/\s+/g, " ");
+
+  return (normalized || fallback).slice(0, maxLength);
+}
+
+function optionalInlineText(value: string | undefined, maxLength: number): string | undefined {
+  const normalized = value?.trim().replace(/\s+/g, " ");
+
+  return normalized ? normalized.slice(0, maxLength) : undefined;
+}
+
+function parseIsoTimestamp(value: string | undefined, fieldName: string): number | undefined {
+  if (value === undefined) {
+    return undefined;
+  }
+
+  const timestamp = Date.parse(value);
+
+  if (!Number.isFinite(timestamp)) {
+    throw new Error(`${fieldName} must be an ISO timestamp.`);
+  }
+
+  return timestamp;
+}
+
+function requireIsoTimestamp(value: string, fieldName: string): number {
+  const timestamp = parseIsoTimestamp(value, fieldName);
+
+  if (timestamp === undefined) {
+    throw new Error(`${fieldName} is required.`);
+  }
+
+  return timestamp;
+}
+
+function requireHttpsUrl(value: string | undefined, fieldName: string): string | undefined {
+  if (value === undefined) {
+    return undefined;
+  }
+
+  const normalized = value.trim();
+
+  try {
+    const url = new URL(normalized);
+
+    if (url.protocol !== "https:" || url.username || url.password) {
+      throw new Error();
+    }
+
+    return url.href.slice(0, EVENT_SOURCE_URL_MAX_LENGTH);
+  } catch {
+    throw new Error(`${fieldName} must be an HTTPS URL without embedded credentials.`);
+  }
+}
+
+function parseAllDayDate(value: string, fieldName: string): number {
+  if (!/^\d{4}-\d{2}-\d{2}$/.test(value)) {
+    throw new Error(`${fieldName} must be a YYYY-MM-DD all-day date.`);
+  }
+
+  return requireIsoTimestamp(`${value}T00:00:00.000Z`, fieldName);
+}
+
+function parseGoogleCalendarTime(
+  value: GoogleCalendarDateValue | undefined,
+  fieldName: string,
+  fallbackTimeZone: string | undefined,
+): { timestamp: number; timezone?: string; allDay: boolean } {
+  if (value?.dateTime !== undefined) {
+    return {
+      timestamp: requireIsoTimestamp(value.dateTime, fieldName),
+      ...optionalRecord("timezone", optionalInlineText(value.timeZone ?? fallbackTimeZone, EVENT_TEXT_MAX_LENGTH)),
+      allDay: false,
+    };
+  }
+
+  if (value?.date !== undefined) {
+    return {
+      timestamp: parseAllDayDate(value.date, fieldName),
+      ...optionalRecord("timezone", optionalInlineText(value.timeZone ?? fallbackTimeZone, EVENT_TEXT_MAX_LENGTH)),
+      allDay: true,
+    };
+  }
+
+  throw new Error(`${fieldName} is required.`);
+}
+
+function normalizeRecurrenceRules(value: string[] | undefined): string[] {
+  const seen = new Set<string>();
+  const rules: string[] = [];
+
+  for (const rule of value ?? []) {
+    const normalized = optionalInlineText(rule, 1_000);
+
+    if (normalized === undefined || seen.has(normalized)) {
+      continue;
+    }
+
+    seen.add(normalized);
+    rules.push(normalized);
+  }
+
+  return rules;
+}
+
+function extractPublicHttpsLinks(...values: Array<string | undefined>): string[] {
+  const links: string[] = [];
+  const seen = new Set<string>();
+
+  for (const value of values) {
+    for (const match of value?.match(HTTPS_URL_PATTERN) ?? []) {
+      const url = requireHttpsUrl(match.replace(/[),.;]+$/g, ""), "Imported event link");
+
+      if (url !== undefined && !seen.has(url)) {
+        seen.add(url);
+        links.push(url);
+      }
+
+      if (links.length >= MAX_EXTRACTED_LINKS) {
+        return links;
+      }
+    }
+  }
+
+  return links;
+}
+
+function candidateField(
+  fieldKey: string,
+  value: unknown,
+  sourceLabel: string,
+  sourceUrl?: string,
+  visibility: EventImportFieldVisibility = "public",
+): EventImportCandidateField {
+  return {
+    fieldKey,
+    value,
+    sourceLabel,
+    ...optionalRecord("sourceUrl", sourceUrl),
+    confidence: "medium",
+    reviewState: "unreviewed",
+    visibility,
+  };
+}
+
+function normalizeGoogleCalendarEvent(
+  event: GoogleCalendarEventInput,
+  sourceLabel: string,
+  fallbackTimeZone: string | undefined,
+): NormalizedGoogleCalendarImportCandidate {
+  const externalEventId = normalizeInlineText(event.id, "", EVENT_TEXT_MAX_LENGTH);
+
+  if (!externalEventId) {
+    throw new Error("Google Calendar event id is required.");
+  }
+
+  const sourceUrl = requireHttpsUrl(event.htmlLink, "Google Calendar event URL");
+  const start = parseGoogleCalendarTime(event.start, "Event start", fallbackTimeZone);
+  const end =
+    event.end === undefined
+      ? undefined
+      : parseGoogleCalendarTime(event.end, "Event end", start.timezone ?? fallbackTimeZone);
+  const title = normalizeInlineText(event.summary, EVENT_TITLE_FALLBACK, EVENT_TEXT_MAX_LENGTH);
+  const description = optionalInlineText(event.description, EVENT_DESCRIPTION_MAX_LENGTH);
+  const location = optionalInlineText(event.location, EVENT_LOCATION_MAX_LENGTH);
+  const recurrenceRules = normalizeRecurrenceRules(event.recurrence);
+  const links = extractPublicHttpsLinks(description, location);
+  const sourceUpdatedAt = parseIsoTimestamp(event.updated, "Google Calendar event updated time");
+  const cancellationState = event.status === "cancelled" ? "cancelled" : "active";
+  const endAt = end === undefined || end.timestamp <= start.timestamp ? undefined : end.timestamp;
+  const fields = [
+    candidateField("title", title, sourceLabel, sourceUrl),
+    candidateField("startAt", start.timestamp, sourceLabel, sourceUrl),
+    candidateField("allDay", start.allDay, sourceLabel, sourceUrl),
+    ...(endAt === undefined ? [] : [candidateField("endAt", endAt, sourceLabel, sourceUrl)]),
+    ...(start.timezone === undefined ? [] : [candidateField("timezone", start.timezone, sourceLabel, sourceUrl)]),
+    ...(description === undefined ? [] : [candidateField("description", description, sourceLabel, sourceUrl)]),
+    ...(location === undefined ? [] : [candidateField("location", location, sourceLabel, sourceUrl)]),
+    ...(links.length === 0 ? [] : [candidateField("links", links, sourceLabel, sourceUrl)]),
+    ...(recurrenceRules.length === 0 ? [] : [candidateField("recurrenceRules", recurrenceRules, sourceLabel, sourceUrl)]),
+    ...(event.recurringEventId === undefined
+      ? []
+      : [candidateField("recurringEventId", event.recurringEventId, sourceLabel, sourceUrl, "private")]),
+    ...(event.status === undefined ? [] : [candidateField("sourceStatus", event.status, sourceLabel, sourceUrl, "private")]),
+  ];
+
+  return {
+    externalEventId,
+    ...optionalRecord("externalICalUid", optionalInlineText(event.iCalUID, EVENT_TEXT_MAX_LENGTH)),
+    ...optionalRecord("sourceUpdatedAt", sourceUpdatedAt),
+    ...optionalRecord("sourceUrl", sourceUrl),
+    title,
+    startAt: start.timestamp,
+    ...optionalRecord("endAt", endAt),
+    ...optionalRecord("timezone", start.timezone),
+    allDay: start.allDay,
+    ...optionalRecord("location", location),
+    ...optionalRecord("description", description),
+    recurrenceRules,
+    ...optionalRecord("recurringEventId", optionalInlineText(event.recurringEventId, EVENT_TEXT_MAX_LENGTH)),
+    cancellationState,
+    reviewState: "unreviewed",
+    publicationState: "draft_private",
+    fields,
+  };
+}
+
+export function normalizeGoogleCalendarImport(input: GoogleCalendarImportInput): NormalizedGoogleCalendarImport {
+  const externalBatchId = normalizeInlineText(input.batchId, "", EVENT_TEXT_MAX_LENGTH);
+  const sourceCalendarId = normalizeInlineText(input.calendarId, "", EVENT_TEXT_MAX_LENGTH);
+
+  if (!externalBatchId) {
+    throw new Error("Calendar import batch id is required.");
+  }
+
+  if (!sourceCalendarId) {
+    throw new Error("Google Calendar id is required.");
+  }
+
+  const sourceCalendarSummary = optionalInlineText(input.calendarSummary, EVENT_TEXT_MAX_LENGTH);
+  const sourceLabel = sourceCalendarSummary ?? "Google Calendar";
+
+  return {
+    externalBatchId,
+    provider: "google_calendar",
+    sourceName: sourceLabel,
+    sourceCalendarId,
+    ...optionalRecord("sourceCalendarSummary", sourceCalendarSummary),
+    ...optionalRecord("sourceCalendarTimeZone", optionalInlineText(input.calendarTimeZone, EVENT_TEXT_MAX_LENGTH)),
+    ...optionalRecord("syncJobId", optionalInlineText(input.syncJobId, EVENT_TEXT_MAX_LENGTH)),
+    receivedAt: requireIsoTimestamp(input.receivedAt, "Calendar import receivedAt"),
+    reviewState: "draft",
+    ...optionalRecord("notes", optionalInlineText(input.notes, 1_000)),
+    candidates: input.events.map((event) =>
+      normalizeGoogleCalendarEvent(event, sourceLabel, input.calendarTimeZone),
+    ),
+  };
+}
+
+export async function createEventImportDocumentsFromGoogleCalendar(
+  db: EventImportWriter,
+  input: GoogleCalendarImportInput,
+  options: { importedBy?: AuthSubject; now: number },
+) {
+  const normalized = normalizeGoogleCalendarImport(input);
+  const batchId = await db.insert("eventImportBatches", {
+    externalBatchId: normalized.externalBatchId,
+    provider: normalized.provider,
+    sourceName: normalized.sourceName,
+    sourceCalendarId: normalized.sourceCalendarId,
+    ...optionalRecord("sourceCalendarSummary", normalized.sourceCalendarSummary),
+    ...optionalRecord("sourceCalendarTimeZone", normalized.sourceCalendarTimeZone),
+    ...optionalRecord("syncJobId", normalized.syncJobId),
+    receivedAt: normalized.receivedAt,
+    ...optionalRecord("importedBy", options.importedBy),
+    reviewState: normalized.reviewState,
+    ...optionalRecord("notes", normalized.notes),
+    createdAt: options.now,
+    updatedAt: options.now,
+  });
+  const candidateIds: Id<"eventImportCandidates">[] = [];
+  const fieldIds: Id<"eventImportCandidateFields">[] = [];
+
+  for (const candidate of normalized.candidates) {
+    const candidateId = await db.insert("eventImportCandidates", {
+      batchId,
+      externalEventId: candidate.externalEventId,
+      ...optionalRecord("externalICalUid", candidate.externalICalUid),
+      ...optionalRecord("sourceUpdatedAt", candidate.sourceUpdatedAt),
+      ...optionalRecord("sourceUrl", candidate.sourceUrl),
+      title: candidate.title,
+      startAt: candidate.startAt,
+      ...optionalRecord("endAt", candidate.endAt),
+      ...optionalRecord("timezone", candidate.timezone),
+      allDay: candidate.allDay,
+      ...optionalRecord("location", candidate.location),
+      ...optionalRecord("description", candidate.description),
+      recurrenceRules: candidate.recurrenceRules,
+      ...optionalRecord("recurringEventId", candidate.recurringEventId),
+      cancellationState: candidate.cancellationState,
+      reviewState: candidate.reviewState,
+      publicationState: candidate.publicationState,
+      createdAt: options.now,
+      updatedAt: options.now,
+    });
+
+    candidateIds.push(candidateId);
+
+    for (const field of candidate.fields) {
+      fieldIds.push(
+        await db.insert("eventImportCandidateFields", {
+          candidateId,
+          fieldKey: field.fieldKey,
+          value: field.value,
+          sourceLabel: field.sourceLabel,
+          ...optionalRecord("sourceUrl", field.sourceUrl),
+          confidence: field.confidence,
+          reviewState: field.reviewState,
+          visibility: field.visibility,
+          createdAt: options.now,
+          updatedAt: options.now,
+        }),
+      );
+    }
+  }
+
+  return {
+    batchId,
+    candidateIds,
+    fieldIds,
+  };
+}
+
+export type EventImportPublicationCandidate = Pick<
+  Doc<"eventImportCandidates">,
+  "reviewState" | "publicationState" | "cancellationState" | "matchedEventId"
+>;
+
+export type EventImportPublicationBatch = Pick<Doc<"eventImportBatches">, "reviewState">;
+export type EventImportPublicationField = Pick<
+  Doc<"eventImportCandidateFields">,
+  "fieldKey" | "reviewState" | "visibility"
+>;
+
+export type EventImportPublicationBlocker =
+  | "batch_not_approved"
+  | "candidate_not_accepted"
+  | "candidate_not_pending_publication"
+  | "candidate_cancelled"
+  | "candidate_already_matched"
+  | "field_unreviewed"
+  | "field_needs_correction"
+  | "unsafe_public_field";
+
+const SAFE_PUBLIC_IMPORT_FIELDS = new Set([
+  "title",
+  "startAt",
+  "endAt",
+  "timezone",
+  "allDay",
+  "description",
+  "location",
+  "links",
+  "recurrenceRules",
+]);
+
+export function getEventImportPublicationBlockers(options: {
+  batch: EventImportPublicationBatch;
+  candidate: EventImportPublicationCandidate;
+  fields: EventImportPublicationField[];
+}): EventImportPublicationBlocker[] {
+  const blockers = new Set<EventImportPublicationBlocker>();
+
+  if (options.batch.reviewState !== "approved") {
+    blockers.add("batch_not_approved");
+  }
+
+  if (options.candidate.reviewState !== "accepted") {
+    blockers.add("candidate_not_accepted");
+  }
+
+  if (options.candidate.publicationState !== "review_pending") {
+    blockers.add("candidate_not_pending_publication");
+  }
+
+  if (options.candidate.cancellationState === "cancelled") {
+    blockers.add("candidate_cancelled");
+  }
+
+  if (options.candidate.matchedEventId !== undefined) {
+    blockers.add("candidate_already_matched");
+  }
+
+  for (const field of options.fields) {
+    if (field.reviewState === "unreviewed") {
+      blockers.add("field_unreviewed");
+    }
+
+    if (field.reviewState === "needs_correction") {
+      blockers.add("field_needs_correction");
+    }
+
+    if (field.visibility === "public" && !SAFE_PUBLIC_IMPORT_FIELDS.has(field.fieldKey)) {
+      blockers.add("unsafe_public_field");
+    }
+  }
+
+  return [...blockers];
+}

--- a/convex/_generated/api.d.ts
+++ b/convex/_generated/api.d.ts
@@ -12,6 +12,7 @@ import type * as _authRedirects from "../_authRedirects.js";
 import type * as _billing from "../_billing.js";
 import type * as _communityAuthority from "../_communityAuthority.js";
 import type * as _discordTimestamps from "../_discordTimestamps.js";
+import type * as _eventCalendarImports from "../_eventCalendarImports.js";
 import type * as _eventDiscordExport from "../_eventDiscordExport.js";
 import type * as _eventInputs from "../_eventInputs.js";
 import type * as _eventMediaControl from "../_eventMediaControl.js";
@@ -72,6 +73,7 @@ declare const fullApi: ApiFromModules<{
   _billing: typeof _billing;
   _communityAuthority: typeof _communityAuthority;
   _discordTimestamps: typeof _discordTimestamps;
+  _eventCalendarImports: typeof _eventCalendarImports;
   _eventDiscordExport: typeof _eventDiscordExport;
   _eventInputs: typeof _eventInputs;
   _eventMediaControl: typeof _eventMediaControl;

--- a/convex/schema.ts
+++ b/convex/schema.ts
@@ -12,6 +12,16 @@ import {
   stripeEnvironmentValidator,
 } from "./_billing";
 import {
+  eventImportBatchReviewStateValidator,
+  eventImportCandidatePublicationStateValidator,
+  eventImportCandidateReviewStateValidator,
+  eventImportCancellationStateValidator,
+  eventImportFieldConfidenceValidator,
+  eventImportFieldReviewStateValidator,
+  eventImportFieldVisibilityValidator,
+  eventImportProviderValidator,
+} from "./_eventCalendarImports";
+import {
   eventMediaActorSurfaceValidator,
   eventMediaCommandStatusValidator,
   eventMediaCommandTypeValidator,
@@ -757,6 +767,78 @@ export default defineSchema({
       "reviewState",
       "startAt",
     ]),
+  eventImportBatches: defineTable({
+    externalBatchId: v.string(),
+    provider: eventImportProviderValidator,
+    sourceName: v.string(),
+    sourceCalendarId: v.string(),
+    sourceCalendarSummary: v.optional(v.string()),
+    sourceCalendarTimeZone: v.optional(v.string()),
+    syncJobId: v.optional(v.string()),
+    receivedAt: v.number(),
+    importedBy: v.optional(authSubject),
+    reviewState: eventImportBatchReviewStateValidator,
+    reviewedBy: v.optional(authSubject),
+    reviewedAt: v.optional(v.number()),
+    notes: v.optional(v.string()),
+    createdAt: v.number(),
+    updatedAt: v.number(),
+  })
+    .index("by_externalBatchId", ["externalBatchId"])
+    .index("by_provider_receivedAt", ["provider", "receivedAt"])
+    .index("by_reviewState_receivedAt", ["reviewState", "receivedAt"]),
+  eventImportCandidates: defineTable({
+    batchId: v.id("eventImportBatches"),
+    externalEventId: v.string(),
+    externalICalUid: v.optional(v.string()),
+    sourceUpdatedAt: v.optional(v.number()),
+    sourceUrl: v.optional(v.string()),
+    title: v.string(),
+    startAt: v.number(),
+    endAt: v.optional(v.number()),
+    timezone: v.optional(v.string()),
+    allDay: v.boolean(),
+    location: v.optional(v.string()),
+    description: v.optional(v.string()),
+    recurrenceRules: v.array(v.string()),
+    recurringEventId: v.optional(v.string()),
+    cancellationState: eventImportCancellationStateValidator,
+    reviewState: eventImportCandidateReviewStateValidator,
+    publicationState: eventImportCandidatePublicationStateValidator,
+    matchedEventId: v.optional(v.id("events")),
+    reviewer: v.optional(authSubject),
+    reviewedAt: v.optional(v.number()),
+    reviewNote: v.optional(v.string()),
+    publicationQueuedBy: v.optional(authSubject),
+    publicationQueuedAt: v.optional(v.number()),
+    createdAt: v.number(),
+    updatedAt: v.number(),
+  })
+    .index("by_batchId", ["batchId"])
+    .index("by_batchId_reviewState", ["batchId", "reviewState"])
+    .index("by_batchId_publicationState", ["batchId", "publicationState"])
+    .index("by_externalEventId", ["externalEventId"])
+    .index("by_sourceUpdatedAt", ["sourceUpdatedAt"])
+    .index("by_matchedEventId", ["matchedEventId"]),
+  eventImportCandidateFields: defineTable({
+    candidateId: v.id("eventImportCandidates"),
+    fieldKey: v.string(),
+    value: v.any(),
+    sourceLabel: v.string(),
+    sourceUrl: v.optional(v.string()),
+    confidence: eventImportFieldConfidenceValidator,
+    reviewState: eventImportFieldReviewStateValidator,
+    visibility: eventImportFieldVisibilityValidator,
+    reviewedBy: v.optional(authSubject),
+    reviewedAt: v.optional(v.number()),
+    reviewNote: v.optional(v.string()),
+    createdAt: v.number(),
+    updatedAt: v.number(),
+  })
+    .index("by_candidateId", ["candidateId"])
+    .index("by_candidateId_reviewState", ["candidateId", "reviewState"])
+    .index("by_candidateId_visibility", ["candidateId", "visibility"])
+    .index("by_fieldKey_reviewState", ["fieldKey", "reviewState"]),
   eventMediaPrograms: defineTable({
     eventId: v.id("events"),
     communityProfileId: v.optional(v.id("profiles")),

--- a/docs/backend/event-schema.md
+++ b/docs/backend/event-schema.md
@@ -2,7 +2,7 @@
 
 ## Status
 
-Current recommendation and implementation note for `#34`, `#35`, `#36`, `#93`, `#119`, `#121`, `#123`, `#124`, `#132`, and `#134`.
+Current recommendation and implementation note for `#34`, `#35`, `#36`, `#93`, `#119`, `#121`, `#123`, `#124`, `#132`, `#134`, and `#138`.
 
 ## Event Records
 
@@ -105,6 +105,20 @@ The first slot editor uses relative minute offsets from the event start for oper
 First `#121` slice: the event editor can preview and copy one deterministic Discord-ready post generated from the public event projection.
 
 The export includes the event title, canonical `/e/<slug>` URL, host and world names when projected, Discord timestamp tokens for the event time and slot times, slot lineup rows or public participant rows, and projected public media/watch links. It does not post to Discord, run a bot/Gateway flow, use arbitrary user-authored templates, depend on generated short links, or include private operator/media-control state.
+
+## Calendar Import And Export
+
+First `#138` slice: public calendar export is a safe serialization layer, and inbound Google Calendar import is a private staging layer.
+
+The shared ICS serializer supports a single public event export and selected public event feeds. Calendar output is derived from the public event projection and includes event title, UTC start/end timestamps, public summary, canonical VRDex URL, and public host/world location text. It must not include private operator notes, moderation fields, unreviewed imports, hidden profile/world data, or media-control internals.
+
+Reviewed Google Calendar imports use staging tables rather than canonical event writes:
+
+- `eventImportBatches` records the provider, source calendar, external batch or sync job, received timestamp, reviewer state, and importer.
+- `eventImportCandidates` records the imported event identity, timestamps, title, location, description, recurrence hints, cancellation state, review state, publication state, and any later matched canonical event.
+- `eventImportCandidateFields` records field-level values, source labels, optional source URLs, confidence, visibility, and review state.
+
+Google Calendar import preserves selected event provenance and maps only reviewable event facts. It does not import attendees, reminders, hidden calendar metadata, private notes, or arbitrary personal calendars by default. Imported candidates remain `draft_private` until an explicit later review/publication flow accepts the batch, candidate, and public fields.
 
 ## Event Operations Panel
 

--- a/docs/planning/calendar-integration.md
+++ b/docs/planning/calendar-integration.md
@@ -99,13 +99,29 @@ Calendar output should include only public event data that is safe to expose:
 
 Do not include private notes, moderation fields, private contact paths, unreviewed scraped data, or hidden/suppressed entities.
 
-## First Export Slice
+## Implemented Export Slice
 
 Locked decision: the first practical calendar implementation is outbound-only single-event `.ics` export for public event pages.
 
 Published events can be exported from `/e/<slug>/calendar.ics`. The route reads the same public event projection used by `/e/<slug>`, returns `404` when the event is missing or not public, and emits UTC `VEVENT` timestamps with summary, canonical VRDex URL, and public location text derived from visible world or host data.
 
-Current recommendation: keep this as a static export slice. Do not add Google OAuth, import jobs, account calendars, schema changes, or subscription UI until the reviewed-import and follow/favorites models are ready.
+Current recommendation: keep the public export surface static and public-data-only. The shared ICS serializer now supports both a single safe event export and a selected public event feed, but product UI for feed subscriptions should wait until follow, favorites, or community calendar selection exists.
+
+Do not add Google OAuth, account calendars, token storage, or personalized subscription UI until the reviewed-import and follow/favorites models are ready.
+
+## Implemented Import Foundation
+
+Locked decision: Google Calendar import begins as reviewed staging only, not a public event publisher.
+
+The first backend foundation adds Convex staging tables for:
+
+- `eventImportBatches`
+- `eventImportCandidates`
+- `eventImportCandidateFields`
+
+The Google Calendar normalizer maps selected public/operator-owned calendar event fields into private review candidates. It preserves calendar/event IDs, batch or sync job identifiers, source update timestamps, source URLs, title, description, start/end time, timezone, location, public HTTPS links, recurrence hints, and cancellation state.
+
+Imported candidates default to `draft_private` and `unreviewed`. The helper can write staging documents and evaluate publication blockers, but it does not create canonical `events` rows, run background sync jobs, resolve conflicts, or expose an import UI.
 
 ## Inbound Import Rules
 
@@ -122,6 +138,8 @@ Imported candidates should preserve:
 
 Do not import attendees, reminders, private notes, hidden calendar metadata, or arbitrary personal calendars by default.
 
+Imported candidate publication requires a later explicit review flow. Before publication, the batch must be approved, the candidate must be accepted and queued for review-pending publication, public fields must be reviewed, cancelled events must stay blocked, and private source fields must not be promoted as public event facts.
+
 ## Self-Hosting Notes
 
 Self-hosted operators that enable Google Calendar sync or import will need their own Google Cloud OAuth or service-account configuration. Do not hard-code BASIC BIT calendar project IDs or secrets into committed defaults.
@@ -129,8 +147,9 @@ Self-hosted operators that enable Google Calendar sync or import will need their
 ## Non-Goals For First Slice
 
 - building calendar sync now
-- building Google Calendar import now
+- building Google Calendar OAuth, token storage, or background import jobs now
 - final multi-provider calendar abstraction
 - full event-subscription preference UI
 - per-user Google OAuth token storage before the account and event-follow models are ready
 - importing private calendar data before reviewed import workflows and provenance rules are ready
+- publishing imported candidates directly into canonical events

--- a/docs/planning/dependency-map.md
+++ b/docs/planning/dependency-map.md
@@ -233,6 +233,7 @@ This file records the current hard and soft dependency assumptions across the dr
 ### #138 Add calendar import/export workflows for events
 
 - soft dependencies: #34, #41, #76, #89, #117
+- implemented foundation: public event/feed ICS serialization plus Google Calendar review-staging tables and normalizer; OAuth, background sync, subscription UI, and canonical event publication remain follow-on work
 
 ### #137 Consider Notion integration for event planning workflows
 

--- a/tests/backend/event-calendar-imports.test.ts
+++ b/tests/backend/event-calendar-imports.test.ts
@@ -1,0 +1,275 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+
+import type { Id } from "../../convex/_generated/dataModel";
+import {
+  createEventImportDocumentsFromGoogleCalendar,
+  getEventImportPublicationBlockers,
+  normalizeGoogleCalendarImport,
+  type GoogleCalendarImportInput,
+} from "../../convex/_eventCalendarImports";
+
+const GOOGLE_CALENDAR_IMPORT_FIXTURE: GoogleCalendarImportInput = {
+  batchId: "calendar_batch_afterglow_2026_001",
+  calendarId: "afterglow-public-calendar",
+  calendarSummary: "Afterglow Public Events",
+  calendarTimeZone: "America/Los_Angeles",
+  syncJobId: "calendar_sync_afterglow_2026_001",
+  receivedAt: "2026-06-01T12:00:00.000Z",
+  notes: "Operator-selected public events for review.",
+  events: [
+    {
+      id: "google_event_afterglow_harbor",
+      iCalUID: "afterglow-harbor@google.com",
+      status: "confirmed",
+      htmlLink: "https://calendar.google.com/calendar/event?eid=afterglow",
+      summary: "Afterglow Harbor Sessions",
+      description: "Main harbor night. RSVP at https://tickets.example.invalid/afterglow.",
+      location: "Neon Harbor https://worlds.example.invalid/neon-harbor",
+      start: {
+        dateTime: "2026-06-14T15:00:00-07:00",
+        timeZone: "America/Los_Angeles",
+      },
+      end: {
+        dateTime: "2026-06-14T18:30:00-07:00",
+        timeZone: "America/Los_Angeles",
+      },
+      updated: "2026-05-24T12:00:00.000Z",
+      recurringEventId: "google_event_afterglow_series",
+      recurrence: ["RRULE:FREQ=WEEKLY;COUNT=2"],
+      attendees: [{ email: "private-person@example.invalid" }],
+      reminders: { useDefault: true },
+      extendedProperties: { private: { operatorNote: "Do not import" } },
+    },
+  ],
+};
+
+function cloneFixture(): GoogleCalendarImportInput {
+  return structuredClone(GOOGLE_CALENDAR_IMPORT_FIXTURE);
+}
+
+describe("Google Calendar event import normalization", () => {
+  it("creates review-only candidates with provenance and safe public fields", () => {
+    const normalized = normalizeGoogleCalendarImport(cloneFixture());
+    const candidate = normalized.candidates[0];
+
+    assert.equal(normalized.externalBatchId, "calendar_batch_afterglow_2026_001");
+    assert.equal(normalized.provider, "google_calendar");
+    assert.equal(normalized.sourceCalendarId, "afterglow-public-calendar");
+    assert.equal(normalized.sourceCalendarSummary, "Afterglow Public Events");
+    assert.equal(normalized.receivedAt, Date.parse("2026-06-01T12:00:00.000Z"));
+    assert.equal(normalized.reviewState, "draft");
+    assert.equal(candidate?.externalEventId, "google_event_afterglow_harbor");
+    assert.equal(candidate?.externalICalUid, "afterglow-harbor@google.com");
+    assert.equal(candidate?.sourceUpdatedAt, Date.parse("2026-05-24T12:00:00.000Z"));
+    assert.equal(candidate?.sourceUrl, "https://calendar.google.com/calendar/event?eid=afterglow");
+    assert.equal(candidate?.title, "Afterglow Harbor Sessions");
+    assert.equal(candidate?.startAt, Date.parse("2026-06-14T15:00:00-07:00"));
+    assert.equal(candidate?.endAt, Date.parse("2026-06-14T18:30:00-07:00"));
+    assert.equal(candidate?.timezone, "America/Los_Angeles");
+    assert.equal(candidate?.allDay, false);
+    assert.equal(candidate?.reviewState, "unreviewed");
+    assert.equal(candidate?.publicationState, "draft_private");
+    assert.equal(candidate?.cancellationState, "active");
+
+    const fieldsByKey = new Map(candidate?.fields.map((field) => [field.fieldKey, field]));
+
+    assert.equal(fieldsByKey.get("title")?.sourceLabel, "Afterglow Public Events");
+    assert.equal(fieldsByKey.get("title")?.confidence, "medium");
+    assert.equal(fieldsByKey.get("title")?.reviewState, "unreviewed");
+    assert.equal(fieldsByKey.get("title")?.visibility, "public");
+    assert.deepEqual(fieldsByKey.get("links")?.value, [
+      "https://tickets.example.invalid/afterglow",
+      "https://worlds.example.invalid/neon-harbor",
+    ]);
+    assert.equal(fieldsByKey.get("recurringEventId")?.visibility, "private");
+    assert.equal(fieldsByKey.get("sourceStatus")?.visibility, "private");
+    assert.equal(fieldsByKey.has("attendees"), false);
+    assert.equal(fieldsByKey.has("reminders"), false);
+    assert.equal(fieldsByKey.has("extendedProperties"), false);
+  });
+
+  it("creates import staging documents without publishing canonical events", async () => {
+    const inserts: Array<{ table: string; id: string; document: Record<string, unknown> }> = [];
+    const db = {
+      async insert(table: string, document: Record<string, unknown>) {
+        const id = `${table}-${inserts.length + 1}`;
+        inserts.push({ table, id, document });
+        return id;
+      },
+    };
+    const importedBy = {
+      tokenIdentifier: "fixture:calendar-import",
+      issuer: "vrdex:test",
+      subject: "calendar-importer",
+      displayName: "Calendar Importer",
+    };
+
+    const result = await createEventImportDocumentsFromGoogleCalendar(
+      db as never,
+      cloneFixture(),
+      { importedBy, now: 1_788_220_800_000 },
+    );
+
+    assert.equal(result.candidateIds.length, 1);
+    assert.ok(result.fieldIds.length >= 8);
+    assert.equal(inserts.some((insert) => insert.table === "events"), false);
+    assert.equal(inserts[0]?.table, "eventImportBatches");
+    assert.deepEqual(inserts[0]?.document, {
+      externalBatchId: "calendar_batch_afterglow_2026_001",
+      provider: "google_calendar",
+      sourceName: "Afterglow Public Events",
+      sourceCalendarId: "afterglow-public-calendar",
+      sourceCalendarSummary: "Afterglow Public Events",
+      sourceCalendarTimeZone: "America/Los_Angeles",
+      syncJobId: "calendar_sync_afterglow_2026_001",
+      receivedAt: Date.parse("2026-06-01T12:00:00.000Z"),
+      importedBy,
+      reviewState: "draft",
+      notes: "Operator-selected public events for review.",
+      createdAt: 1_788_220_800_000,
+      updatedAt: 1_788_220_800_000,
+    });
+
+    const candidateInsert = inserts.find((insert) => insert.table === "eventImportCandidates");
+    assert.equal(candidateInsert?.document.reviewState, "unreviewed");
+    assert.equal(candidateInsert?.document.publicationState, "draft_private");
+    assert.equal(candidateInsert?.document.cancellationState, "active");
+
+    const fieldInsert = inserts.find(
+      (insert) =>
+        insert.table === "eventImportCandidateFields" &&
+        insert.document.fieldKey === "links",
+    );
+    assert.deepEqual(fieldInsert?.document.value, [
+      "https://tickets.example.invalid/afterglow",
+      "https://worlds.example.invalid/neon-harbor",
+    ]);
+    assert.equal(fieldInsert?.document.visibility, "public");
+  });
+
+  it("handles all-day and cancelled events as private review candidates", () => {
+    const fixture = cloneFixture();
+    fixture.events = [
+      {
+        id: "google_event_cancelled_all_day",
+        status: "cancelled",
+        summary: "Cancelled all-day meetup",
+        start: { date: "2026-07-03" },
+        end: { date: "2026-07-04" },
+      },
+    ];
+
+    const candidate = normalizeGoogleCalendarImport(fixture).candidates[0];
+
+    assert.equal(candidate?.allDay, true);
+    assert.equal(candidate?.startAt, Date.parse("2026-07-03T00:00:00.000Z"));
+    assert.equal(candidate?.endAt, Date.parse("2026-07-04T00:00:00.000Z"));
+    assert.equal(candidate?.timezone, "America/Los_Angeles");
+    assert.equal(candidate?.cancellationState, "cancelled");
+    assert.equal(candidate?.publicationState, "draft_private");
+  });
+
+  it("omits imported end times that do not come after the start time", () => {
+    const fixture = cloneFixture();
+    fixture.events[0]!.end = {
+      dateTime: "2026-06-14T14:00:00-07:00",
+      timeZone: "America/Los_Angeles",
+    };
+
+    const candidate = normalizeGoogleCalendarImport(fixture).candidates[0];
+
+    assert.equal(candidate?.endAt, undefined);
+    assert.equal(candidate?.fields.some((field) => field.fieldKey === "endAt"), false);
+  });
+
+  it("rejects missing ids, unsafe event URLs, and invalid timestamps", () => {
+    const missingBatch = cloneFixture();
+    missingBatch.batchId = " ";
+    assert.throws(() => normalizeGoogleCalendarImport(missingBatch), /batch id/);
+
+    const missingCalendar = cloneFixture();
+    missingCalendar.calendarId = "";
+    assert.throws(() => normalizeGoogleCalendarImport(missingCalendar), /Calendar id/);
+
+    const unsafeUrl = cloneFixture();
+    unsafeUrl.events[0]!.htmlLink = "http://calendar.google.com/calendar/event?eid=afterglow";
+    assert.throws(() => normalizeGoogleCalendarImport(unsafeUrl), /HTTPS URL/);
+
+    const invalidTimestamp = cloneFixture();
+    invalidTimestamp.events[0]!.start = { dateTime: "not-a-date" };
+    assert.throws(() => normalizeGoogleCalendarImport(invalidTimestamp), /ISO timestamp/);
+  });
+});
+
+describe("event import publication guards", () => {
+  const approvedBatch = { reviewState: "approved" as const };
+  const acceptedCandidate = {
+    reviewState: "accepted" as const,
+    publicationState: "review_pending" as const,
+    cancellationState: "active" as const,
+  };
+  const acceptedPublicFields = [
+    {
+      fieldKey: "title",
+      reviewState: "accepted" as const,
+      visibility: "public" as const,
+    },
+    {
+      fieldKey: "startAt",
+      reviewState: "accepted" as const,
+      visibility: "public" as const,
+    },
+  ];
+
+  it("allows a reviewed active event candidate to be queued for later publication", () => {
+    assert.deepEqual(
+      getEventImportPublicationBlockers({
+        batch: approvedBatch,
+        candidate: acceptedCandidate,
+        fields: acceptedPublicFields,
+      }),
+      [],
+    );
+  });
+
+  it("blocks unreviewed, cancelled, already matched, and unsafe candidate data", () => {
+    const blockers = getEventImportPublicationBlockers({
+      batch: { reviewState: "draft" },
+      candidate: {
+        reviewState: "unreviewed",
+        publicationState: "draft_private",
+        cancellationState: "cancelled",
+        matchedEventId: "event_existing" as Id<"events">,
+      },
+      fields: [
+        {
+          fieldKey: "title",
+          reviewState: "unreviewed",
+          visibility: "public",
+        },
+        {
+          fieldKey: "description",
+          reviewState: "needs_correction",
+          visibility: "public",
+        },
+        {
+          fieldKey: "sourceStatus",
+          reviewState: "accepted",
+          visibility: "public",
+        },
+      ],
+    });
+
+    assert.deepEqual(new Set(blockers), new Set([
+      "batch_not_approved",
+      "candidate_not_accepted",
+      "candidate_not_pending_publication",
+      "candidate_cancelled",
+      "candidate_already_matched",
+      "field_unreviewed",
+      "field_needs_correction",
+      "unsafe_public_field",
+    ]));
+  });
+});

--- a/tests/web/calendar-ics.test.ts
+++ b/tests/web/calendar-ics.test.ts
@@ -2,6 +2,7 @@ import assert from "node:assert/strict";
 import { describe, it } from "node:test";
 
 import {
+  createPublicEventFeedIcs,
   createPublicEventIcs,
   escapeIcsText,
   foldIcsLine,
@@ -54,6 +55,44 @@ describe("public event ICS serialization", () => {
     assert.ok(physicalLines.length > 1);
     assert.ok(physicalLines.slice(1).every((line) => line.startsWith(" ")));
     assert.ok(physicalLines.every((line) => new TextEncoder().encode(line).length <= 75));
+  });
+
+  it("serializes a public feed with multiple safe VEVENT entries", () => {
+    const feed = createPublicEventFeedIcs(
+      [
+        {
+          id: "event_afterglow",
+          slug: "afterglow",
+          title: "Afterglow Harbor",
+          startAt: Date.UTC(2026, 5, 14, 22, 0, 0),
+          endAt: Date.UTC(2026, 5, 15, 1, 0, 0),
+          summary: "Public harbor night.",
+          communityName: "Afterglow Social",
+          worlds: [{ displayName: "Neon Harbor" }],
+        },
+        {
+          id: "event_dawn",
+          slug: "dawn-room",
+          title: "Dawn Room",
+          startAt: Date.UTC(2026, 5, 21, 3, 0, 0),
+          worlds: [],
+        },
+      ],
+      {
+        feedName: "VRDex public events",
+        feedUrl: "https://vrdex.example/calendar/events.ics",
+        eventUrl: (event) => `https://vrdex.example/e/${event.slug}`,
+        now: Date.UTC(2026, 4, 24, 12, 0, 0),
+      },
+    );
+    const unfoldedFeed = unfoldIcs(feed);
+
+    assert.match(unfoldedFeed, /X-WR-CALNAME:VRDex public events\r\n/);
+    assert.match(unfoldedFeed, /URL:https:\/\/vrdex\.example\/calendar\/events\.ics\r\n/);
+    assert.equal(unfoldedFeed.match(/BEGIN:VEVENT\r\n/g)?.length, 2);
+    assert.match(unfoldedFeed, /UID:event_afterglow@vrdex\.example\r\n/);
+    assert.match(unfoldedFeed, /UID:event_dawn@vrdex\.example\r\n/);
+    assert.equal(feed.includes("operatorNotes"), false);
   });
 
   it("omits missing or invalid end times and ignores fields outside the public export contract", () => {


### PR DESCRIPTION
## Summary

- add shared public ICS feed serialization alongside the existing single-event export
- add review-only Google Calendar import staging validators, schema tables, document creation helper, and publication blockers
- document the `#138` calendar workflow foundation and remaining non-goals

## Validation

- `node --import tsx --test tests/web/calendar-ics.test.ts tests/backend/event-calendar-imports.test.ts`
- `node --import tsx --test tests/backend/**/*.test.ts`
- `node_modules\.bin\tsc.CMD --noEmit --project convex\tsconfig.json`
- `node_modules\.bin\eslint.CMD src\lib\calendar\ics.ts` from `apps/web`
- `node_modules\.bin\next.CMD typegen`; `node scripts\ensure-next-type-stubs.mjs`; `node_modules\.bin\tsc.CMD --noEmit --incremental false` from `apps/web`
- `node_modules\.bin\markdownlint-cli2.CMD docs\planning\calendar-integration.md docs\backend\event-schema.md docs\planning\dependency-map.md`
- `node scripts/run-convex-local.mjs dev --local --once --run health:status --tail-logs disable`
- `git diff --check`

Part of #138.