### PR TITLE
Remove redundant Playwright MCP launcher

### DIFF
--- a/.codex/config.toml
+++ b/.codex/config.toml
@@ -1,3 +1,6 @@
+[mcp_servers.playwright]
+url = "http://localhost:8931/mcp"
+
 [mcp_servers.vercel_vrdex]
 url = "https://mcp.vercel.com"
 

--- a/.codex/config.toml
+++ b/.codex/config.toml
@@ -1,7 +1,3 @@
-[mcp_servers.playwright]
-command = "npx"
-args = ["-y", "@playwright/mcp@latest"]
-
 [mcp_servers.vercel_vrdex]
 url = "https://mcp.vercel.com"
 


### PR DESCRIPTION
## What changed

- Remove the project-level Playwright STDIO launcher from .codex/config.toml.
- Let VRDex inherit the global Streamable HTTP Playwright endpoint.

## Why

Codex merges user and trusted-project configuration layers. The project command/rgs keys combined with the global url key into an invalid mixed transport, causing url is not supported for stdio and spawning redundant Playwright processes.

## Validation

- Both TOML layers parse successfully.
- Effective Playwright configuration contains only url = http://localhost:8931/mcp and no STDIO command.
- git diff --check passes.