### PR TITLE
Add profile asset guard and mock fixture plan

### DIFF
--- a/.github/workflows/terraform.yml
+++ b/.github/workflows/terraform.yml
@@ -297,10 +297,20 @@ jobs:
           account_id="$(aws sts get-caller-identity --query Account --output text)"
           provider_arn="arn:aws:iam::${account_id}:oidc-provider/oidc.vercel.com/${TERRAFORM_PROFILE_ASSETS_VERCEL_TEAM_SLUG}"
 
-          if ! aws iam get-open-id-connect-provider --open-id-connect-provider-arn "$provider_arn" >/tmp/vrdex-profile-assets-oidc-provider.json; then
+          provider_check="$(mktemp)"
+          if ! aws iam get-open-id-connect-provider --open-id-connect-provider-arn "$provider_arn" >"$provider_check" 2>&1; then
+            if grep -q "NoSuchEntity" "$provider_check"; then
+              {
+                echo "## Terraform profile-assets"
+                echo "No existing Vercel OIDC provider was found at \`$provider_arn\`."
+                echo "Terraform may create it during this apply if the CI role has the profile-assets IAM permissions from \`state-mgmt\`."
+              } >> "$GITHUB_STEP_SUMMARY"
+              exit 0
+            fi
+
             {
               echo "## Terraform profile-assets"
-              echo "Apply blocked before planning because the Terraform CI role cannot read the active Vercel OIDC provider."
+              echo "Apply blocked before planning because the Terraform CI role cannot inspect the Vercel OIDC provider."
               echo ""
               echo "Expected provider: \`$provider_arn\`"
               echo ""

--- a/.github/workflows/terraform.yml
+++ b/.github/workflows/terraform.yml
@@ -55,6 +55,7 @@ env:
   TERRAFORM_ROUTE53_ZONE_ID: ${{ vars.TERRAFORM_ROUTE53_ZONE_ID }}
   TERRAFORM_PROFILE_ASSETS_ENABLED: ${{ vars.TERRAFORM_PROFILE_ASSETS_ENABLED }}
   TERRAFORM_PROFILE_ASSETS_STAGING_CUSTOM_ENVIRONMENT_IDS: ${{ vars.TERRAFORM_PROFILE_ASSETS_STAGING_CUSTOM_ENVIRONMENT_IDS }}
+  TERRAFORM_PROFILE_ASSETS_VERCEL_TEAM_SLUG: ${{ vars.TERRAFORM_PROFILE_ASSETS_VERCEL_TEAM_SLUG || 'basicbit' }}
 
 jobs:
   terraform-fmt:
@@ -286,6 +287,28 @@ jobs:
         if: steps.selection.outputs.run == 'true' && steps.gate.outputs.plan_enabled == 'true' && matrix.stack.backend == 'true'
         working-directory: ${{ matrix.stack.path }}
         run: terraform init -reconfigure
+
+      - name: Check profile-assets IAM prerequisites
+        if: steps.selection.outputs.run == 'true' && steps.gate.outputs.apply_enabled == 'true' && matrix.stack.name == 'profile-assets'
+        working-directory: ${{ matrix.stack.path }}
+        run: |
+          set -euo pipefail
+
+          account_id="$(aws sts get-caller-identity --query Account --output text)"
+          provider_arn="arn:aws:iam::${account_id}:oidc-provider/oidc.vercel.com/${TERRAFORM_PROFILE_ASSETS_VERCEL_TEAM_SLUG}"
+
+          if ! aws iam get-open-id-connect-provider --open-id-connect-provider-arn "$provider_arn" >/tmp/vrdex-profile-assets-oidc-provider.json; then
+            {
+              echo "## Terraform profile-assets"
+              echo "Apply blocked before planning because the Terraform CI role cannot read the active Vercel OIDC provider."
+              echo ""
+              echo "Expected provider: \`$provider_arn\`"
+              echo ""
+              echo "Apply \`infra/terraform/state-mgmt\` from a trusted operator machine before applying \`profile-assets\`."
+              echo "If the provider already exists outside this stack, import it into \`infra/terraform/profile-assets\` state before rerunning."
+            } >> "$GITHUB_STEP_SUMMARY"
+            exit 1
+          fi
 
       - name: Plan
         if: steps.selection.outputs.run == 'true' && steps.gate.outputs.plan_enabled == 'true'

--- a/apps/web/src/app/api/v0/profile-assets/upload-intents/probe/route.ts
+++ b/apps/web/src/app/api/v0/profile-assets/upload-intents/probe/route.ts
@@ -1,0 +1,38 @@
+import { NextResponse } from "next/server";
+
+import { probeProfileAssetStorage } from "@/lib/server/profile-asset-storage";
+
+export const dynamic = "force-dynamic";
+
+export async function GET() {
+  const checkedAt = new Date().toISOString();
+  const result = await probeProfileAssetStorage();
+
+  if (!result.configured) {
+    return NextResponse.json(
+      {
+        checkedAt,
+        configured: false,
+        storageReachable: false,
+      },
+      { status: 501 },
+    );
+  }
+
+  if (!result.reachable) {
+    return NextResponse.json(
+      {
+        checkedAt,
+        configured: true,
+        storageReachable: false,
+      },
+      { status: 503 },
+    );
+  }
+
+  return NextResponse.json({
+    checkedAt,
+    configured: true,
+    storageReachable: true,
+  });
+}

--- a/apps/web/src/lib/server/profile-asset-storage.ts
+++ b/apps/web/src/lib/server/profile-asset-storage.ts
@@ -1,4 +1,4 @@
-import { GetObjectCommand, PutObjectCommand, S3Client } from "@aws-sdk/client-s3";
+import { GetObjectCommand, HeadObjectCommand, PutObjectCommand, S3Client } from "@aws-sdk/client-s3";
 import { awsCredentialsProvider } from "@vercel/oidc-aws-credentials-provider";
 
 type StorageConfig = {
@@ -12,7 +12,22 @@ type StoredObject = {
   contentLength?: number;
 };
 
+type StorageProbeResult =
+  | {
+      configured: false;
+      reachable: false;
+    }
+  | {
+      configured: true;
+      reachable: true;
+    }
+  | {
+      configured: true;
+      reachable: false;
+    };
+
 const cachedClients = new Map<string, S3Client>();
+const PROFILE_ASSET_STORAGE_PROBE_KEY = "profile-assets/.vrdex-storage-probe";
 
 function vercelOidcRoleArn(): string | undefined {
   const roleArn = process.env.VRDEX_PROFILE_ASSET_ROLE_ARN;
@@ -53,6 +68,45 @@ function s3Client(config: StorageConfig): S3Client {
 
 export function isProfileAssetStorageConfigured(): boolean {
   return storageConfig() !== null;
+}
+
+function isMissingObjectError(error: unknown): boolean {
+  if (typeof error !== "object" || error === null) {
+    return false;
+  }
+
+  const name = "name" in error ? String(error.name) : "";
+  const metadata =
+    "$metadata" in error && typeof error.$metadata === "object" && error.$metadata !== null
+      ? (error.$metadata as { httpStatusCode?: number })
+      : null;
+
+  return name === "NoSuchKey" || name === "NotFound" || metadata?.httpStatusCode === 404;
+}
+
+export async function probeProfileAssetStorage(): Promise<StorageProbeResult> {
+  const config = storageConfig();
+
+  if (config === null) {
+    return { configured: false, reachable: false };
+  }
+
+  try {
+    await s3Client(config).send(
+      new HeadObjectCommand({
+        Bucket: config.bucket,
+        Key: PROFILE_ASSET_STORAGE_PROBE_KEY,
+      }),
+    );
+
+    return { configured: true, reachable: true };
+  } catch (error) {
+    if (isMissingObjectError(error)) {
+      return { configured: true, reachable: true };
+    }
+
+    return { configured: true, reachable: false };
+  }
 }
 
 export async function putProfileAssetObject(input: {

--- a/apps/web/src/lib/server/profile-asset-storage.ts
+++ b/apps/web/src/lib/server/profile-asset-storage.ts
@@ -76,12 +76,7 @@ function isMissingObjectError(error: unknown): boolean {
   }
 
   const name = "name" in error ? String(error.name) : "";
-  const metadata =
-    "$metadata" in error && typeof error.$metadata === "object" && error.$metadata !== null
-      ? (error.$metadata as { httpStatusCode?: number })
-      : null;
-
-  return name === "NoSuchKey" || name === "NotFound" || metadata?.httpStatusCode === 404;
+  return name === "NoSuchKey" || name === "NotFound";
 }
 
 export async function probeProfileAssetStorage(): Promise<StorageProbeResult> {

--- a/docs/deployment/aws-baseline.md
+++ b/docs/deployment/aws-baseline.md
@@ -74,6 +74,15 @@ The first asset-storage implementation uses:
 
 Do not make profile asset buckets public. Public profile pages should render through a controlled URL path that can enforce profile visibility, moderation suppression, replacement, and deletion behavior.
 
+Operational probe:
+
+- `GET /api/v0/profile-assets/upload-intents/probe` returns `501` when runtime
+  storage environment variables are missing.
+- A configured environment performs a lightweight private S3 `HeadObject` check
+  against a sentinel key and returns `200` when storage auth is reachable.
+- The probe returns only coarse health state and does not expose bucket names,
+  role ARNs, or object keys.
+
 Terraform/runtime baseline:
 
 - Terraform stack: `infra/terraform/profile-assets`

--- a/docs/deployment/aws-baseline.md
+++ b/docs/deployment/aws-baseline.md
@@ -80,6 +80,9 @@ Operational probe:
   storage environment variables are missing.
 - A configured environment performs a lightweight private S3 `HeadObject` check
   against a sentinel key and returns `200` when storage auth is reachable.
+- The runtime role includes narrow `s3:ListBucket` permission for only that
+  sentinel key prefix so a missing sentinel is reported as an object-level miss,
+  not as an authorization failure.
 - The probe returns only coarse health state and does not expose bucket names,
   role ARNs, or object keys.
 

--- a/docs/planning/README.md
+++ b/docs/planning/README.md
@@ -13,6 +13,7 @@ Planning docs capture product, architecture, roadmap, and backlog decisions befo
 - `docs/planning/restreaming-media-control.md` - restreaming, VRCDN-first media control, worker architecture, CDN economics, and Discord operator-control direction
 - `docs/planning/genre-graph.md` - genre ontology, alias normalization, and recommendation graph direction
 - `docs/planning/seed-import-model.md` - reviewed partner/list seed-import model and fake fixture shape
+- `docs/planning/mock-profile-fixtures.md` - mock profile fixture strategy, consented showcase allowlists, and group representation direction
 - `docs/planning/world-discovery.md` - world pages, creator attribution, active-world discovery, and creator-commerce boundaries
 - `docs/planning/marketplace-api-research.md` - marketplace sync gate, provider posture, and disallowed storefront data
 - `docs/planning/engineering-strategy.md` - stack, testing, verification, and agentic factory plan

--- a/docs/planning/mock-profile-fixtures.md
+++ b/docs/planning/mock-profile-fixtures.md
@@ -1,0 +1,108 @@
+# Mock Profile Fixtures
+
+## Status
+
+Current recommendation for deterministic profile demos, tests, and showcase
+data. This extends the reviewed seed-import model without authorizing real
+confidential data in git.
+
+## Locked Decisions
+
+- Do not commit real friend, partner, roster, contact, or profile data to git.
+- Fake fixtures must stay obviously fake and use `.invalid` URLs or checked-in
+  local fixture assets.
+- Consented real production profiles are operational data, not repository
+  fixtures.
+- Public profile, search, API, MCP, export, and discovery queries should exclude
+  mock records unless a caller intentionally requests the mock fixture surface.
+
+## Current Recommendation
+
+Add `isMock` to root public entities that can be seeded for deterministic
+fixtures:
+
+- `profiles`
+- `events`
+- `worlds`
+- future root entities that can appear independently in public search or public
+  pages
+
+Default `isMock` to `false`. Treat missing values as false during migrations so
+existing production data remains visible. Shared query helpers should filter
+`isMock !== true` by default, and fixture routes or test helpers should opt into
+mock data through an explicit option instead of ad hoc query rewrites.
+
+For public/demo substitution, prefer an explicit request shape such as
+`?data=mock` on the profile list/discovery surface. That mode should return
+mock results instead of ordinary production results, not silently blend the two,
+unless a future demo surface deliberately asks for a mixed result set.
+
+## Consented Real Showcase Profiles
+
+Do not add a broad `appearsInMockResults` field to every entity. Use a narrow
+allowlist table for the rare case where a real, consented profile should appear
+in a mock/demo surface:
+
+- `entityType`: initially `profile`
+- `entityId`
+- `surface`: for example `dj_list_demo`
+- `enabled`
+- `reason` or internal note
+- `createdBy`
+- `createdAt`
+- optional `expiresAt`
+
+This keeps ordinary profile records clean, avoids polluting every table with a
+showcase flag, and lets operators revoke demo inclusion without editing the
+profile itself. The allowlist must never imply that the profile is fake; it only
+means the real profile may appear on an explicitly requested mock/demo surface.
+
+## Query Rules
+
+- Default public reads: exclude `isMock === true`.
+- Explicit mock reads: include only `isMock === true` plus explicitly allowlisted
+  real records for that surface.
+- Tests: seed fake records with `isMock === true` and assert default queries do
+  not return them.
+- Production manual profile operations: keep real consented data as `isMock ===
+  false`; use the showcase allowlist only when the real profile is approved for
+  a demo surface.
+
+## Group Representation
+
+Current recommendation:
+
+- Keep `person` and `community` as the two root profile types.
+- Model artist groups, collectives, labels, venues, and clubs as `community`
+  profiles with flexible subtype/category tags.
+- Add relationship edges rather than overloading person profiles when a person
+  represents or performs as part of a group.
+
+Candidate direction:
+
+- Add a `profileRepresentations` or broader `profileRelationships` table with
+  `fromProfileId`, `toProfileId`, `relationshipType`, `label`, visibility,
+  source, claim/review state, and timestamps.
+- Use relationship types such as `member_of`, `represents`, `resident_at`, and
+  `booking_contact_for` only after real workflows justify them.
+- Let public pages render selected relationships as concise links, not as
+  explanatory trust copy.
+
+Interview later:
+
+- Whether artist duos should usually be community profiles, person aliases, or
+  both.
+- Whether an individual owner account should be able to claim both a person
+  profile and an artist-group profile in one flow.
+- Whether demo surfaces need mixed fake-plus-real results, or whether strict
+  substitution is enough.
+
+## Suggested Slices
+
+1. Add `isMock` to root public entities and centralize default filtering.
+2. Add a mock/demo profile query mode for the DJ list using existing fake
+   fixtures.
+3. Add a narrow real-profile demo allowlist table and operator mutation.
+4. Add tests proving default public reads exclude mock records.
+5. Add profile relationship planning or schema once group representation is
+   needed by a real profile workflow.

--- a/infra/terraform/README.md
+++ b/infra/terraform/README.md
@@ -39,10 +39,12 @@ Required CI settings by provider:
 
 `state-mgmt/` is validation-only in CI because it intentionally uses local bootstrap state and owns the GitHub Actions AWS role used by the provider-backed stacks. Apply it manually when changing the shared state bucket or Terraform CI role, then store `terraform output -raw github_actions_terraform_role_arn` in GitHub variable `AWS_TERRAFORM_ROLE_ARN`.
 
-The `profile-assets` apply path checks that the Terraform CI role can read the
-active Vercel OIDC provider before planning an apply. If that guard fails, apply
-`state-mgmt/` locally from a trusted operator machine and import any preexisting
-OIDC provider into the `profile-assets` remote state before rerunning the stack.
+The `profile-assets` apply path checks whether a preexisting Vercel OIDC
+provider is readable before planning an apply. A missing provider is allowed so
+Terraform can create it on first run. If the guard fails for any other reason,
+apply `state-mgmt/` locally from a trusted operator machine and import any
+preexisting OIDC provider into the `profile-assets` remote state before
+rerunning the stack.
 
 ## Stack Boundaries
 

--- a/infra/terraform/README.md
+++ b/infra/terraform/README.md
@@ -35,8 +35,14 @@ Required CI settings by provider:
 | `TERRAFORM_ROUTE53_ZONE_ID` | optional repository variable | `docs-site`, `ses` |
 | `TERRAFORM_PROFILE_ASSETS_ENABLED=true` | repository variable | `profile-assets` after `state-mgmt` has been applied with profile asset permissions |
 | `TERRAFORM_PROFILE_ASSETS_STAGING_CUSTOM_ENVIRONMENT_IDS` | optional repository variable | `profile-assets`; HCL list of Vercel custom environment IDs, for example `["env_..."]` |
+| `TERRAFORM_PROFILE_ASSETS_VERCEL_TEAM_SLUG` | optional repository variable | `profile-assets`; defaults to `basicbit` for the hosted Vercel OIDC provider guard |
 
 `state-mgmt/` is validation-only in CI because it intentionally uses local bootstrap state and owns the GitHub Actions AWS role used by the provider-backed stacks. Apply it manually when changing the shared state bucket or Terraform CI role, then store `terraform output -raw github_actions_terraform_role_arn` in GitHub variable `AWS_TERRAFORM_ROLE_ARN`.
+
+The `profile-assets` apply path checks that the Terraform CI role can read the
+active Vercel OIDC provider before planning an apply. If that guard fails, apply
+`state-mgmt/` locally from a trusted operator machine and import any preexisting
+OIDC provider into the `profile-assets` remote state before rerunning the stack.
 
 ## Stack Boundaries
 

--- a/infra/terraform/profile-assets/README.md
+++ b/infra/terraform/profile-assets/README.md
@@ -43,10 +43,11 @@ Before enabling that gate, apply `infra/terraform/state-mgmt` so the GitHub Acti
 5. Redeploy the Vercel production and staging environments so functions receive the new environment variables.
 6. Probe `/api/v0/profile-assets/upload-intents/probe`; a configured environment should no longer return `501`.
 
-The Terraform workflow blocks `profile-assets` applies when the GitHub Actions
-Terraform role cannot read the active Vercel OIDC provider. Apply
-`infra/terraform/state-mgmt` locally first, and import any preexisting provider
-into this stack's remote state before rerunning apply.
+The Terraform workflow allows Terraform to create a missing Vercel OIDC
+provider, but blocks `profile-assets` applies when the GitHub Actions Terraform
+role cannot inspect a preexisting provider. Apply `infra/terraform/state-mgmt`
+locally first, and import any preexisting provider into this stack's remote
+state before rerunning apply.
 
 ## State Backend
 

--- a/infra/terraform/profile-assets/README.md
+++ b/infra/terraform/profile-assets/README.md
@@ -43,6 +43,11 @@ Before enabling that gate, apply `infra/terraform/state-mgmt` so the GitHub Acti
 5. Redeploy the Vercel production and staging environments so functions receive the new environment variables.
 6. Probe `/api/v0/profile-assets/upload-intents/probe`; a configured environment should no longer return `501`.
 
+The Terraform workflow blocks `profile-assets` applies when the GitHub Actions
+Terraform role cannot read the active Vercel OIDC provider. Apply
+`infra/terraform/state-mgmt` locally first, and import any preexisting provider
+into this stack's remote state before rerunning apply.
+
 ## State Backend
 
 Terraform state for this stack is stored in the S3 backend declared in `versions.tf`:

--- a/infra/terraform/profile-assets/main.tf
+++ b/infra/terraform/profile-assets/main.tf
@@ -8,6 +8,7 @@ data "vercel_project" "web" {
 locals {
   asset_bucket_name = var.asset_bucket_name != null ? var.asset_bucket_name : "vrdex-profile-assets-${data.aws_caller_identity.current.account_id}"
   object_prefix     = "profile-assets/"
+  storage_probe_key = "${local.object_prefix}.vrdex-storage-probe"
 
   vercel_oidc_issuer_path = "oidc.vercel.com/${var.vercel_team_slug}"
   vercel_oidc_issuer_url  = "https://${local.vercel_oidc_issuer_path}"
@@ -141,6 +142,21 @@ resource "aws_iam_role" "vercel_profile_assets" {
 }
 
 data "aws_iam_policy_document" "vercel_profile_assets" {
+  statement {
+    sid = "CheckProfileAssetStorageProbe"
+    actions = [
+      "s3:ListBucket",
+    ]
+
+    resources = [aws_s3_bucket.profile_assets.arn]
+
+    condition {
+      test     = "StringEquals"
+      variable = "s3:prefix"
+      values   = [local.storage_probe_key]
+    }
+  }
+
   statement {
     sid = "ReadAndWriteProfileAssets"
     actions = [


### PR DESCRIPTION
## Summary

- Add a profile asset storage probe endpoint for production and preview smoke checks.
- Add a Terraform workflow guard that fails `profile-assets` applies early when the Terraform CI role cannot read the expected Vercel OIDC provider.
- Document the profile-assets guard and the mock-profile fixture direction, including the `isMock` model, demo allowlist shape, and group representation follow-up.

## Why

The profile-assets stack recovered after a manual state import, but the failure mode was too easy to repeat: CI could get as far as planning/applying before discovering IAM could not read or manage the active Vercel OIDC provider. This adds a direct preflight and gives operators a small runtime probe for storage health without exposing bucket names, keys, ARNs, or credentials.

The mock-profile planning note captures the agreed direction without committing confidential friend/profile data to git.

## Validation

- `eslint` on the touched web files from `apps/web`
- `markdownlint-cli2`
- `pnpm --filter web typecheck`
- `git diff --check`
- Read-only production checks confirmed the G-Catz S3 object and asset API/file endpoints still return 200 after the Terraform repair.