### PR TITLE
Fix event API ownership and PATCH semantics

### DIFF
--- a/apps/web/e2e/handoff.flow.spec.ts
+++ b/apps/web/e2e/handoff.flow.spec.ts
@@ -6,7 +6,7 @@ test.beforeEach(async ({ page }) => {
   await prepareVisualPage(page);
 });
 
-test("handoff invitations are excluded from indexing @fixture", async ({ page }) => {
+test("handoff invitations are excluded from indexing @flow @fixture", async ({ page }) => {
   await page.goto("/handoff/playwright-ready");
   await expect(page.locator('meta[name="robots"]')).toHaveAttribute(
     "content",
@@ -14,7 +14,7 @@ test("handoff invitations are excluded from indexing @fixture", async ({ page })
   );
 });
 
-test("handoff shows a loading state @fixture", async ({ page }) => {
+test("handoff shows a loading state @flow @fixture", async ({ page }) => {
   await page.goto("/handoff/playwright-loading");
   await expect(page.getByRole("status")).toContainText("Opening your invitation");
   await expect(page.getByRole("heading", { name: "Preparing your review." })).toBeVisible();
@@ -25,14 +25,14 @@ for (const state of [
   { token: "expired", heading: "Invitation expired" },
   { token: "revoked", heading: "Invitation revoked" },
 ] as const) {
-  test(`handoff shows the ${state.token} state @fixture`, async ({ page }) => {
+  test(`handoff shows the ${state.token} state @flow @fixture`, async ({ page }) => {
     await page.goto(`/handoff/playwright-${state.token}`);
     await expect(page.getByRole("heading", { name: state.heading })).toBeVisible();
     await expect(page.getByRole("link", { name: "Return to VRDex" })).toBeVisible();
   });
 }
 
-test("handoff shows the accepted state and owner destination @fixture", async ({ page }) => {
+test("handoff shows the accepted state and owner destination @flow @fixture", async ({ page }) => {
   await page.goto("/handoff/playwright-accepted");
   await expect(page.getByRole("heading", { name: "Invitation already accepted" })).toBeVisible();
   await expect(page.getByRole("link", { name: "Open account" })).toHaveAttribute(
@@ -41,7 +41,7 @@ test("handoff shows the accepted state and owner destination @fixture", async ({
   );
 });
 
-test("handoff preserves the invitation through sign-in @fixture", async ({ page }) => {
+test("handoff preserves the invitation through sign-in @flow @fixture", async ({ page }) => {
   await page.goto("/handoff/playwright-signed-out");
   await expect(page.getByRole("heading", { name: "DJ Aurora" })).toBeVisible();
   await expect(page.getByRole("heading", { name: "Continue to your account" })).toBeVisible();
@@ -52,14 +52,14 @@ test("handoff preserves the invitation through sign-in @fixture", async ({ page 
   await expect(page.getByLabel("Include Display name")).toBeDisabled();
 });
 
-test("handoff blocks acceptance until email is verified @fixture", async ({ page }) => {
+test("handoff blocks acceptance until email is verified @flow @fixture", async ({ page }) => {
   await page.goto("/handoff/playwright-unverified");
   await expect(page.getByRole("heading", { name: "Verify your email first" })).toBeVisible();
   await expect(page.getByRole("link", { name: "Open account" })).toHaveAttribute("href", "/account");
   await expect(page.getByLabel("Include Display name")).toBeDisabled();
 });
 
-test("handoff accepts individually selected fields and routes to the owner profile @fixture", async ({ page }) => {
+test("handoff accepts individually selected fields and routes to the owner profile @flow @fixture", async ({ page }) => {
   await page.goto("/handoff/playwright-ready");
   await expect(page.getByRole("heading", { name: "DJ Aurora" })).toBeVisible();
   await expect(page.getByText("4 of 4 selected")).toBeVisible();

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -25,7 +25,7 @@
     "pretest:e2e": "node ../../scripts/guard-main-worktree.mjs",
     "test:e2e": "playwright test --grep-invert \"@visual|@snapshot|@storybook\"",
     "pretest:e2e:hosted": "node ../../scripts/guard-main-worktree.mjs",
-    "test:e2e:hosted": "playwright test --grep @flow --project=desktop-chromium",
+    "test:e2e:hosted": "playwright test --grep @flow --grep-invert @fixture --project=desktop-chromium",
     "pretest:e2e:hosted:auth-smoke": "node ../../scripts/guard-main-worktree.mjs",
     "test:e2e:hosted:auth-smoke": "playwright test --grep @production-auth --project=desktop-chromium",
     "pretest:e2e:hosted:smoke": "node ../../scripts/guard-main-worktree.mjs",

--- a/convex/_eventInputs.ts
+++ b/convex/_eventInputs.ts
@@ -80,6 +80,37 @@ export type EventDraftInput = {
   preferredSlug?: string;
 };
 
+export const eventDraftNullableFields = [
+  "doorsOpenAt",
+  "endAt",
+  "timezone",
+  "worldSlug",
+  "summary",
+  "notes",
+  "sourceUrl",
+  "posterImageUrl",
+  "bannerImageUrl",
+  "thumbnailImageUrl",
+] as const satisfies ReadonlyArray<keyof EventDraftInput>;
+
+type EventDraftNullableField = (typeof eventDraftNullableFields)[number];
+
+export type EventDraftUpdateInput = Omit<Partial<EventDraftInput>, EventDraftNullableField> & {
+  [Field in EventDraftNullableField]?: EventDraftInput[Field] | null;
+};
+
+export function normalizeEventDraftUpdateInput(input: EventDraftUpdateInput): Partial<EventDraftInput> {
+  const normalized = { ...input } as Record<string, unknown>;
+
+  for (const field of eventDraftNullableFields) {
+    if (normalized[field] === null) {
+      normalized[field] = undefined;
+    }
+  }
+
+  return normalized as Partial<EventDraftInput>;
+}
+
 export function preserveOmittedEventDraftFields(
   input: Partial<EventDraftInput>,
   preserved: EventDraftInput,

--- a/convex/events.ts
+++ b/convex/events.ts
@@ -1923,6 +1923,17 @@ export const updateCommunityEventForApiOwner = internalMutation({
     }
 
     const updateFields = suppliedEventDraftFields(args);
+    if (args.timezone === null && !updateFields.has("slotLinks")) {
+      const preservedSlot = await ctx.db
+        .query("eventSlots")
+        .withIndex("by_eventId_startAt", (query) => query.eq("eventId", event._id))
+        .first();
+
+      if (preservedSlot !== null) {
+        throw new Error("Time zone cannot be cleared while event slots are preserved.");
+      }
+    }
+
     const normalizedUpdate = normalizeEventDraftUpdateInput(args);
     const input = sanitizeEventDraftInput(
       preserveOmittedEventDraftFields(normalizedUpdate, {

--- a/convex/events.ts
+++ b/convex/events.ts
@@ -1,3 +1,4 @@
+import { getAuthUserId } from "@convex-dev/auth/server";
 import { v } from "convex/values";
 
 import type { Doc, Id } from "./_generated/dataModel";
@@ -36,9 +37,11 @@ import {
   sanitizeVrcdnOperatorOwnedOutputSetup,
 } from "./_eventMediaControl";
 import {
+  normalizeEventDraftUpdateInput,
   preserveOmittedEventDraftFields,
   sanitizeEventDraftInput,
   type EventDraftInput,
+  type EventDraftUpdateInput,
   type SanitizedEventDraftInput,
 } from "./_eventInputs";
 import { findEventOperationSlots } from "./_eventOperations";
@@ -146,6 +149,16 @@ const eventDraftUpdateArgs = {
   ...eventDraftArgs,
   title: v.optional(v.string()),
   startAt: v.optional(v.number()),
+  doorsOpenAt: v.optional(v.union(v.number(), v.null())),
+  endAt: v.optional(v.union(v.number(), v.null())),
+  timezone: v.optional(v.union(v.string(), v.null())),
+  worldSlug: v.optional(v.union(v.string(), v.null())),
+  summary: v.optional(v.union(v.string(), v.null())),
+  notes: v.optional(v.union(v.string(), v.null())),
+  sourceUrl: v.optional(v.union(v.string(), v.null())),
+  posterImageUrl: v.optional(v.union(v.string(), v.null())),
+  bannerImageUrl: v.optional(v.union(v.string(), v.null())),
+  thumbnailImageUrl: v.optional(v.union(v.string(), v.null())),
 };
 
 const vrcdnOutputSetupArgs = {
@@ -382,6 +395,7 @@ async function canUpdateEvent(
   db: DatabaseReader,
   event: Doc<"events">,
   subject: AuthSubject,
+  userId?: Id<"users"> | null,
 ): Promise<boolean> {
   if (isSameAuthSubject(event.submitter, subject)) {
     return true;
@@ -389,6 +403,14 @@ async function canUpdateEvent(
 
   if (event.communityProfileId === undefined) {
     return false;
+  }
+
+  if (
+    userId !== undefined &&
+    userId !== null &&
+    await userOwnsProfile(db, event.communityProfileId, userId)
+  ) {
+    return true;
   }
 
   return subjectHasCommunityCapability(db, event.communityProfileId, subject, "manage_events");
@@ -398,6 +420,7 @@ async function canManageEventMedia(
   db: DatabaseReader,
   event: Doc<"events">,
   subject: AuthSubject,
+  userId?: Id<"users"> | null,
 ): Promise<boolean> {
   if (isSameAuthSubject(event.submitter, subject)) {
     return true;
@@ -405,6 +428,14 @@ async function canManageEventMedia(
 
   if (event.communityProfileId === undefined) {
     return false;
+  }
+
+  if (
+    userId !== undefined &&
+    userId !== null &&
+    await userOwnsProfile(db, event.communityProfileId, userId)
+  ) {
+    return true;
   }
 
   return subjectHasCommunityCapability(db, event.communityProfileId, subject, "manage_event_media");
@@ -414,6 +445,7 @@ async function canViewEventOperations(
   db: DatabaseReader,
   event: Doc<"events">,
   subject: AuthSubject,
+  userId?: Id<"users"> | null,
 ): Promise<boolean> {
   if (isSameAuthSubject(event.submitter, subject)) {
     return true;
@@ -421,6 +453,14 @@ async function canViewEventOperations(
 
   if (event.communityProfileId === undefined) {
     return false;
+  }
+
+  if (
+    userId !== undefined &&
+    userId !== null &&
+    await userOwnsProfile(db, event.communityProfileId, userId)
+  ) {
+    return true;
   }
 
   return subjectHasAnyCommunityCapability(db, event.communityProfileId, subject, [
@@ -609,7 +649,7 @@ async function linkedPublishedEventWorld(db: DatabaseReader, eventId: Id<"events
   return world?.publicationState === "published" ? world : undefined;
 }
 
-function suppliedEventDraftFields(input: Partial<EventDraftInput>) {
+function suppliedEventDraftFields(input: EventDraftUpdateInput) {
   const fields = new Set<keyof EventDraftInput>();
 
   for (const field of Object.keys(eventDraftArgs) as Array<keyof EventDraftInput>) {
@@ -934,7 +974,7 @@ async function getEditableEventBySlug(
     throw new Error("Event was not found.");
   }
 
-  if (!(await canUpdateEvent(ctx.db, event, subject))) {
+  if (!(await canUpdateEvent(ctx.db, event, subject, await getAuthUserId(ctx)))) {
     throw new Error("You do not have permission to update this event.");
   }
 
@@ -958,7 +998,7 @@ async function getMediaManageableEventBySlug(
     throw new Error("Event was not found.");
   }
 
-  if (!(await canManageEventMedia(ctx.db, event, subject))) {
+  if (!(await canManageEventMedia(ctx.db, event, subject, await getAuthUserId(ctx)))) {
     throw new Error("You do not have permission to control event media.");
   }
 
@@ -982,7 +1022,7 @@ async function getOperationsReadableEventBySlug(
     throw new Error("Event was not found.");
   }
 
-  if (!(await canViewEventOperations(ctx.db, event, subject))) {
+  if (!(await canViewEventOperations(ctx.db, event, subject, await getAuthUserId(ctx)))) {
     throw new Error("You do not have permission to view event operations.");
   }
 
@@ -1883,8 +1923,9 @@ export const updateCommunityEventForApiOwner = internalMutation({
     }
 
     const updateFields = suppliedEventDraftFields(args);
+    const normalizedUpdate = normalizeEventDraftUpdateInput(args);
     const input = sanitizeEventDraftInput(
-      preserveOmittedEventDraftFields(args, {
+      preserveOmittedEventDraftFields(normalizedUpdate, {
         title: event.title,
         startAt: event.startAt,
         communitySlug: currentCommunity.slug,
@@ -1930,6 +1971,7 @@ export const updateCommunityEvent = mutation({
   },
   handler: async (ctx, args) => {
     const subject = await requireAuthenticatedSubject(ctx);
+    const userId = await getAuthUserId(ctx);
     const validation = validateEventSlug(args.currentSlug);
 
     if (!validation.ok) {
@@ -1944,7 +1986,7 @@ export const updateCommunityEvent = mutation({
 
     const isSubmitter = isSameAuthSubject(event.submitter, subject);
 
-    if (!(await canUpdateEvent(ctx.db, event, subject))) {
+    if (!(await canUpdateEvent(ctx.db, event, subject, userId))) {
       throw new Error("You do not have permission to update this event.");
     }
 

--- a/convex/events.ts
+++ b/convex/events.ts
@@ -1923,7 +1923,10 @@ export const updateCommunityEventForApiOwner = internalMutation({
     }
 
     const updateFields = suppliedEventDraftFields(args);
-    if (args.timezone === null && !updateFields.has("slotLinks")) {
+    const clearsTimezone =
+      args.timezone === null ||
+      (typeof args.timezone === "string" && args.timezone.trim().length === 0);
+    if (clearsTimezone && !updateFields.has("slotLinks")) {
       const preservedSlot = await ctx.db
         .query("eventSlots")
         .withIndex("by_eventId_startAt", (query) => query.eq("eventId", event._id))

--- a/docs/api/openapi.json
+++ b/docs/api/openapi.json
@@ -3735,23 +3735,51 @@
             "maximum": 9007199254740991
           },
           "doorsOpenAt": {
-            "type": "integer",
-            "minimum": 0,
-            "maximum": 9007199254740991
+            "anyOf": [
+              {
+                "type": "integer",
+                "minimum": 0,
+                "maximum": 9007199254740991
+              },
+              {
+                "type": "null"
+              }
+            ]
           },
           "endAt": {
-            "type": "integer",
-            "minimum": 0,
-            "maximum": 9007199254740991
+            "anyOf": [
+              {
+                "type": "integer",
+                "minimum": 0,
+                "maximum": 9007199254740991
+              },
+              {
+                "type": "null"
+              }
+            ]
           },
           "timezone": {
-            "type": "string",
-            "maxLength": 64
+            "anyOf": [
+              {
+                "type": "string",
+                "maxLength": 64
+              },
+              {
+                "type": "null"
+              }
+            ]
           },
           "worldSlug": {
-            "type": "string",
-            "minLength": 1,
-            "maxLength": 160
+            "anyOf": [
+              {
+                "type": "string",
+                "minLength": 1,
+                "maxLength": 160
+              },
+              {
+                "type": "null"
+              }
+            ]
           },
           "preferredSlug": {
             "type": "string",
@@ -3759,32 +3787,74 @@
             "maxLength": 160
           },
           "summary": {
-            "type": "string",
-            "maxLength": 240
+            "anyOf": [
+              {
+                "type": "string",
+                "maxLength": 240
+              },
+              {
+                "type": "null"
+              }
+            ]
           },
           "notes": {
-            "type": "string",
-            "maxLength": 1200
+            "anyOf": [
+              {
+                "type": "string",
+                "maxLength": 1200
+              },
+              {
+                "type": "null"
+              }
+            ]
           },
           "sourceLabel": {
             "type": "string",
             "maxLength": 120
           },
           "sourceUrl": {
-            "type": "string",
-            "format": "uri"
+            "anyOf": [
+              {
+                "type": "string",
+                "format": "uri"
+              },
+              {
+                "type": "null"
+              }
+            ]
           },
           "posterImageUrl": {
-            "type": "string",
-            "format": "uri"
+            "anyOf": [
+              {
+                "type": "string",
+                "format": "uri"
+              },
+              {
+                "type": "null"
+              }
+            ]
           },
           "bannerImageUrl": {
-            "type": "string",
-            "format": "uri"
+            "anyOf": [
+              {
+                "type": "string",
+                "format": "uri"
+              },
+              {
+                "type": "null"
+              }
+            ]
           },
           "thumbnailImageUrl": {
-            "type": "string",
-            "format": "uri"
+            "anyOf": [
+              {
+                "type": "string",
+                "format": "uri"
+              },
+              {
+                "type": "null"
+              }
+            ]
           },
           "watchSurfaceEnabled": {
             "type": "boolean"
@@ -3917,7 +3987,7 @@
             }
           }
         },
-        "description": "Update a public event attached to a community profile owned by the current authenticated API user."
+        "description": "Update a public event attached to a community profile owned by the current authenticated API user. Omitted fields are preserved; null clears optional scalar fields and the world relation; empty arrays clear collection fields."
       },
       "ApiEventCreateRequest": {
         "type": "object",

--- a/docs/api/openapi.yaml
+++ b/docs/api/openapi.yaml
@@ -1753,45 +1753,65 @@ components:
           minimum: 0
           maximum: 9007199254740991
         doorsOpenAt:
-          type: integer
-          minimum: 0
-          maximum: 9007199254740991
+          anyOf:
+            - type: integer
+              minimum: 0
+              maximum: 9007199254740991
+            - type: "null"
         endAt:
-          type: integer
-          minimum: 0
-          maximum: 9007199254740991
+          anyOf:
+            - type: integer
+              minimum: 0
+              maximum: 9007199254740991
+            - type: "null"
         timezone:
-          type: string
-          maxLength: 64
+          anyOf:
+            - type: string
+              maxLength: 64
+            - type: "null"
         worldSlug:
-          type: string
-          minLength: 1
-          maxLength: 160
+          anyOf:
+            - type: string
+              minLength: 1
+              maxLength: 160
+            - type: "null"
         preferredSlug:
           type: string
           minLength: 1
           maxLength: 160
         summary:
-          type: string
-          maxLength: 240
+          anyOf:
+            - type: string
+              maxLength: 240
+            - type: "null"
         notes:
-          type: string
-          maxLength: 1200
+          anyOf:
+            - type: string
+              maxLength: 1200
+            - type: "null"
         sourceLabel:
           type: string
           maxLength: 120
         sourceUrl:
-          type: string
-          format: uri
+          anyOf:
+            - type: string
+              format: uri
+            - type: "null"
         posterImageUrl:
-          type: string
-          format: uri
+          anyOf:
+            - type: string
+              format: uri
+            - type: "null"
         bannerImageUrl:
-          type: string
-          format: uri
+          anyOf:
+            - type: string
+              format: uri
+            - type: "null"
         thumbnailImageUrl:
-          type: string
-          format: uri
+          anyOf:
+            - type: string
+              format: uri
+            - type: "null"
         watchSurfaceEnabled:
           type: boolean
         mediaLinks:
@@ -1890,7 +1910,7 @@ components:
               - displayLabel
               - startAt
             additionalProperties: {}
-      description: Update a public event attached to a community profile owned by the current authenticated API user.
+      description: Update a public event attached to a community profile owned by the current authenticated API user. Omitted fields are preserved; null clears optional scalar fields and the world relation; empty arrays clear collection fields.
     ApiEventCreateRequest:
       type: object
       properties:

--- a/docs/developers/api-auth.md
+++ b/docs/developers/api-auth.md
@@ -230,6 +230,8 @@ Current constraints:
 - update also requires ownership of the event's current community profile
 - update preserves optional event fields, media, world, schedule, and lineup
   data when those fields are omitted from the request
+- update clears optional scalar fields and the world relation when their values
+  are explicitly `null`; empty arrays clear collection fields
 - replacing schedule or lineup data requires both `slotLinks` and
   `participantLinks` in the same update
 - creates a published public event using the same sanitizers as the web event

--- a/docs/developers/public-api.md
+++ b/docs/developers/public-api.md
@@ -109,8 +109,10 @@ user authority, and ownership of the target `communitySlug`. Event updates also
 require ownership of the event's current community. The first public write
 version only creates and updates events attached to owned community profiles; it
 does not create standalone submitter-only events. Event updates preserve
-optional fields and relations that are omitted from the PATCH body. Schedule
-and lineup replacements supply `slotLinks` and `participantLinks` together.
+fields and relations that are omitted from the PATCH body. Set an optional
+scalar or `worldSlug` to `null` to clear it. Supply an empty array to clear
+`mediaLinks`; schedule and lineup replacements supply `slotLinks` and
+`participantLinks` together, using two empty arrays to clear both.
 
 Developer list routes require `developer:read` plus user authority. Developer
 creation and revocation routes require `developer:write` plus user authority.

--- a/packages/api-contracts/src/schemas.ts
+++ b/packages/api-contracts/src/schemas.ts
@@ -458,6 +458,18 @@ export const ApiEventCreateRequestSchema = z
   });
 
 export const ApiEventUpdateRequestSchema = ApiEventCreateRequestSchema.partial()
+  .extend({
+    doorsOpenAt: timestampMs.nullable().optional(),
+    endAt: timestampMs.nullable().optional(),
+    timezone: z.string().max(64).nullable().optional(),
+    worldSlug: slug.nullable().optional(),
+    summary: z.string().max(240).nullable().optional(),
+    notes: z.string().max(1_200).nullable().optional(),
+    sourceUrl: absoluteUrl.nullable().optional(),
+    posterImageUrl: absoluteUrl.nullable().optional(),
+    bannerImageUrl: absoluteUrl.nullable().optional(),
+    thumbnailImageUrl: absoluteUrl.nullable().optional(),
+  })
   .superRefine((value, context) => {
     const replacesParticipants = value.participantLinks !== undefined;
     const replacesSlots = value.slotLinks !== undefined;
@@ -472,7 +484,7 @@ export const ApiEventUpdateRequestSchema = ApiEventCreateRequestSchema.partial()
   })
   .meta({
     description:
-      "Update a public event attached to a community profile owned by the current authenticated API user.",
+      "Update a public event attached to a community profile owned by the current authenticated API user. Omitted fields are preserved; null clears optional scalar fields and the world relation; empty arrays clear collection fields.",
     id: "ApiEventUpdateRequest",
   });
 

--- a/packages/api-contracts/tests/contracts.test.ts
+++ b/packages/api-contracts/tests/contracts.test.ts
@@ -332,9 +332,41 @@ describe("@vrdex/api-contracts", () => {
       summary: "Updated public event details.",
     });
 
-    assert.throws(() => ApiEventUpdateRequestSchema.parse({
-      participantLinks: [],
-    }), /participantLinks and slotLinks must be supplied together/);
+    ApiEventUpdateRequestSchema.parse({
+      doorsOpenAt: null,
+      endAt: null,
+      timezone: null,
+      worldSlug: null,
+      summary: null,
+      notes: null,
+      sourceUrl: null,
+      posterImageUrl: null,
+      bannerImageUrl: null,
+      thumbnailImageUrl: null,
+    });
+
+    assert.throws(() =>
+      ApiEventUpdateRequestSchema.parse({
+        title: null,
+      }),
+    );
+    assert.throws(() =>
+      ApiEventUpdateRequestSchema.parse({
+        communitySlug: null,
+      }),
+    );
+    assert.throws(() =>
+      ApiEventUpdateRequestSchema.parse({
+        mediaLinks: null,
+      }),
+    );
+    assert.throws(
+      () =>
+        ApiEventUpdateRequestSchema.parse({
+          participantLinks: [],
+        }),
+      /participantLinks and slotLinks must be supplied together/,
+    );
   });
 
   it("parses profile update contracts", () => {

--- a/tests/backend/api-platform-review-boundaries.test.ts
+++ b/tests/backend/api-platform-review-boundaries.test.ts
@@ -36,8 +36,10 @@ describe("API platform review boundaries", () => {
     const events = source("convex/events.ts");
 
     assert.match(events, /const eventDraftUpdateArgs = \{[\s\S]*title: v\.optional\(v\.string\(\)\)[\s\S]*startAt: v\.optional\(v\.number\(\)\)/);
+    assert.match(events, /summary: v\.optional\(v\.union\(v\.string\(\), v\.null\(\)\)\)/);
     assert.match(events, /const updateFields = suppliedEventDraftFields\(args\)/);
-    assert.match(events, /preserveOmittedEventDraftFields\(args, \{/);
+    assert.match(events, /const normalizedUpdate = normalizeEventDraftUpdateInput\(args\)/);
+    assert.match(events, /preserveOmittedEventDraftFields\(normalizedUpdate, \{/);
     assert.match(events, /communitySlug: currentCommunity\.slug/);
     assert.match(events, /shouldUpdate\("watchSurfaceEnabled"\)/);
     assert.match(events, /shouldUpdate\("mediaLinks"\)/);
@@ -45,6 +47,15 @@ describe("API platform review boundaries", () => {
     assert.match(events, /const replaceSlots = shouldUpdate\("slotLinks"\)/);
     assert.match(events, /const replaceParticipants = shouldUpdate\("participantLinks"\)/);
     assert.match(events, /syncPreservedEventAssociationStartAt/);
+  });
+
+  it("authorizes normal event sessions through durable profile ownership", () => {
+    const events = source("convex/events.ts");
+
+    assert.match(events, /canUpdateEvent\([\s\S]*userOwnsProfile\(db, event\.communityProfileId, userId\)/);
+    assert.match(events, /canManageEventMedia\([\s\S]*userOwnsProfile\(db, event\.communityProfileId, userId\)/);
+    assert.match(events, /canViewEventOperations\([\s\S]*userOwnsProfile\(db, event\.communityProfileId, userId\)/);
+    assert.match(events, /canUpdateEvent\(ctx\.db, event, subject, userId\)/);
   });
 
   it("creates and returns refresh tokens only for clients that allow refresh", () => {

--- a/tests/backend/event-api-ownership.test.ts
+++ b/tests/backend/event-api-ownership.test.ts
@@ -160,15 +160,17 @@ describe("API-created event ownership", () => {
       ],
     });
 
-    await assert.rejects(
-      t.mutation(internal.events.updateCommunityEventForApiOwner, {
-        actorKind: "personal_api_token",
-        ownerUserId: userId,
-        currentSlug: created.slug,
-        timezone: null,
-      }),
-      /Time zone cannot be cleared while event slots are preserved/,
-    );
+    for (const timezone of [null, "", "   "]) {
+      await assert.rejects(
+        t.mutation(internal.events.updateCommunityEventForApiOwner, {
+          actorKind: "personal_api_token",
+          ownerUserId: userId,
+          currentSlug: created.slug,
+          timezone,
+        }),
+        /Time zone cannot be cleared while event slots are preserved/,
+      );
+    }
 
     const stored = await t.run(async (ctx) => ctx.db.get(created.eventId));
     assert.equal(stored?.timezone, "UTC");

--- a/tests/backend/event-api-ownership.test.ts
+++ b/tests/backend/event-api-ownership.test.ts
@@ -138,4 +138,39 @@ describe("API-created event ownership", () => {
     assert.equal(result.event?.notes, "Preserved when omitted.");
     assert.deepEqual(result.worldLinks, []);
   });
+
+  it("does not clear the timezone while preserving existing event slots", async () => {
+    const t = convexTest({ schema, modules });
+    const { userId } = await seedOwnedCommunity(t);
+    const startAt = NOW + 86_400_000;
+    const created = await t.mutation(internal.events.createCommunityEventForApiOwner, {
+      actorKind: "personal_api_token",
+      ownerUserId: userId,
+      title: "Faceless Friday",
+      communitySlug: "faceless",
+      startAt,
+      timezone: "UTC",
+      participantLinks: [],
+      slotLinks: [
+        {
+          displayLabel: "Opening set",
+          startAt,
+          endAt: startAt + 3_600_000,
+        },
+      ],
+    });
+
+    await assert.rejects(
+      t.mutation(internal.events.updateCommunityEventForApiOwner, {
+        actorKind: "personal_api_token",
+        ownerUserId: userId,
+        currentSlug: created.slug,
+        timezone: null,
+      }),
+      /Time zone cannot be cleared while event slots are preserved/,
+    );
+
+    const stored = await t.run(async (ctx) => ctx.db.get(created.eventId));
+    assert.equal(stored?.timezone, "UTC");
+  });
 });

--- a/tests/backend/event-api-ownership.test.ts
+++ b/tests/backend/event-api-ownership.test.ts
@@ -1,0 +1,141 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+
+import { convexTest } from "convex-test";
+
+import { api, internal } from "../../convex/_generated/api";
+import schemaModule from "../../convex/schema";
+
+const modules = {
+  "../../convex/_generated/api.ts": () => import("../../convex/_generated/api"),
+  "../../convex/events.ts": () => import("../../convex/events"),
+};
+const schema = (schemaModule as unknown as { default?: typeof schemaModule }).default ?? schemaModule;
+const NOW = Date.parse("2026-07-24T12:00:00.000Z");
+
+async function seedOwnedCommunity(t: ReturnType<typeof convexTest>) {
+  return t.run(async (ctx) => {
+    const userId = await ctx.db.insert("users", {
+      name: "Community Owner",
+      email: "owner@example.com",
+      emailVerificationTime: NOW,
+    });
+    const profileId = await ctx.db.insert("profiles", {
+      slug: "faceless",
+      displayName: "The Faceless",
+      sortName: "the faceless",
+      aliases: [],
+      tags: [],
+      claimState: "claimed_verified",
+      publicationState: "published",
+      publicSurfacingState: "public",
+      creationSource: "self",
+      updatedAt: NOW,
+      profileType: "community",
+      community: { categoryTags: [] },
+    });
+    await ctx.db.insert("profileOwners", {
+      profileId,
+      userId,
+      roleKey: "owner",
+      state: "active",
+      grantedAt: NOW,
+      updatedAt: NOW,
+    });
+
+    return {
+      userId,
+      identity: {
+        subject: `${userId}|web-session`,
+        issuer: "test",
+        tokenIdentifier: `test|${userId}`,
+      },
+    };
+  });
+}
+
+describe("API-created event ownership", () => {
+  it("lets the durable community owner edit and manage media from a normal session", async () => {
+    const t = convexTest({ schema, modules });
+    const { identity, userId } = await seedOwnedCommunity(t);
+    const created = await t.mutation(internal.events.createCommunityEventForApiOwner, {
+      actorKind: "personal_api_token",
+      ownerUserId: userId,
+      title: "Faceless Friday",
+      communitySlug: "faceless",
+      startAt: NOW + 86_400_000,
+      summary: "Created through the public API.",
+    });
+
+    await t.withIdentity(identity).mutation(api.events.updateCommunityEvent, {
+      currentSlug: created.slug,
+      title: "Faceless Friday",
+      communitySlug: "faceless",
+      startAt: NOW + 86_400_000,
+      summary: "Edited through the normal web session.",
+    });
+    const media = await t.withIdentity(identity).mutation(api.events.configureVrcdnOutput, {
+      currentSlug: created.slug,
+      key: "main",
+      label: "Main output",
+    });
+
+    assert.equal(media.state, "draft");
+    const stored = await t.run(async (ctx) => ctx.db.get(created.eventId));
+    assert.equal(stored?.summary, "Edited through the normal web session.");
+  });
+
+  it("preserves omitted values and clears explicit nullable fields and the world relation", async () => {
+    const t = convexTest({ schema, modules });
+    const { userId } = await seedOwnedCommunity(t);
+    await t.run((ctx) =>
+      ctx.db.insert("worlds", {
+        slug: "faceless-club",
+        displayName: "Faceless Club",
+        sortName: "faceless club",
+        tags: [],
+        visibilityStatus: "public",
+        platformCompatibility: ["pc"],
+        media: [],
+        creatorAttributions: [],
+        outboundLinks: [],
+        publicationState: "published",
+        creationSource: "community",
+        updatedAt: NOW,
+      }),
+    );
+    const created = await t.mutation(internal.events.createCommunityEventForApiOwner, {
+      actorKind: "personal_api_token",
+      ownerUserId: userId,
+      title: "Faceless Friday",
+      communitySlug: "faceless",
+      worldSlug: "faceless-club",
+      startAt: NOW + 86_400_000,
+      timezone: "UTC",
+      summary: "Keep me until explicitly cleared.",
+      notes: "Preserved when omitted.",
+    });
+
+    await t.mutation(internal.events.updateCommunityEventForApiOwner, {
+      actorKind: "personal_api_token",
+      ownerUserId: userId,
+      currentSlug: created.slug,
+      summary: null,
+      timezone: null,
+      worldSlug: null,
+    });
+
+    const result = await t.run(async (ctx) => {
+      const event = await ctx.db.get(created.eventId);
+      const worldLinks = await ctx.db
+        .query("eventWorlds")
+        .withIndex("by_eventId", (query) => query.eq("eventId", created.eventId))
+        .collect();
+      return { event, worldLinks };
+    });
+    assert.equal(result.event?.summary, undefined);
+    assert.equal(result.event?.timezone, undefined);
+    assert.equal(result.event?.notes, "Preserved when omitted.");
+    assert.deepEqual(result.worldLinks, []);
+  });
+});

--- a/tests/backend/event-foundation.test.ts
+++ b/tests/backend/event-foundation.test.ts
@@ -4,7 +4,11 @@ import { describe, it } from "node:test";
 import type { Doc } from "../../convex/_generated/dataModel";
 import type { DatabaseReader } from "../../convex/_generated/server";
 import { createDiscordTimestampSet, toDiscordTimestamp } from "../../convex/_discordTimestamps";
-import { preserveOmittedEventDraftFields, sanitizeEventDraftInput } from "../../convex/_eventInputs";
+import {
+  normalizeEventDraftUpdateInput,
+  preserveOmittedEventDraftFields,
+  sanitizeEventDraftInput,
+} from "../../convex/_eventInputs";
 import { findEventOperationSlots } from "../../convex/_eventOperations";
 import {
   getPublicEventPreviews,
@@ -77,6 +81,18 @@ describe("event draft input", () => {
     assert.equal(input.summary, "Updated public event details.");
     assert.equal(Object.hasOwn(input, "participantLinks"), false);
     assert.equal(Object.hasOwn(input, "slotLinks"), false);
+  });
+
+  it("normalizes explicit API nulls into clear operations without losing supplied keys", () => {
+    const input = normalizeEventDraftUpdateInput({
+      summary: null,
+      worldSlug: null,
+    });
+
+    assert.equal(Object.hasOwn(input, "summary"), true);
+    assert.equal(Object.hasOwn(input, "worldSlug"), true);
+    assert.equal(input.summary, undefined);
+    assert.equal(input.worldSlug, undefined);
   });
 
   it("sanitizes media links, participants, and optional event fields", () => {

--- a/tests/scripts/production-runtime-health.test.ts
+++ b/tests/scripts/production-runtime-health.test.ts
@@ -108,15 +108,18 @@ test("production smoke probes a rate-limited anonymous API read", async () => {
   assert.match(smoke, /\/api\/v0\/search\?q=basicbit&limit=1/);
 });
 
-test("fixture-backed handoff coverage stays out of hosted runs", async () => {
+test("fixture-backed handoff coverage runs in the flow lane and stays out of production smoke", async () => {
   const handoff = await readFile("apps/web/e2e/handoff.flow.spec.ts", "utf8");
   const webPackage = JSON.parse(await readFile("apps/web/package.json", "utf8")) as {
     scripts?: Record<string, string>;
   };
 
   const fixtureTags = handoff.match(/@fixture/g) ?? [];
+  const flowTags = handoff.match(/@flow/g) ?? [];
 
   assert.equal(fixtureTags.length, 7);
-  assert.match(webPackage.scripts?.["test:e2e:hosted:smoke"] ?? "", /--grep-invert.*@fixture/);
+  assert.equal(flowTags.length, 7);
   assert.match(webPackage.scripts?.["test:e2e:hosted"] ?? "", /--grep @flow/);
+  assert.match(webPackage.scripts?.["test:e2e:hosted:smoke"] ?? "", /--grep-invert.*@flow/);
+  assert.match(webPackage.scripts?.["test:e2e:hosted:smoke"] ?? "", /--grep-invert.*@fixture/);
 });

--- a/tests/scripts/production-runtime-health.test.ts
+++ b/tests/scripts/production-runtime-health.test.ts
@@ -110,6 +110,7 @@ test("production smoke probes a rate-limited anonymous API read", async () => {
 
 test("fixture-backed handoff coverage runs in the flow lane and stays out of production smoke", async () => {
   const handoff = await readFile("apps/web/e2e/handoff.flow.spec.ts", "utf8");
+  const workflow = await readFile(".github/workflows/baseline-checks.yml", "utf8");
   const webPackage = JSON.parse(await readFile("apps/web/package.json", "utf8")) as {
     scripts?: Record<string, string>;
   };
@@ -119,7 +120,9 @@ test("fixture-backed handoff coverage runs in the flow lane and stays out of pro
 
   assert.equal(fixtureTags.length, 7);
   assert.equal(flowTags.length, 7);
+  assert.match(workflow, /playwright test --grep @flow --project=desktop-chromium/);
   assert.match(webPackage.scripts?.["test:e2e:hosted"] ?? "", /--grep @flow/);
+  assert.match(webPackage.scripts?.["test:e2e:hosted"] ?? "", /--grep-invert @fixture/);
   assert.match(webPackage.scripts?.["test:e2e:hosted:smoke"] ?? "", /--grep-invert.*@flow/);
   assert.match(webPackage.scripts?.["test:e2e:hosted:smoke"] ?? "", /--grep-invert.*@fixture/);
 });


### PR DESCRIPTION
[AGENT]

## Outcome

Closes #166 and removes the correctness blocker for authenticated event-write tooling.

- authorizes normal signed-in event editing, media management, and operations reads through durable community profile ownership, independent of the API credential's synthetic submitter identity
- preserves omitted PATCH fields while allowing explicit `null` clears for optional scalar fields and the world relation; empty arrays remain the collection-clear contract
- regenerates OpenAPI and documents the preserve/clear behavior
- places fixture-backed handoff coverage in the hosted flow lane while keeping it excluded from production smoke

## Root cause

API-created events stored a synthetic API submitter subject, while normal web authorization checked only that exact subject or delegated community roles. The singleton profile owner therefore could own the event's community but still fail normal edit and media checks. The PATCH transport also could not distinguish an omitted optional value from an explicit clear because nullable values were rejected before reaching Convex.

## Verification

- `pnpm test:backend` — 241 passed
- `pnpm test:scripts` — 152 passed
- `pnpm test:api-contracts` — 29 passed
- `pnpm check:api-openapi`
- `pnpm typecheck:backend`
- `pnpm typecheck:api-contracts`
- `pnpm lint:web`
- `pnpm lint:markdown`
