### PR TITLE
Fix private seed lookup suggestions

### DIFF
--- a/apps/web/e2e/public-routes.smoke.spec.ts
+++ b/apps/web/e2e/public-routes.smoke.spec.ts
@@ -129,4 +129,16 @@ test.describe("fixture lookup smoke", () => {
     await page.getByLabel("DJ name").focus();
     await expect(page.getByRole("option", { name: /BASICBIT/i })).toBeVisible();
   });
+
+  test("lookup suggestions include authorized private seed rows", async ({ page }) => {
+    await page.goto("/lookup");
+    await page.getByLabel("DJ name").fill("nwinn");
+
+    const privateOption = page.getByRole("option", { name: /DJ Northstar.*Private seed.*NWinn/i });
+
+    await expect(privateOption).toBeVisible();
+    await privateOption.click();
+    await expect(page).toHaveURL(/\/lookup\?q=DJ%20Northstar$/);
+    await expect(page.locator(".lookup-result-card.lookup-private-result").filter({ hasText: "DJ Northstar" })).toBeVisible();
+  });
 });

--- a/apps/web/src/app/_components/lookup-search-box.tsx
+++ b/apps/web/src/app/_components/lookup-search-box.tsx
@@ -3,33 +3,51 @@
 import Image from "next/image";
 import { useDeferredValue, useEffect, useMemo, useRef, useState, useTransition } from "react";
 
-import type { PublicProfileLookupResult } from "./profile-lookup-page";
+import type {
+  PrivateSeedLookupResult,
+  ProfileLookupDisplayResult,
+  PublicProfileLookupResult,
+  SeedLookupViewerAccess,
+} from "./profile-lookup-page";
 import { Input, Textarea } from "@/components/ui/field";
 
 type LookupSuggestionResponse = {
+  privateResults: PrivateSeedLookupResult[];
   results: PublicProfileLookupResult[];
+  viewerAccess: SeedLookupViewerAccess;
 };
 
 type FetchedSuggestions = {
   query: string;
-  results: PublicProfileLookupResult[];
+  results: ProfileLookupDisplayResult[];
 };
 
 const RECENT_SEARCH_LIMIT = 5;
 const RECENT_SEARCHES_STORAGE_KEY = "vrdex.lookup.recentSearches";
 
-function profileOptionLabel(profile: PublicProfileLookupResult): string {
+function isPrivateSuggestion(
+  profile: ProfileLookupDisplayResult,
+): profile is PrivateSeedLookupResult {
+  return "publicationState" in profile;
+}
+
+function profileOptionLabel(profile: ProfileLookupDisplayResult): string {
+  if (isPrivateSuggestion(profile)) {
+    return profile.source?.name ? `Private seed - ${profile.source.name}` : "Private seed";
+  }
+
   const context = [...new Set([...profile.roleTags, ...profile.tags])].slice(0, 3).join(" / ");
 
   return context || profile.profilePath;
 }
 
-function SuggestionAvatar({ profile }: { profile: PublicProfileLookupResult }) {
+function SuggestionAvatar({ profile }: { profile: ProfileLookupDisplayResult }) {
   const initials = profile.displayName.trim().slice(0, 2).toUpperCase();
+  const avatarImageUrl = isPrivateSuggestion(profile) ? undefined : profile.avatarImageUrl;
 
   return (
     <span className="lookup-suggestion-avatar" aria-hidden="true">
-      {profile.avatarImageUrl ? <Image alt="" height={38} src={profile.avatarImageUrl} unoptimized width={38} /> : <span>{initials}</span>}
+      {avatarImageUrl ? <Image alt="" height={38} src={avatarImageUrl} unoptimized width={38} /> : <span>{initials}</span>}
     </span>
   );
 }
@@ -105,13 +123,15 @@ export function LookupSearchBox({
   onBulkLookup,
   onClear,
   onLookup,
+  showPrivateSuggestions,
 }: {
   initialQuery: string;
-  initialResults: PublicProfileLookupResult[];
+  initialResults: ProfileLookupDisplayResult[];
   isSearching: boolean;
   onBulkLookup: (lines: string[]) => void;
   onClear: () => void;
   onLookup: (query: string) => void;
+  showPrivateSuggestions: boolean;
 }) {
   const [query, setQuery] = useState(initialQuery);
   const [bulkMode, setBulkMode] = useState(false);
@@ -158,13 +178,25 @@ export function LookupSearchBox({
     fetch(`/lookup/suggest?q=${encodeURIComponent(deferredQuery)}`, { signal: controller.signal })
       .then(async (response) => {
         if (!response.ok) {
-          return { results: [] } satisfies LookupSuggestionResponse;
+          return {
+            privateResults: [],
+            results: [],
+            viewerAccess: { allowed: false, source: "signed_out" },
+          } satisfies LookupSuggestionResponse;
         }
 
         return await response.json() as LookupSuggestionResponse;
       })
       .then((data) => {
-        startTransition(() => setFetchedSuggestions({ query: deferredQuery, results: data.results }));
+        const privateSuggestionsEnabled = showPrivateSuggestions || data.viewerAccess.source === "super_admin";
+        const privateResults = privateSuggestionsEnabled && data.viewerAccess.allowed
+          ? data.privateResults
+          : [];
+
+        startTransition(() => setFetchedSuggestions({
+          query: deferredQuery,
+          results: [...data.results, ...privateResults],
+        }));
       })
       .catch((error: unknown) => {
         if (error instanceof DOMException && error.name === "AbortError") {
@@ -175,7 +207,7 @@ export function LookupSearchBox({
       });
 
     return () => controller.abort();
-  }, [bulkMode, deferredQuery, normalizedInitialQuery]);
+  }, [bulkMode, deferredQuery, normalizedInitialQuery, showPrivateSuggestions]);
 
   useEffect(() => {
     if (!bulkMode) {
@@ -359,7 +391,7 @@ export function LookupSearchBox({
                 {suggestions.map((profile) => (
                   <button
                     className="lookup-suggestion-option"
-                    key={profile.slug}
+                    key={isPrivateSuggestion(profile) ? `private:${profile.id}` : `public:${profile.slug}`}
                     type="button"
                     role="option"
                     aria-selected={false}

--- a/apps/web/src/app/_components/profile-lookup-page.tsx
+++ b/apps/web/src/app/_components/profile-lookup-page.tsx
@@ -1187,11 +1187,15 @@ function ProfileLookupPageContent({
           </div>
           <LookupSearchBox
             initialQuery={displayQuery}
-            initialResults={displayResults}
+            initialResults={[
+              ...displayResults,
+              ...(seedViewerAccess.allowed && privateUiEnabled ? displayPrivateResults : []),
+            ]}
             isSearching={isSearching}
             onBulkLookup={runBulkLookup}
             onClear={clearLookup}
             onLookup={runLookup}
+            showPrivateSuggestions={seedViewerAccess.allowed && privateUiEnabled}
           />
         </section>
 

--- a/apps/web/src/convex/playwright-fixtures.ts
+++ b/apps/web/src/convex/playwright-fixtures.ts
@@ -1184,7 +1184,7 @@ export function getPlaywrightProfileLookupFixture(query: string): PlaywrightProf
     return { kind: "handled", results: [] };
   }
 
-  if (normalized === "nwinn") {
+  if (normalized === "nwinn" || normalized === "dj northstar") {
     const sourceObservedAt = Date.UTC(2025, 10, 2);
     const lastCheckedAt = Date.UTC(2026, 6, 8);
     const reviewedAt = Date.UTC(2026, 6, 9);

--- a/apps/web/src/convex/server.ts
+++ b/apps/web/src/convex/server.ts
@@ -16,6 +16,12 @@ import {
 
 const seedAccessApi = (api as unknown as {
   seedAccess: {
+    lookupPeople: FunctionReference<
+      "query",
+      "public",
+      { query: string; limit?: number },
+      PrivateSeedLookupResult[]
+    >;
     viewerAccess: FunctionReference<"query", "public", Record<string, never>, SeedLookupViewerAccess>;
   };
 }).seedAccess;
@@ -310,9 +316,15 @@ export async function fetchProfileLookup(query: string) {
       ? fetchQuery(seedAccessApi.viewerAccess, {}, { token })
       : Promise.resolve(signedOutSeedAccess);
     const [results, viewerAccess] = await Promise.all([publicResultsPromise, viewerAccessPromise]);
+    const privateResults = fixturePrivateResults ?? (
+      token && query && viewerAccess.allowed
+        ? await fetchQuery(seedAccessApi.lookupPeople, { query, limit: 12 }, { token })
+        : []
+    );
+
     return {
       kind: "live" as const,
-      privateResults: fixturePrivateResults ?? [] as PrivateSeedLookupResult[],
+      privateResults,
       results,
       viewerAccess,
     };


### PR DESCRIPTION
## Summary

- populate authenticated private seed candidates in the lookup suggestion response
- render private candidates in the lookahead for super-admins and feature-flagged authorized users
- preserve anonymous/public-only suggestion behavior
- label private options with their source and select them through the normal lookup flow

## Root cause

The suggestion route exposed a private-results field but server lookup never populated it. The search-box client also modeled and rendered only public profile results, so private candidates could appear after submitting a lookup but never in the lookahead.

## Validation

- `corepack pnpm typecheck:web`
- `corepack pnpm lint:web`
- `corepack pnpm test:web` (132 passing)
- `corepack pnpm --filter web test:e2e --grep "authorized private seed rows"` (desktop and mobile passing)

The authenticated Convex feature grant remains the authorization boundary. PostHog controls beta UI rollout only; super-admin access bypasses that UI flag.