### PR TITLE
Improve lookup typeahead matching

### DIFF
--- a/apps/web/e2e/public-routes.smoke.spec.ts
+++ b/apps/web/e2e/public-routes.smoke.spec.ts
@@ -143,4 +143,16 @@ test.describe("fixture lookup smoke", () => {
     await expect(page).toHaveURL(/\/lookup\?q=DJ%20Northstar$/);
     await expect(page.locator(".lookup-result-card.lookup-private-result").filter({ hasText: "DJ Northstar" })).toBeVisible();
   });
+
+  test("bulk lookup summaries dedupe overlapping public and private rows", async ({ page }) => {
+    await page.goto("/lookup");
+    await page.getByRole("button", { name: "Bulk" }).click();
+    await page.getByLabel("Lineup text").fill("BASICBIT");
+    await page.getByRole("button", { name: "Lookup lineup" }).click();
+
+    const summaryRow = page.locator(".lookup-bulk-row").filter({ hasText: "BASICBIT" });
+
+    await expect(summaryRow).toBeVisible();
+    await expect(summaryRow.locator(".text-sm")).toHaveText("BASICBIT");
+  });
 });

--- a/apps/web/e2e/public-routes.smoke.spec.ts
+++ b/apps/web/e2e/public-routes.smoke.spec.ts
@@ -105,9 +105,11 @@ test.describe("fixture lookup smoke", () => {
 
   test("lookup suggestions select a public person row", async ({ page }) => {
     await page.goto("/lookup");
-    await page.getByLabel("DJ name").fill("bas");
-    await expect(page.getByRole("option", { name: /BASICBIT/i })).toBeVisible();
-    await page.getByRole("option", { name: /BASICBIT/i }).click();
+    await page.getByLabel("DJ name").fill("b");
+    const basicBitOption = page.getByRole("option", { name: /BASICBIT/i });
+    await expect(basicBitOption).toHaveCount(1);
+    await expect(basicBitOption).not.toContainText("Private seed");
+    await basicBitOption.click();
     await expect(page).toHaveURL(/\/lookup\?q=BASICBIT$/);
     await expect(page.getByRole("link", { name: "BASICBIT", exact: true })).toBeVisible();
     await expect(page.getByRole("link", { name: "Website: basicbit.net", exact: true })).toBeVisible();

--- a/apps/web/src/app/_components/lookup-search-box.tsx
+++ b/apps/web/src/app/_components/lookup-search-box.tsx
@@ -9,6 +9,7 @@ import type {
   PublicProfileLookupResult,
   SeedLookupViewerAccess,
 } from "./profile-lookup-page";
+import { mergeLookupSuggestions } from "./lookup-suggestion-merge";
 import { Input, Textarea } from "@/components/ui/field";
 
 type LookupSuggestionResponse = {
@@ -151,7 +152,7 @@ export function LookupSearchBox({
     deferredQuery.startsWith(fetchedSuggestions.query) || fetchedSuggestions.query.startsWith(deferredQuery)
   );
   const suggestions =
-    bulkMode || deferredQuery.length < 2
+    bulkMode || deferredQuery.length < 1
       ? []
       : deferredQuery === normalizedInitialQuery
         ? initialResults
@@ -169,7 +170,7 @@ export function LookupSearchBox({
   }, []);
 
   useEffect(() => {
-    if (bulkMode || deferredQuery.length < 2 || deferredQuery === normalizedInitialQuery) {
+    if (bulkMode || deferredQuery.length < 1 || deferredQuery === normalizedInitialQuery) {
       return;
     }
 
@@ -195,7 +196,7 @@ export function LookupSearchBox({
 
         startTransition(() => setFetchedSuggestions({
           query: deferredQuery,
-          results: [...data.results, ...privateResults],
+          results: mergeLookupSuggestions(data.results, privateResults),
         }));
       })
       .catch((error: unknown) => {

--- a/apps/web/src/app/_components/lookup-suggestion-merge.ts
+++ b/apps/web/src/app/_components/lookup-suggestion-merge.ts
@@ -4,6 +4,8 @@ import type {
   PublicProfileLookupResult,
 } from "./profile-lookup-page";
 
+const CASE_INSENSITIVE_PATH_HOSTS = new Set(["twitch.tv"]);
+
 function normalizeIdentityText(value: string): string {
   return value.trim().replace(/\s+/g, " ").toLowerCase();
 }
@@ -15,6 +17,9 @@ function normalizeLookupUrl(value: string): string | null {
     const hostname = url.hostname.toLowerCase();
     url.hostname = hostname.startsWith("www.") ? hostname.slice(4) : hostname;
     url.pathname = url.pathname.replace(/\/+$/, "") || "/";
+    if (CASE_INSENSITIVE_PATH_HOSTS.has(url.hostname)) {
+      url.pathname = url.pathname.toLowerCase();
+    }
     return url.toString();
   } catch {
     return null;

--- a/apps/web/src/app/_components/lookup-suggestion-merge.ts
+++ b/apps/web/src/app/_components/lookup-suggestion-merge.ts
@@ -12,7 +12,8 @@ function normalizeLookupUrl(value: string): string | null {
   try {
     const url = new URL(value);
     url.hash = "";
-    url.hostname = url.hostname.toLowerCase();
+    const hostname = url.hostname.toLowerCase();
+    url.hostname = hostname.startsWith("www.") ? hostname.slice(4) : hostname;
     url.pathname = url.pathname.replace(/\/+$/, "") || "/";
     return url.toString();
   } catch {

--- a/apps/web/src/app/_components/lookup-suggestion-merge.ts
+++ b/apps/web/src/app/_components/lookup-suggestion-merge.ts
@@ -1,0 +1,74 @@
+import type {
+  PrivateSeedLookupResult,
+  ProfileLookupDisplayResult,
+  PublicProfileLookupResult,
+} from "./profile-lookup-page";
+
+function normalizeIdentityText(value: string): string {
+  return value.trim().replace(/\s+/g, " ").toLowerCase();
+}
+
+function normalizeLookupUrl(value: string): string | null {
+  try {
+    const url = new URL(value);
+    url.hash = "";
+    url.hostname = url.hostname.toLowerCase();
+    url.pathname = url.pathname.replace(/\/+$/, "") || "/";
+    return url.toString();
+  } catch {
+    return null;
+  }
+}
+
+function privateSeedOutboundUrls(profile: PrivateSeedLookupResult): Set<string> {
+  const urls = new Set<string>();
+
+  for (const field of profile.fields) {
+    if (field.fieldKey !== "outboundLinks" || !Array.isArray(field.value)) {
+      continue;
+    }
+
+    for (const link of field.value) {
+      if (typeof link !== "object" || link === null || !("url" in link) || typeof link.url !== "string") {
+        continue;
+      }
+
+      const normalized = normalizeLookupUrl(link.url);
+      if (normalized) {
+        urls.add(normalized);
+      }
+    }
+  }
+
+  return urls;
+}
+
+export function mergeLookupSuggestions(
+  publicResults: PublicProfileLookupResult[],
+  privateResults: PrivateSeedLookupResult[],
+): ProfileLookupDisplayResult[] {
+  const publicSlugs = new Set(publicResults.map((profile) => normalizeIdentityText(profile.slug)));
+  const publicIdentities = publicResults.map((profile) => ({
+    names: new Set([profile.displayName, ...profile.aliases].map(normalizeIdentityText)),
+    urls: new Set(
+      profile.outboundLinks
+        .map((link) => normalizeLookupUrl(link.url))
+        .filter((url): url is string => url !== null),
+    ),
+  }));
+  const uniquePrivateResults = privateResults.filter((profile) => {
+    if (profile.proposedSlug && publicSlugs.has(normalizeIdentityText(profile.proposedSlug))) {
+      return false;
+    }
+
+    const displayName = normalizeIdentityText(profile.displayName);
+    const privateUrls = privateSeedOutboundUrls(profile);
+
+    return !publicIdentities.some((publicProfile) => (
+      publicProfile.names.has(displayName) &&
+      [...privateUrls].some((url) => publicProfile.urls.has(url))
+    ));
+  });
+
+  return [...publicResults, ...uniquePrivateResults];
+}

--- a/apps/web/src/app/_components/profile-lookup-page.tsx
+++ b/apps/web/src/app/_components/profile-lookup-page.tsx
@@ -1091,10 +1091,10 @@ function ProfileLookupPageContent({
           return {
             lookup: { ...lookup, privateResults },
             query: line,
-            results: [
-              ...lookup.results,
-              ...(showPrivate ? privateResults : []),
-            ],
+            results: mergeLookupSuggestions(
+              lookup.results,
+              showPrivate ? privateResults : [],
+            ),
           };
         }),
       );

--- a/apps/web/src/app/_components/profile-lookup-page.tsx
+++ b/apps/web/src/app/_components/profile-lookup-page.tsx
@@ -11,6 +11,7 @@ import { api } from "@convex-generated-api";
 import { LookupCopyButton } from "./lookup-copy-button";
 import { shouldRefreshBulkPrivateLookup } from "./lookup-private-refresh";
 import { LookupSearchBox } from "./lookup-search-box";
+import { mergeLookupSuggestions } from "./lookup-suggestion-merge";
 import { buttonVariants } from "@/components/ui/button";
 import { Card } from "@/components/ui/card";
 import { BrandLink, PageContainer, PageNav, PageShell } from "@/components/ui/page-shell";
@@ -898,7 +899,14 @@ function ProfileLookupPageContent({
   const [isPending, startTransition] = useTransition();
   const isSearching = pendingLabel !== null || isPending;
   const privateUiEnabled = seedViewerAccess.source === "super_admin" || privateUiFlag === true;
-  const visiblePrivateResults = seedViewerAccess.allowed && privateUiEnabled ? displayPrivateResults : [];
+  const visibleResults = mergeLookupSuggestions(
+    displayResults,
+    seedViewerAccess.allowed && privateUiEnabled ? displayPrivateResults : [],
+  );
+  const visiblePublicResults = visibleResults.filter(
+    (result): result is PublicProfileLookupResult => !isPrivateSeedLookupResult(result),
+  );
+  const visiblePrivateResults = visibleResults.filter(isPrivateSeedLookupResult);
   const seedViewerAccessAllowed = seedViewerAccess.allowed;
   const seedViewerAccessSource = seedViewerAccess.source;
   const hasQuery = Boolean(displayQuery.trim()) || bulkEntries.length > 0 || isSearching;
@@ -952,7 +960,7 @@ function ProfileLookupPageContent({
 
     if (
       bulkEntries.length > 0 ||
-      currentQuery.length < 2 ||
+      currentQuery.length < 1 ||
       displayPrivateResults.length > 0 ||
       !seedViewerAccess.allowed ||
       !enabled ||
@@ -1187,10 +1195,7 @@ function ProfileLookupPageContent({
           </div>
           <LookupSearchBox
             initialQuery={displayQuery}
-            initialResults={[
-              ...displayResults,
-              ...(seedViewerAccess.allowed && privateUiEnabled ? displayPrivateResults : []),
-            ]}
+            initialResults={visibleResults}
             isSearching={isSearching}
             onBulkLookup={runBulkLookup}
             onClear={clearLookup}
@@ -1206,14 +1211,14 @@ function ProfileLookupPageContent({
             {isSearching ? <span className="sr-only">{pendingLabel ?? "Searching"}</span> : null}
             <BulkLookupSummary entries={bulkEntries} />
             <div className={cn("lookup-results-wrap", isSearching ? "lookup-results-wrap--pending" : undefined)}>
-              {displayResults.length === 0 && visiblePrivateResults.length === 0 && !isSearching ? (
+              {visiblePublicResults.length === 0 && visiblePrivateResults.length === 0 && !isSearching ? (
                 <Card className="lookup-panel" surface="dashed">
                   <p className="font-medium">No matches found.</p>
                 </Card>
-              ) : displayResults.length > 0 || visiblePrivateResults.length > 0 ? (
+              ) : visiblePublicResults.length > 0 || visiblePrivateResults.length > 0 ? (
                 <>
                   <div className="grid gap-3 min-[1320px]:hidden">
-                    {displayResults.map((profile) => <LookupResultCard key={profile.slug} profile={profile} />)}
+                    {visiblePublicResults.map((profile) => <LookupResultCard key={profile.slug} profile={profile} />)}
                     {visiblePrivateResults.map((candidate) => (
                       <PrivateSeedResultCard candidate={candidate} key={candidate.id} />
                     ))}
@@ -1228,7 +1233,7 @@ function ProfileLookupPageContent({
                         </tr>
                       </TableHead>
                       <tbody className="divide-y divide-border">
-                        {displayResults.map((profile) => <LookupResultRow key={profile.slug} profile={profile} />)}
+                        {visiblePublicResults.map((profile) => <LookupResultRow key={profile.slug} profile={profile} />)}
                         {visiblePrivateResults.map((candidate) => (
                           <PrivateSeedResultRow candidate={candidate} key={candidate.id} />
                         ))}

--- a/apps/web/src/convex/playwright-fixtures.ts
+++ b/apps/web/src/convex/playwright-fixtures.ts
@@ -1271,6 +1271,40 @@ export function getPlaywrightProfileLookupFixture(query: string): PlaywrightProf
     return result !== null && searchableText.includes(normalized) ? [result] : [];
   });
 
+  if (results.some((profile) => profile.slug === basicBitSlug)) {
+    return {
+      kind: "handled",
+      privateResults: [
+        {
+          id: "playwright-nwinn-basicbit",
+          displayName: "BASICBIT",
+          publicationState: "draft_private",
+          reviewState: "unreviewed",
+          source: { name: "NWinn" },
+          fields: [
+            {
+              confidence: "medium",
+              fieldKey: "outboundLinks",
+              id: "playwright-nwinn-basicbit-links",
+              reviewState: "unreviewed",
+              sourceLabel: "NWinn",
+              value: [
+                {
+                  label: "Twitch",
+                  type: "twitch",
+                  url: "https://www.twitch.tv/basic_bit/",
+                },
+              ],
+              visibility: "private",
+            },
+          ],
+        },
+      ],
+      results,
+      viewerAccess: { allowed: true, source: "super_admin" },
+    };
+  }
+
   if (results.length > 0) {
     return { kind: "handled", results };
   }

--- a/convex/seedAccess.ts
+++ b/convex/seedAccess.ts
@@ -44,8 +44,8 @@ export const lookupPeople = query({
     const { access } = await requirePrivateSeedLookupAccess(ctx);
     const searchTerm = args.query.trim().replace(/\s+/g, " ").slice(0, 120);
 
-    if (searchTerm.length < 2) {
-      throw new Error("Private seed lookup requires at least two characters.");
+    if (searchTerm.length < 1) {
+      throw new Error("Private seed lookup requires at least one character.");
     }
 
     const limit = Math.max(1, Math.min(Math.floor(args.limit ?? 20), 50));

--- a/tests/backend/onboarding-seed-handlers.test.ts
+++ b/tests/backend/onboarding-seed-handlers.test.ts
@@ -104,6 +104,28 @@ describe("private seed Convex handlers", () => {
     );
   });
 
+  it("supports single-character private lookup for an authorized account", async () => {
+    const t = convexTest({ schema, modules });
+    await importCandidate(t);
+    const userId = await t.run((ctx) => ctx.db.insert("users", { name: "Seed lookup operator" }));
+    await t.run((ctx) => ctx.db.insert("accountFeatureGrants", {
+      userId,
+      feature: "super_admin",
+      state: "active",
+      grantedBy: actor,
+      grantedAt: NOW,
+      updatedAt: NOW,
+    }));
+
+    const results = await t.withIdentity({ subject: userId }).query(
+      api.seedAccess.lookupPeople,
+      { query: "D", limit: 5 },
+    );
+
+    assert.equal(results.length, 1);
+    assert.equal(results[0]?.displayName, "DJ Example");
+  });
+
   it("rejects changed candidate payloads under an existing import id", async () => {
     const t = convexTest({ schema, modules });
     await t.mutation(internal.seedImports.importPermissionedJsonBatch, {

--- a/tests/web/lookup-suggestion-merge.test.ts
+++ b/tests/web/lookup-suggestion-merge.test.ts
@@ -16,7 +16,7 @@ function publicProfile(overrides: Partial<PublicProfileLookupResult> = {}): Publ
       label: "Twitch",
       source: "owner_authored",
       type: "twitch",
-      url: "https://www.twitch.tv/basic_bit",
+      url: "https://twitch.tv/basic_bit",
     }],
     profilePath: "/p/basicbit",
     roleTags: [],

--- a/tests/web/lookup-suggestion-merge.test.ts
+++ b/tests/web/lookup-suggestion-merge.test.ts
@@ -1,0 +1,82 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+
+import { mergeLookupSuggestions } from "../../apps/web/src/app/_components/lookup-suggestion-merge";
+import type {
+  PrivateSeedLookupResult,
+  PublicProfileLookupResult,
+} from "../../apps/web/src/app/_components/profile-lookup-page";
+
+function publicProfile(overrides: Partial<PublicProfileLookupResult> = {}): PublicProfileLookupResult {
+  return {
+    aliases: [],
+    displayName: "BASICBIT",
+    genres: [],
+    outboundLinks: [{
+      label: "Twitch",
+      source: "owner_authored",
+      type: "twitch",
+      url: "https://www.twitch.tv/basic_bit",
+    }],
+    profilePath: "/p/basicbit",
+    roleTags: [],
+    slug: "basicbit",
+    tags: [],
+    trustLabel: "claimed_verified",
+    ...overrides,
+  };
+}
+
+function privateCandidate(overrides: Partial<PrivateSeedLookupResult> = {}): PrivateSeedLookupResult {
+  return {
+    displayName: "BASICBIT",
+    fields: [{
+      confidence: "medium",
+      fieldKey: "outboundLinks",
+      id: "candidate-links",
+      reviewState: "unreviewed",
+      sourceLabel: "NWinn",
+      value: [{ url: "https://www.twitch.tv/basic_bit/" }],
+      visibility: "private",
+    }],
+    id: "candidate-basicbit",
+    publicationState: "draft_private",
+    reviewState: "unreviewed",
+    source: { name: "NWinn" },
+    ...overrides,
+  };
+}
+
+describe("lookup suggestion merging", () => {
+  it("prefers a public profile when a same-name private candidate shares a link", () => {
+    const result = mergeLookupSuggestions([publicProfile()], [privateCandidate()]);
+
+    assert.deepEqual(result.map((profile) => profile.displayName), ["BASICBIT"]);
+  });
+
+  it("prefers a public profile when the candidate proposes its canonical slug", () => {
+    const result = mergeLookupSuggestions(
+      [publicProfile()],
+      [privateCandidate({ displayName: "BASIC BIT", fields: [], proposedSlug: "BASICBIT" })],
+    );
+
+    assert.equal(result.length, 1);
+  });
+
+  it("keeps same-name candidates when their public links differ", () => {
+    const result = mergeLookupSuggestions(
+      [publicProfile()],
+      [privateCandidate({ fields: [{
+        confidence: "medium",
+        fieldKey: "outboundLinks",
+        id: "other-links",
+        reviewState: "unreviewed",
+        sourceLabel: "NWinn",
+        value: [{ url: "https://www.twitch.tv/a-different-dj" }],
+        visibility: "private",
+      }] })],
+    );
+
+    assert.equal(result.length, 2);
+  });
+});

--- a/tests/web/lookup-suggestion-merge.test.ts
+++ b/tests/web/lookup-suggestion-merge.test.ts
@@ -16,7 +16,7 @@ function publicProfile(overrides: Partial<PublicProfileLookupResult> = {}): Publ
       label: "Twitch",
       source: "owner_authored",
       type: "twitch",
-      url: "https://twitch.tv/basic_bit",
+      url: "https://twitch.tv/BASIC_BIT",
     }],
     profilePath: "/p/basicbit",
     roleTags: [],


### PR DESCRIPTION
## Summary

- start public and authorized private lookup suggestions after one character
- prefer an existing public profile over a private seed candidate when they match by proposed slug or by display name plus a shared outbound link
- apply the same dedupe policy to both the lookahead and submitted lookup results
- retain same-name candidates when their links differ

## Root cause

The UI and private Convex query each enforced a two-character threshold. Public and private lookup rows were also concatenated without identity-aware merging, so the claimed BASICBIT profile and its NWinn seed candidate appeared as separate results.

## Product impact

Typing a single character now opens useful typeahead results. Existing claimed/public profiles remain the canonical visible result when a private seed row clearly overlaps, while the private candidate stays in review staging with its provenance and proposed fields intact.

## Validation

- `corepack pnpm typecheck:backend`
- `corepack pnpm typecheck:web`
- `corepack pnpm lint:web`
- `corepack pnpm test:web` (135 passing)
- `corepack pnpm test:backend` (220 passing)
- targeted authorized one-character Convex handler test
- targeted Playwright lookup tests on desktop and mobile (4 passing)

A final local Playwright rerun after extracting the pure merge helper was blocked before app startup by sandbox network access to Convex. The extracted helper then passed direct unit coverage, web typecheck, lint, and the full web suite; the exact desktop/mobile flow had passed immediately before that code-only extraction.