### PR TITLE
Add authenticated local MCP event writes

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -18,6 +18,7 @@ This repo keeps durable markdown under `docs/` so product, developer, engineerin
 - `docs/developers/partner-agent-skill.md` - Docusaurus-visible canonical partner-agent guidance
 - `docs/developers/public-api.md` - public API posture, versioning, client classes, and rate-limiting direction
 - `docs/developers/vrdex-mcp-read-tools.md` - hosted read-only VRDex MCP tools and private/local MCP direction
+- `docs/developers/vrdex-mcp-event-writes.md` - authenticated local MCP event-write contract and operator runbook
 - `docs/engineering/service-map.md` - cross-link map for services, docs, and implementation surfaces
 - `docs/deployment/aws-baseline.md` - first-pass AWS service baseline for SES and private S3 profile assets
 - `docs/deployment/docs-site.md` - Docusaurus docs deployment runbook for `docs.vrdex.net`

--- a/docs/developers/api-auth.md
+++ b/docs/developers/api-auth.md
@@ -43,6 +43,11 @@ Personal tokens are best for local automation and the local stdio MCP package:
 VRDEX_API_TOKEN=<personal-api-token> pnpm --silent --dir <path-to-vrdex-checkout> exec tsx packages/vrdex-mcp/src/stdio.ts
 ```
 
+When that token includes `events:write`, local stdio registers authenticated
+event create/update tools. The hosted anonymous MCP remains read-only. See
+`docs/developers/vrdex-mcp-event-writes.md` for approval, readback, rotation,
+and real-event production-proof requirements.
+
 ## OAuth Access Tokens
 
 OAuth access tokens are short-lived JWT bearer tokens. They are bound to:

--- a/docs/developers/mcp-client-compatibility.md
+++ b/docs/developers/mcp-client-compatibility.md
@@ -882,8 +882,12 @@ pnpm ops:mcp-client-smokes -- \
    gated until reviewed OAuth smoke secrets are installed or
    `VRDEX_HOSTED_E2E_DEVELOPER_CREDENTIALS=true` is enabled alongside the
    already-present hosted auth-helper inputs.
-1. Claude Desktop local stdio starts, lists six tools, and calls
-   `vrdex_search`.
+For local stdio rows, an anonymous session lists the six public read tools. A
+session configured with a bearer credential lists eight tools: those six reads
+plus `vrdex_event_create` and `vrdex_event_update`.
+
+1. Claude Desktop local stdio starts, lists six anonymous tools or eight
+   credentialed tools as appropriate, and calls `vrdex_search`.
 2. Claude Desktop hosted Custom Connector lists anonymous tools and completes
    OAuth for `mcp:read` when protected tools are enabled.
 3. Claude Code local stdio and hosted HTTP anonymous reads pass through
@@ -893,10 +897,12 @@ pnpm ops:mcp-client-smokes -- \
    login`, uses reviewed OAuth app client credentials, or uses
    `VRDEX_CLAUDE_CODE_OAUTH_TOKEN` fallback for an authenticated smoke, paired
    with DCR and public-client CIMD protocol evidence.
-4. Gemini CLI local stdio lists six tools through `/mcp`, hosted anonymous
-   reads work through `httpUrl`, and hosted OAuth succeeds through automatic
-   discovery or a documented static OAuth fallback.
-5. VS Code local stdio lists six tools and hosted HTTP anonymous reads work.
+4. Gemini CLI local stdio lists six anonymous tools or eight credentialed
+   tools through `/mcp`, hosted anonymous reads work through `httpUrl`, and
+   hosted OAuth succeeds through automatic discovery or a documented static
+   OAuth fallback.
+5. VS Code local stdio lists six anonymous tools or eight credentialed tools
+   and hosted HTTP anonymous reads work.
 6. Cursor local stdio and hosted HTTP read tools work in the current release.
 7. OpenAI or ChatGPT MCP-capable surfaces connect to hosted `/mcp` if the
    current product supports custom remote MCP connectors. Responses API hosted

--- a/docs/developers/self-hosting-and-iac.md
+++ b/docs/developers/self-hosting-and-iac.md
@@ -98,7 +98,7 @@ Current local stdio MCP variables:
 | Variable | Scope | Notes |
 | --- | --- | --- |
 | `VRDEX_API_BASE_URL` | Local client config | Hosted or self-hosted web origin, or explicit `/api/v0` base path. |
-| `VRDEX_API_TOKEN` | Local client secret | Personal API token for authenticated API reads. |
+| `VRDEX_API_TOKEN` | Local client secret | Personal API token for authenticated API reads and, with `events:write`, local/private MCP event tools. |
 | `VRDEX_OAUTH_ACCESS_TOKEN` | Local client secret | API-resource OAuth access token. |
 | `VRDEX_OAUTH_TOKEN_FILE` | Local client secret path | Plain token file or JSON with `access_token`. |
 | `VRDEX_MCP_OUTPUT_MODE` | Local client config | `compact` by default; `detail` pretty-prints JSON text output. |

--- a/docs/developers/vrdex-mcp-event-writes.md
+++ b/docs/developers/vrdex-mcp-event-writes.md
@@ -38,6 +38,8 @@ Both tools:
 - call the public API rather than a private Convex mutation path
 - require an API-resource credential with `events:write`, user authority, and
   ownership of the target community
+- keep the six public read tools anonymous even when the local server has a
+  write credential configured
 - are annotated as mutating and open-world so an MCP host can require
   explicit user approval
 - read the saved public event back anonymously after an accepted write, so the
@@ -94,6 +96,10 @@ readback fails, the tool reports that the write already succeeded and tells the
 caller not to retry automatically. Inspect the event by its returned slug
 before taking another action; blind retries can create a duplicate event or
 repeat an audit entry.
+
+Thrown mutation requests and HTTP 5xx mutation responses are also reported as
+indeterminate outcomes because the server may have committed before the
+response failed. Inspect existing state before retrying either operation.
 
 API problem responses remain structured tool errors. They may include safe
 status, title, detail, and retry timing, but never the bearer credential.

--- a/docs/developers/vrdex-mcp-event-writes.md
+++ b/docs/developers/vrdex-mcp-event-writes.md
@@ -1,0 +1,128 @@
+# VRDex MCP Event Writes
+
+## Status
+
+Implementation checkpoint for
+[#184](https://github.com/BASIC-BIT/VRDex/issues/184).
+
+The local/private `@basicbit/vrdex-mcp` stdio server can expose authenticated
+event-create and event-update tools over the existing `/api/v0` routes. The
+hosted `/mcp` implementation remains anonymous-capable and read-only; it does
+not register these tools.
+
+The real Faceless production proof is still operator gated. Do not create a
+fake production event or execute a real write until the operator has selected
+the event data and approved that exact tool call.
+
+## Tools
+
+### `vrdex_event_create`
+
+Creates and publishes an event attached to a community owned by the
+authenticated user. Its input is the shared `ApiEventCreateRequest` contract.
+
+### `vrdex_event_update`
+
+Updates an owned community event. Its input contains:
+
+- `slug`: the event's current public slug
+- `update`: the shared `ApiEventUpdateRequest` contract
+
+Omitted update fields are preserved. Documented nullable fields use `null` to
+clear, collection fields use an empty array to clear, and lineup replacements
+must supply `participantLinks` and `slotLinks` together.
+
+Both tools:
+
+- are registered only when local stdio has a non-empty bearer credential
+- call the public API rather than a private Convex mutation path
+- require an API-resource credential with `events:write`, user authority, and
+  ownership of the target community
+- are annotated as mutating and open-world so an MCP host can require
+  explicit user approval
+- read the saved public event back after an accepted write
+- return the write identifiers, canonical URL, and normalized public event
+
+Tool annotations are advisory protocol metadata. Operators must use an MCP host
+that presents an approval step for mutating tools and inspect the exact
+arguments before accepting the call.
+
+## Local Configuration
+
+Create a personal API token at `/developers/tokens` with `events:write`.
+Configure the local stdio server without placing the raw token in repository
+files:
+
+```json
+{
+  "mcpServers": {
+    "vrdex-private": {
+      "command": "pnpm",
+      "args": [
+        "--silent",
+        "--dir",
+        "<path-to-vrdex-checkout>",
+        "exec",
+        "tsx",
+        "packages/vrdex-mcp/src/stdio.ts"
+      ],
+      "env": {
+        "VRDEX_API_BASE_URL": "https://vrdex.net",
+        "VRDEX_API_TOKEN": "<personal-api-token>"
+      }
+    }
+  }
+}
+```
+
+An API-resource OAuth access token can be supplied through
+`VRDEX_OAUTH_ACCESS_TOKEN` or `VRDEX_OAUTH_TOKEN_FILE`. Hosted `/mcp` tokens are
+bound to the MCP resource and cannot be reused for these API-backed local
+tools.
+
+If no bearer credential is configured, local stdio lists only the six public
+read tools. A present but revoked, expired, under-scoped, wrong-resource, or
+wrong-owner credential still lists the tools, but the API rejects every write
+before mutation.
+
+## Write And Readback Safety
+
+An accepted mutation is followed by `GET /api/v0/events/:slug`. If that
+readback fails, the tool reports that the write already succeeded and tells the
+caller not to retry automatically. Inspect the event by its returned slug
+before taking another action; blind retries can create a duplicate event or
+repeat an audit entry.
+
+API problem responses remain structured tool errors. They may include safe
+status, title, detail, and retry timing, but never the bearer credential.
+
+## Operator Runbook
+
+Before a real community event write:
+
+1. Use `GET /api/v0/me` to confirm the credential is user-authorized and has
+   `events:write`.
+2. Use `GET /api/v0/me/communities` to confirm the target community is claimed
+   and owned by that user.
+3. Prepare the complete create payload or the minimal update payload.
+4. Show the exact tool name and arguments to the operator.
+5. Execute only after explicit action-time approval.
+6. Confirm the tool's normalized readback and canonical public URL.
+7. Open the event in the normal signed-in web UI and verify edit and media
+   authority.
+8. Record only sanitized evidence. Never paste tokens into issues, logs, docs,
+   or screenshots.
+
+For the first Faceless proof, use a real operator-selected event. The proof must
+cover MCP write, API/public readback, the public event page, and normal web
+edit/media authority. It must not enable VRChat telemetry collection or weaken
+the separate provider-approval and non-empty-instance gates.
+
+## Rotation And Revocation
+
+- Revoke a personal token immediately from `/developers/tokens` when it is no
+  longer needed or may have been exposed.
+- Create a replacement token before updating local MCP configuration.
+- Restart the MCP client after rotating the configured credential.
+- OAuth access tokens remain short-lived and resource-bound; rotate them
+  through the normal authorization and refresh-token flow.

--- a/docs/developers/vrdex-mcp-event-writes.md
+++ b/docs/developers/vrdex-mcp-event-writes.md
@@ -40,7 +40,8 @@ Both tools:
   ownership of the target community
 - are annotated as mutating and open-world so an MCP host can require
   explicit user approval
-- read the saved public event back after an accepted write
+- read the saved public event back anonymously after an accepted write, so the
+  write credential does not also need `public:read`
 - return the write identifiers, canonical URL, and normalized public event
 
 Tool annotations are advisory protocol metadata. Operators must use an MCP host
@@ -49,9 +50,10 @@ arguments before accepting the call.
 
 ## Local Configuration
 
-Create a personal API token at `/developers/tokens` with `events:write`.
-Configure the local stdio server without placing the raw token in repository
-files:
+Create a personal API token at `/developers/tokens` with `events:write`. Add
+`community:read` when following the full operator runbook, which verifies the
+target community through `/api/v0/me/communities`. Configure the local stdio
+server without placing the raw token in repository files:
 
 ```json
 {
@@ -101,7 +103,7 @@ status, title, detail, and retry timing, but never the bearer credential.
 Before a real community event write:
 
 1. Use `GET /api/v0/me` to confirm the credential is user-authorized and has
-   `events:write`.
+   `events:write` plus `community:read`.
 2. Use `GET /api/v0/me/communities` to confirm the target community is claimed
    and owned by that user.
 3. Prepare the complete create payload or the minimal update payload.

--- a/docs/developers/vrdex-mcp-read-tools.md
+++ b/docs/developers/vrdex-mcp-read-tools.md
@@ -203,6 +203,13 @@ OAuth token file can contain a plain access token or a JSON object with an
 tokens used here must be issued for the API resource. Hosted `/mcp` OAuth
 sessions use the MCP resource instead.
 
+When a bearer credential is configured, local stdio also registers the
+approval-gated `vrdex_event_create` and `vrdex_event_update` tools. They require
+`events:write`, use the existing public API routes, and read the normalized
+event back after every accepted mutation. See
+`docs/developers/vrdex-mcp-event-writes.md` for the write contract and operator
+runbook. These tools are not registered by the hosted `/mcp` server.
+
 Local workspace command:
 
 ```sh

--- a/packages/vrdex-mcp/src/api-client.ts
+++ b/packages/vrdex-mcp/src/api-client.ts
@@ -163,7 +163,7 @@ export function createVrdexApiClient(options: ApiClientOptions) {
     path: string,
     searchParams?: Record<string, number | string | undefined>,
   ) {
-    return request(schema, path, { searchParams });
+    return request(schema, path, { authenticate: false, searchParams });
   }
 
   return {

--- a/packages/vrdex-mcp/src/api-client.ts
+++ b/packages/vrdex-mcp/src/api-client.ts
@@ -1,5 +1,8 @@
 import type { z } from "@vrdex/api-contracts";
 import {
+  ApiEventCreateRequestSchema,
+  ApiEventUpdateRequestSchema,
+  ApiEventWriteResponseSchema,
   PublicActiveWorldsResponseSchema,
   PublicEventSchema,
   PublicEventsResponseSchema,
@@ -12,6 +15,8 @@ import type { VrdexMcpConfig } from "./config";
 
 export type VrdexSearchType = "all" | "person" | "community" | "profile" | "world" | "event";
 export type VrdexProfileType = "person" | "community";
+export type VrdexEventCreateInput = z.infer<typeof ApiEventCreateRequestSchema>;
+export type VrdexEventUpdateInput = z.infer<typeof ApiEventUpdateRequestSchema>;
 
 export type VrdexApiSuccess<T> = {
   data: T;
@@ -105,12 +110,16 @@ export function createVrdexApiClient(options: ApiClientOptions) {
   const fetcher = options.fetch ?? fetch;
   const userAgent = options.userAgent ?? "vrdex-mcp/0.0.0";
 
-  async function get<T>(
+  async function request<T>(
     schema: ResponseSchema<T>,
     path: string,
-    searchParams?: Record<string, number | string | undefined>,
+    requestOptions: {
+      body?: unknown;
+      method?: "GET" | "PATCH" | "POST";
+      searchParams?: Record<string, number | string | undefined>;
+    } = {},
   ): Promise<VrdexApiResult<T>> {
-    const url = buildApiUrl(options.apiBaseUrl, path, searchParams);
+    const url = buildApiUrl(options.apiBaseUrl, path, requestOptions.searchParams);
     const headers = new Headers({
       accept: "application/json",
       "user-agent": userAgent,
@@ -120,7 +129,15 @@ export function createVrdexApiClient(options: ApiClientOptions) {
       headers.set("authorization", `Bearer ${options.bearerToken}`);
     }
 
-    const response = await fetcher(url, { headers });
+    if (requestOptions.body !== undefined) {
+      headers.set("content-type", "application/json");
+    }
+
+    const response = await fetcher(url, {
+      headers,
+      method: requestOptions.method ?? "GET",
+      ...(requestOptions.body === undefined ? {} : { body: JSON.stringify(requestOptions.body) }),
+    });
     const payload = await parseResponseBody(response);
 
     if (!response.ok) {
@@ -140,9 +157,23 @@ export function createVrdexApiClient(options: ApiClientOptions) {
     return { ok: true, data: schema.parse(payload) };
   }
 
+  function get<T>(
+    schema: ResponseSchema<T>,
+    path: string,
+    searchParams?: Record<string, number | string | undefined>,
+  ) {
+    return request(schema, path, { searchParams });
+  }
+
   return {
     get apiBaseUrl() {
       return options.apiBaseUrl;
+    },
+    createEvent(input: VrdexEventCreateInput) {
+      return request(ApiEventWriteResponseSchema, "events", {
+        body: ApiEventCreateRequestSchema.parse(input),
+        method: "POST",
+      });
     },
     getEvent(slug: string) {
       return get(PublicEventSchema, `events/${encodeURIComponent(slug)}`);
@@ -167,6 +198,12 @@ export function createVrdexApiClient(options: ApiClientOptions) {
         limit: input.limit,
         q: input.query,
         type: input.type,
+      });
+    },
+    updateEvent(slug: string, input: VrdexEventUpdateInput) {
+      return request(ApiEventWriteResponseSchema, `events/${encodeURIComponent(slug)}`, {
+        body: ApiEventUpdateRequestSchema.parse(input),
+        method: "PATCH",
       });
     },
   };

--- a/packages/vrdex-mcp/src/api-client.ts
+++ b/packages/vrdex-mcp/src/api-client.ts
@@ -114,6 +114,7 @@ export function createVrdexApiClient(options: ApiClientOptions) {
     schema: ResponseSchema<T>,
     path: string,
     requestOptions: {
+      authenticate?: boolean;
       body?: unknown;
       method?: "GET" | "PATCH" | "POST";
       searchParams?: Record<string, number | string | undefined>;
@@ -125,7 +126,7 @@ export function createVrdexApiClient(options: ApiClientOptions) {
       "user-agent": userAgent,
     });
 
-    if (options.bearerToken !== undefined) {
+    if (requestOptions.authenticate !== false && options.bearerToken !== undefined) {
       headers.set("authorization", `Bearer ${options.bearerToken}`);
     }
 
@@ -177,6 +178,11 @@ export function createVrdexApiClient(options: ApiClientOptions) {
     },
     getEvent(slug: string) {
       return get(PublicEventSchema, `events/${encodeURIComponent(slug)}`);
+    },
+    getPublicEvent(slug: string) {
+      return request(PublicEventSchema, `events/${encodeURIComponent(slug)}`, {
+        authenticate: false,
+      });
     },
     getProfile(input: { profileType?: VrdexProfileType; slug: string }) {
       const segment =

--- a/packages/vrdex-mcp/src/index.ts
+++ b/packages/vrdex-mcp/src/index.ts
@@ -4,6 +4,8 @@ export type {
   VrdexApiFailure,
   VrdexApiResult,
   VrdexApiSuccess,
+  VrdexEventCreateInput,
+  VrdexEventUpdateInput,
   VrdexProfileType,
   VrdexSearchType,
 } from "./api-client";

--- a/packages/vrdex-mcp/src/server.ts
+++ b/packages/vrdex-mcp/src/server.ts
@@ -302,7 +302,7 @@ export function buildVrdexMcpServer(options: VrdexMcpServerOptions = {}) {
         }
 
         if (!write.ok) {
-          return mcpApiError(write);
+          return write.status >= 500 ? mcpEventWriteIndeterminate("create") : mcpApiError(write);
         }
 
         let readback: Awaited<ReturnType<typeof apiClient.getPublicEvent>>;
@@ -354,7 +354,7 @@ export function buildVrdexMcpServer(options: VrdexMcpServerOptions = {}) {
         }
 
         if (!write.ok) {
-          return mcpApiError(write);
+          return write.status >= 500 ? mcpEventWriteIndeterminate("update") : mcpApiError(write);
         }
 
         let readback: Awaited<ReturnType<typeof apiClient.getPublicEvent>>;

--- a/packages/vrdex-mcp/src/server.ts
+++ b/packages/vrdex-mcp/src/server.ts
@@ -1,5 +1,8 @@
 import { fromJsonSchema, McpServer } from "@modelcontextprotocol/server";
 import {
+  ApiEventCreateRequestSchema,
+  ApiEventUpdateRequestSchema,
+  ApiEventWriteResponseSchema,
   mcpOutputJsonSchemaForZodSchema,
   PublicActiveWorldsResponseSchema,
   PublicEventSchema,
@@ -24,6 +27,17 @@ export type VrdexMcpServerOptions = {
 const mcpSearchTypes = ["all", "person", "community", "profile", "world", "event"] as const;
 const mcpSlugSchema = z.string().min(1).max(160);
 const mcpLimitSchema = z.number().int().min(1);
+const mcpEventUpdateInputSchema = z.object({
+  slug: mcpSlugSchema.describe("Current public event slug."),
+  update: ApiEventUpdateRequestSchema,
+});
+const mcpEventWriteResultSchema = ApiEventWriteResponseSchema.extend({
+  canonicalUrl: z.string().url(),
+  event: PublicEventSchema,
+}).meta({
+  description: "Accepted event write plus the normalized public event read back from VRDex.",
+  id: "McpEventWriteResult",
+});
 
 function boundedLimit(value: number | undefined, fallback: number, max: number) {
   return Math.max(1, Math.min(value ?? fallback, max));
@@ -62,6 +76,35 @@ function mcpApiError(error: VrdexApiFailure) {
 
   if (error.retryAfter !== undefined) {
     parts.push(`Retry after ${error.retryAfter} seconds.`);
+  }
+
+  return {
+    content: [{ type: "text" as const, text: parts.join(" ") }],
+    isError: true as const,
+  };
+}
+
+function canonicalEventUrl(apiBaseUrl: string, eventPath: string) {
+  const url = new URL(apiBaseUrl);
+
+  url.pathname = eventPath;
+  url.search = "";
+  url.hash = "";
+
+  return url.toString();
+}
+
+function mcpEventReadbackError(
+  write: z.infer<typeof ApiEventWriteResponseSchema>,
+  error: VrdexApiFailure,
+) {
+  const parts = [
+    `VRDex accepted the event write for slug "${write.slug}", but the required readback failed with ${error.status}: ${error.title}.`,
+    "Do not retry the mutation automatically; inspect the saved event first.",
+  ];
+
+  if (error.detail !== undefined) {
+    parts.push(error.detail);
   }
 
   return {
@@ -218,6 +261,88 @@ export function buildVrdexMcpServer(options: VrdexMcpServerOptions = {}) {
         : mcpApiError(result);
     },
   );
+
+  if (config.bearerToken !== undefined) {
+    server.registerTool(
+      "vrdex_event_create",
+      {
+        title: "Create VRDex Event",
+        description:
+          "Create and publish a community event through the authenticated VRDex API. This changes public VRDex data and requires explicit operator approval.",
+        inputSchema: ApiEventCreateRequestSchema,
+        outputSchema: mcpOutputSchema(mcpEventWriteResultSchema),
+        annotations: {
+          readOnlyHint: false,
+          destructiveHint: false,
+          idempotentHint: false,
+          openWorldHint: true,
+        },
+      },
+      async (input) => {
+        const write = await apiClient.createEvent(input);
+
+        if (!write.ok) {
+          return mcpApiError(write);
+        }
+
+        const readback = await apiClient.getEvent(write.data.slug);
+
+        if (!readback.ok) {
+          return mcpEventReadbackError(write.data, readback);
+        }
+
+        return mcpJsonResult(
+          mcpEventWriteResultSchema,
+          {
+            ...write.data,
+            canonicalUrl: canonicalEventUrl(apiClient.apiBaseUrl, write.data.eventPath),
+            event: readback.data,
+          },
+          config.outputMode,
+        );
+      },
+    );
+
+    server.registerTool(
+      "vrdex_event_update",
+      {
+        title: "Update VRDex Event",
+        description:
+          "Update a community event through the authenticated VRDex API. Omitted fields are preserved; explicit nulls and empty arrays can clear data. This changes public VRDex data and requires explicit operator approval.",
+        inputSchema: mcpEventUpdateInputSchema,
+        outputSchema: mcpOutputSchema(mcpEventWriteResultSchema),
+        annotations: {
+          readOnlyHint: false,
+          destructiveHint: true,
+          idempotentHint: false,
+          openWorldHint: true,
+        },
+      },
+      async ({ slug, update }) => {
+        const write = await apiClient.updateEvent(slug, update);
+
+        if (!write.ok) {
+          return mcpApiError(write);
+        }
+
+        const readback = await apiClient.getEvent(write.data.slug);
+
+        if (!readback.ok) {
+          return mcpEventReadbackError(write.data, readback);
+        }
+
+        return mcpJsonResult(
+          mcpEventWriteResultSchema,
+          {
+            ...write.data,
+            canonicalUrl: canonicalEventUrl(apiClient.apiBaseUrl, write.data.eventPath),
+            event: readback.data,
+          },
+          config.outputMode,
+        );
+      },
+    );
+  }
 
   return server;
 }

--- a/packages/vrdex-mcp/src/server.ts
+++ b/packages/vrdex-mcp/src/server.ts
@@ -96,19 +96,33 @@ function canonicalEventUrl(apiBaseUrl: string, eventPath: string) {
 
 function mcpEventReadbackError(
   write: z.infer<typeof ApiEventWriteResponseSchema>,
-  error: VrdexApiFailure,
+  error?: VrdexApiFailure,
 ) {
   const parts = [
-    `VRDex accepted the event write for slug "${write.slug}", but the required readback failed with ${error.status}: ${error.title}.`,
+    error === undefined
+      ? `VRDex accepted the event write for slug "${write.slug}", but the required readback did not complete cleanly.`
+      : `VRDex accepted the event write for slug "${write.slug}", but the required readback failed with ${error.status}: ${error.title}.`,
     "Do not retry the mutation automatically; inspect the saved event first.",
   ];
 
-  if (error.detail !== undefined) {
+  if (error?.detail !== undefined) {
     parts.push(error.detail);
   }
 
   return {
     content: [{ type: "text" as const, text: parts.join(" ") }],
+    isError: true as const,
+  };
+}
+
+function mcpEventWriteIndeterminate(operation: "create" | "update") {
+  return {
+    content: [
+      {
+        type: "text" as const,
+        text: `The VRDex event ${operation} request did not complete cleanly, and the server may already have accepted the mutation. Do not retry the mutation automatically; inspect the target event or community first.`,
+      },
+    ],
     isError: true as const,
   };
 }
@@ -279,13 +293,25 @@ export function buildVrdexMcpServer(options: VrdexMcpServerOptions = {}) {
         },
       },
       async (input) => {
-        const write = await apiClient.createEvent(input);
+        let write: Awaited<ReturnType<typeof apiClient.createEvent>>;
+
+        try {
+          write = await apiClient.createEvent(input);
+        } catch {
+          return mcpEventWriteIndeterminate("create");
+        }
 
         if (!write.ok) {
           return mcpApiError(write);
         }
 
-        const readback = await apiClient.getEvent(write.data.slug);
+        let readback: Awaited<ReturnType<typeof apiClient.getPublicEvent>>;
+
+        try {
+          readback = await apiClient.getPublicEvent(write.data.slug);
+        } catch {
+          return mcpEventReadbackError(write.data);
+        }
 
         if (!readback.ok) {
           return mcpEventReadbackError(write.data, readback);
@@ -319,13 +345,25 @@ export function buildVrdexMcpServer(options: VrdexMcpServerOptions = {}) {
         },
       },
       async ({ slug, update }) => {
-        const write = await apiClient.updateEvent(slug, update);
+        let write: Awaited<ReturnType<typeof apiClient.updateEvent>>;
+
+        try {
+          write = await apiClient.updateEvent(slug, update);
+        } catch {
+          return mcpEventWriteIndeterminate("update");
+        }
 
         if (!write.ok) {
           return mcpApiError(write);
         }
 
-        const readback = await apiClient.getEvent(write.data.slug);
+        let readback: Awaited<ReturnType<typeof apiClient.getPublicEvent>>;
+
+        try {
+          readback = await apiClient.getPublicEvent(write.data.slug);
+        } catch {
+          return mcpEventReadbackError(write.data);
+        }
 
         if (!readback.ok) {
           return mcpEventReadbackError(write.data, readback);

--- a/packages/vrdex-mcp/tests/api-client.test.ts
+++ b/packages/vrdex-mcp/tests/api-client.test.ts
@@ -7,6 +7,8 @@ import { normalizeApiBaseUrl } from "../src/config";
 
 type FixtureRequest = {
   authorization: string | undefined;
+  body: unknown;
+  contentType: string | undefined;
   method: string | undefined;
   pathname: string;
   searchParams: URLSearchParams;
@@ -26,11 +28,26 @@ function eventPreview(slug = "club-night") {
   };
 }
 
-function handleFixtureRequest(request: IncomingMessage, response: ServerResponse, requests: FixtureRequest[]) {
+async function requestBody(request: IncomingMessage) {
+  const chunks: Buffer[] = [];
+
+  for await (const chunk of request) {
+    chunks.push(Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk));
+  }
+
+  const text = Buffer.concat(chunks).toString("utf8");
+
+  return text ? (JSON.parse(text) as unknown) : undefined;
+}
+
+async function handleFixtureRequest(request: IncomingMessage, response: ServerResponse, requests: FixtureRequest[]) {
   const url = new URL(request.url ?? "/", "http://127.0.0.1");
+  const body = await requestBody(request);
 
   requests.push({
     authorization: request.headers.authorization,
+    body,
+    contentType: request.headers["content-type"],
     method: request.method,
     pathname: url.pathname,
     searchParams: url.searchParams,
@@ -68,6 +85,36 @@ function handleFixtureRequest(request: IncomingMessage, response: ServerResponse
         currentPopulation: { value: 42, activeInstanceCount: 2, observedAt: 1798761600000, coverage: "observed" },
       },
       trustLabel: "claimed_verified",
+    });
+
+    return;
+  }
+
+  if (url.pathname.endsWith("/api/v0/events") && request.method === "POST") {
+    writeJson(response, 200, {
+      eventId: "event_created",
+      eventPath: "/events/created-club-night",
+      slug: "created-club-night",
+    });
+
+    return;
+  }
+
+  if (url.pathname.endsWith("/api/v0/events/club-night") && request.method === "PATCH") {
+    writeJson(response, 200, {
+      eventId: "event_1",
+      eventPath: "/events/club-night",
+      slug: "club-night",
+    });
+
+    return;
+  }
+
+  if (url.pathname.endsWith("/api/v0/events/created-club-night")) {
+    writeJson(response, 200, {
+      ...eventPreview("created-club-night"),
+      id: "event_created",
+      watchSurfaceEnabled: false,
     });
 
     return;
@@ -130,7 +177,15 @@ function handleFixtureRequest(request: IncomingMessage, response: ServerResponse
 
 async function startFixtureServer() {
   const requests: FixtureRequest[] = [];
-  const server = createServer((request, response) => handleFixtureRequest(request, response, requests));
+  const server = createServer((request, response) => {
+    void handleFixtureRequest(request, response, requests).catch((error: unknown) => {
+      writeJson(response, 500, {
+        detail: error instanceof Error ? error.message : "Fixture request failed.",
+        status: 500,
+        title: "Fixture error",
+      });
+    });
+  });
 
   await new Promise<void>((resolve) => {
     server.listen(0, "127.0.0.1", resolve);
@@ -161,6 +216,14 @@ test("calls public API routes with bearer credentials and validates schemas", as
     const upcoming = await client.listUpcomingEvents({ limit: 1 });
     const world = await client.getWorld("club-world");
     const activeWorlds = await client.listActiveWorlds({ limit: 1 });
+    const created = await client.createEvent({
+      communitySlug: "basic-bit",
+      startAt: 1_798_761_600_000,
+      title: "Created Club Night",
+    });
+    const updated = await client.updateEvent("club-night", {
+      summary: null,
+    });
 
     assert.equal(search.ok, true);
     assert.equal(profile.ok, true);
@@ -169,6 +232,8 @@ test("calls public API routes with bearer credentials and validates schemas", as
     assert.equal(upcoming.ok, true);
     assert.equal(world.ok, true);
     assert.equal(activeWorlds.ok, true);
+    assert.equal(created.ok, true);
+    assert.equal(updated.ok, true);
     assert.deepEqual(
       fixture.requests.map((request) => request.pathname),
       [
@@ -178,12 +243,24 @@ test("calls public API routes with bearer credentials and validates schemas", as
         "/custom-root/api/v0/events/upcoming",
         "/custom-root/api/v0/worlds/club-world",
         "/custom-root/api/v0/worlds/active",
+        "/custom-root/api/v0/events",
+        "/custom-root/api/v0/events/club-night",
       ],
     );
     assert.equal(fixture.requests[0]?.authorization, "Bearer vrdx_test_token");
     assert.equal(fixture.requests[0]?.searchParams.get("q"), "club");
     assert.equal(fixture.requests[0]?.searchParams.get("type"), "event");
     assert.equal(fixture.requests[0]?.searchParams.get("limit"), "2");
+    assert.equal(fixture.requests[6]?.authorization, "Bearer vrdx_test_token");
+    assert.equal(fixture.requests[6]?.contentType, "application/json");
+    assert.equal(fixture.requests[6]?.method, "POST");
+    assert.deepEqual(fixture.requests[6]?.body, {
+      communitySlug: "basic-bit",
+      startAt: 1_798_761_600_000,
+      title: "Created Club Night",
+    });
+    assert.equal(fixture.requests[7]?.method, "PATCH");
+    assert.deepEqual(fixture.requests[7]?.body, { summary: null });
   } finally {
     await fixture.close();
   }

--- a/packages/vrdex-mcp/tests/api-client.test.ts
+++ b/packages/vrdex-mcp/tests/api-client.test.ts
@@ -250,7 +250,7 @@ test("calls public API routes with bearer credentials and validates schemas", as
         "/custom-root/api/v0/events/club-night",
       ],
     );
-    assert.equal(fixture.requests[0]?.authorization, "Bearer vrdx_test_token");
+    assert.equal(fixture.requests[0]?.authorization, undefined);
     assert.equal(fixture.requests[0]?.searchParams.get("q"), "club");
     assert.equal(fixture.requests[0]?.searchParams.get("type"), "event");
     assert.equal(fixture.requests[0]?.searchParams.get("limit"), "2");
@@ -263,6 +263,7 @@ test("calls public API routes with bearer credentials and validates schemas", as
       title: "Created Club Night",
     });
     assert.equal(fixture.requests[7]?.authorization, undefined);
+    assert.equal(fixture.requests[8]?.authorization, "Bearer vrdx_test_token");
     assert.equal(fixture.requests[8]?.method, "PATCH");
     assert.deepEqual(fixture.requests[8]?.body, { summary: null });
   } finally {

--- a/packages/vrdex-mcp/tests/api-client.test.ts
+++ b/packages/vrdex-mcp/tests/api-client.test.ts
@@ -221,6 +221,7 @@ test("calls public API routes with bearer credentials and validates schemas", as
       startAt: 1_798_761_600_000,
       title: "Created Club Night",
     });
+    const publicReadback = await client.getPublicEvent("created-club-night");
     const updated = await client.updateEvent("club-night", {
       summary: null,
     });
@@ -233,6 +234,7 @@ test("calls public API routes with bearer credentials and validates schemas", as
     assert.equal(world.ok, true);
     assert.equal(activeWorlds.ok, true);
     assert.equal(created.ok, true);
+    assert.equal(publicReadback.ok, true);
     assert.equal(updated.ok, true);
     assert.deepEqual(
       fixture.requests.map((request) => request.pathname),
@@ -244,6 +246,7 @@ test("calls public API routes with bearer credentials and validates schemas", as
         "/custom-root/api/v0/worlds/club-world",
         "/custom-root/api/v0/worlds/active",
         "/custom-root/api/v0/events",
+        "/custom-root/api/v0/events/created-club-night",
         "/custom-root/api/v0/events/club-night",
       ],
     );
@@ -259,8 +262,9 @@ test("calls public API routes with bearer credentials and validates schemas", as
       startAt: 1_798_761_600_000,
       title: "Created Club Night",
     });
-    assert.equal(fixture.requests[7]?.method, "PATCH");
-    assert.deepEqual(fixture.requests[7]?.body, { summary: null });
+    assert.equal(fixture.requests[7]?.authorization, undefined);
+    assert.equal(fixture.requests[8]?.method, "PATCH");
+    assert.deepEqual(fixture.requests[8]?.body, { summary: null });
   } finally {
     await fixture.close();
   }

--- a/packages/vrdex-mcp/tests/api-fixture.ts
+++ b/packages/vrdex-mcp/tests/api-fixture.ts
@@ -104,6 +104,21 @@ async function handleFixtureRequest(
       body !== null &&
       typeof body === "object" &&
       "title" in body &&
+      body.title === "Server Error After Create"
+    ) {
+      writeJson(response, 500, {
+        status: 500,
+        title: "Response failed after mutation",
+        type: "about:blank",
+      });
+
+      return;
+    }
+
+    if (
+      body !== null &&
+      typeof body === "object" &&
+      "title" in body &&
       body.title === "Readback Failure"
     ) {
       writeJson(response, 200, {
@@ -147,6 +162,21 @@ async function handleFixtureRequest(
       body.summary === "Indeterminate Update"
     ) {
       response.destroy();
+
+      return;
+    }
+
+    if (
+      body !== null &&
+      typeof body === "object" &&
+      "summary" in body &&
+      body.summary === "Server Error After Update"
+    ) {
+      writeJson(response, 500, {
+        status: 500,
+        title: "Response failed after mutation",
+        type: "about:blank",
+      });
 
       return;
     }

--- a/packages/vrdex-mcp/tests/api-fixture.ts
+++ b/packages/vrdex-mcp/tests/api-fixture.ts
@@ -2,6 +2,9 @@ import assert from "node:assert/strict";
 import { createServer, type IncomingMessage, type ServerResponse } from "node:http";
 
 export type VrdexMcpApiFixtureRequest = {
+  authorization: string | undefined;
+  body: unknown;
+  method: string | undefined;
   pathname: string;
   searchParams: URLSearchParams;
 };
@@ -20,14 +23,33 @@ function eventPreview(slug = "club-night") {
   };
 }
 
-function handleFixtureRequest(
+async function requestBody(request: IncomingMessage) {
+  const chunks: Buffer[] = [];
+
+  for await (const chunk of request) {
+    chunks.push(Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk));
+  }
+
+  const text = Buffer.concat(chunks).toString("utf8");
+
+  return text ? (JSON.parse(text) as unknown) : undefined;
+}
+
+async function handleFixtureRequest(
   request: IncomingMessage,
   response: ServerResponse,
   captured: VrdexMcpApiFixtureRequest[],
 ) {
   const url = new URL(request.url ?? "/", "http://127.0.0.1");
+  const body = await requestBody(request);
 
-  captured.push({ pathname: url.pathname, searchParams: url.searchParams });
+  captured.push({
+    authorization: request.headers.authorization,
+    body,
+    method: request.method,
+    pathname: url.pathname,
+    searchParams: url.searchParams,
+  });
 
   if (url.pathname.endsWith("/api/v0/search")) {
     writeJson(response, 200, {
@@ -61,6 +83,51 @@ function handleFixtureRequest(
         currentPopulation: { value: 42, activeInstanceCount: 2, observedAt: 1798761600000, coverage: "observed" },
       },
       trustLabel: "claimed_verified",
+    });
+
+    return;
+  }
+
+  if (url.pathname.endsWith("/api/v0/events") && request.method === "POST") {
+    if (
+      body !== null &&
+      typeof body === "object" &&
+      "title" in body &&
+      body.title === "Readback Failure"
+    ) {
+      writeJson(response, 200, {
+        eventId: "event_missing_readback",
+        eventPath: "/events/missing-readback",
+        slug: "missing-readback",
+      });
+
+      return;
+    }
+
+    writeJson(response, 200, {
+      eventId: "event_created",
+      eventPath: "/events/created-club-night",
+      slug: "created-club-night",
+    });
+
+    return;
+  }
+
+  if (url.pathname.endsWith("/api/v0/events/club-night") && request.method === "PATCH") {
+    writeJson(response, 200, {
+      eventId: "event_1",
+      eventPath: "/events/club-night",
+      slug: "club-night",
+    });
+
+    return;
+  }
+
+  if (url.pathname.endsWith("/api/v0/events/created-club-night")) {
+    writeJson(response, 200, {
+      ...eventPreview("created-club-night"),
+      id: "event_created",
+      watchSurfaceEnabled: false,
     });
 
     return;
@@ -123,7 +190,15 @@ function handleFixtureRequest(
 
 export async function startVrdexMcpApiFixture() {
   const captured: VrdexMcpApiFixtureRequest[] = [];
-  const server = createServer((request, response) => handleFixtureRequest(request, response, captured));
+  const server = createServer((request, response) => {
+    void handleFixtureRequest(request, response, captured).catch((error: unknown) => {
+      writeJson(response, 500, {
+        detail: error instanceof Error ? error.message : "Fixture request failed.",
+        status: 500,
+        title: "Fixture error",
+      });
+    });
+  });
 
   await new Promise<void>((resolve) => {
     server.listen(0, "127.0.0.1", resolve);

--- a/packages/vrdex-mcp/tests/api-fixture.ts
+++ b/packages/vrdex-mcp/tests/api-fixture.ts
@@ -93,12 +93,38 @@ async function handleFixtureRequest(
       body !== null &&
       typeof body === "object" &&
       "title" in body &&
+      body.title === "Indeterminate Create"
+    ) {
+      response.destroy();
+
+      return;
+    }
+
+    if (
+      body !== null &&
+      typeof body === "object" &&
+      "title" in body &&
       body.title === "Readback Failure"
     ) {
       writeJson(response, 200, {
         eventId: "event_missing_readback",
         eventPath: "/events/missing-readback",
         slug: "missing-readback",
+      });
+
+      return;
+    }
+
+    if (
+      body !== null &&
+      typeof body === "object" &&
+      "title" in body &&
+      body.title === "Thrown Readback"
+    ) {
+      writeJson(response, 200, {
+        eventId: "event_invalid_readback",
+        eventPath: "/events/invalid-readback",
+        slug: "invalid-readback",
       });
 
       return;
@@ -114,11 +140,28 @@ async function handleFixtureRequest(
   }
 
   if (url.pathname.endsWith("/api/v0/events/club-night") && request.method === "PATCH") {
+    if (
+      body !== null &&
+      typeof body === "object" &&
+      "summary" in body &&
+      body.summary === "Indeterminate Update"
+    ) {
+      response.destroy();
+
+      return;
+    }
+
     writeJson(response, 200, {
       eventId: "event_1",
       eventPath: "/events/club-night",
       slug: "club-night",
     });
+
+    return;
+  }
+
+  if (url.pathname.endsWith("/api/v0/events/invalid-readback")) {
+    writeJson(response, 200, {});
 
     return;
   }

--- a/packages/vrdex-mcp/tests/stdio.test.ts
+++ b/packages/vrdex-mcp/tests/stdio.test.ts
@@ -397,7 +397,46 @@ test("serves VRDex tools over stdio and calls the configured API base URL", asyn
     assert.match(thrownReadbackResult.content?.[0]?.text ?? "", /write for slug "invalid-readback"/);
     assert.match(thrownReadbackResult.content?.[0]?.text ?? "", /Do not retry the mutation automatically/);
 
-    assert.equal(fixture.captured.length, 16);
+    const serverErrorCreate = await callTool({
+      id: 15,
+      messages,
+      name: "vrdex_event_create",
+      onMessage,
+      send,
+      stderr,
+      toolArgs: {
+        communitySlug: "basic-bit",
+        startAt: 1_798_761_600_000,
+        title: "Server Error After Create",
+      },
+    });
+    const serverErrorCreateResult = serverErrorCreate.result as {
+      content?: Array<{ text?: string }>;
+      isError?: boolean;
+    };
+    assert.equal(serverErrorCreateResult.isError, true);
+    assert.match(serverErrorCreateResult.content?.[0]?.text ?? "", /may already have accepted the mutation/);
+
+    const serverErrorUpdate = await callTool({
+      id: 16,
+      messages,
+      name: "vrdex_event_update",
+      onMessage,
+      send,
+      stderr,
+      toolArgs: {
+        slug: "club-night",
+        update: { summary: "Server Error After Update" },
+      },
+    });
+    const serverErrorUpdateResult = serverErrorUpdate.result as {
+      content?: Array<{ text?: string }>;
+      isError?: boolean;
+    };
+    assert.equal(serverErrorUpdateResult.isError, true);
+    assert.match(serverErrorUpdateResult.content?.[0]?.text ?? "", /may already have accepted the mutation/);
+
+    assert.equal(fixture.captured.length, 18);
     assert.deepEqual(
       fixture.captured.map((request) => request.pathname),
       [
@@ -417,6 +456,8 @@ test("serves VRDex tools over stdio and calls the configured API base URL", asyn
         "/api/v0/events/club-night",
         "/api/v0/events",
         "/api/v0/events/invalid-readback",
+        "/api/v0/events",
+        "/api/v0/events/club-night",
       ],
     );
     assert.equal(fixture.captured[0]?.searchParams.get("q"), "club");
@@ -424,11 +465,11 @@ test("serves VRDex tools over stdio and calls the configured API base URL", asyn
     assert.equal(fixture.captured[0]?.searchParams.get("limit"), "2");
     assert.equal(fixture.captured[3]?.searchParams.get("limit"), "1");
     assert.equal(fixture.captured[5]?.searchParams.get("limit"), "1");
-    const anonymousReadbackIndexes = new Set([7, 9, 11, 15]);
+    const authenticatedMutationIndexes = new Set([6, 8, 10, 12, 13, 14, 16, 17]);
     fixture.captured.forEach((request, index) => {
       assert.equal(
         request.authorization,
-        anonymousReadbackIndexes.has(index) ? undefined : "Bearer vrdx_stdio_token",
+        authenticatedMutationIndexes.has(index) ? "Bearer vrdx_stdio_token" : undefined,
       );
     });
     assert.equal(fixture.captured[6]?.method, "POST");

--- a/packages/vrdex-mcp/tests/stdio.test.ts
+++ b/packages/vrdex-mcp/tests/stdio.test.ts
@@ -335,7 +335,69 @@ test("serves VRDex tools over stdio and calls the configured API base URL", asyn
     assert.match(failedReadbackResult.content?.[0]?.text ?? "", /write for slug "missing-readback"/);
     assert.match(failedReadbackResult.content?.[0]?.text ?? "", /Do not retry the mutation automatically/);
 
-    assert.equal(fixture.captured.length, 12);
+    const indeterminateCreate = await callTool({
+      id: 12,
+      messages,
+      name: "vrdex_event_create",
+      onMessage,
+      send,
+      stderr,
+      toolArgs: {
+        communitySlug: "basic-bit",
+        startAt: 1_798_761_600_000,
+        title: "Indeterminate Create",
+      },
+    });
+    const indeterminateCreateResult = indeterminateCreate.result as {
+      content?: Array<{ text?: string }>;
+      isError?: boolean;
+    };
+    assert.equal(indeterminateCreateResult.isError, true);
+    assert.match(indeterminateCreateResult.content?.[0]?.text ?? "", /may already have accepted the mutation/);
+    assert.match(indeterminateCreateResult.content?.[0]?.text ?? "", /Do not retry the mutation automatically/);
+
+    const indeterminateUpdate = await callTool({
+      id: 13,
+      messages,
+      name: "vrdex_event_update",
+      onMessage,
+      send,
+      stderr,
+      toolArgs: {
+        slug: "club-night",
+        update: { summary: "Indeterminate Update" },
+      },
+    });
+    const indeterminateUpdateResult = indeterminateUpdate.result as {
+      content?: Array<{ text?: string }>;
+      isError?: boolean;
+    };
+    assert.equal(indeterminateUpdateResult.isError, true);
+    assert.match(indeterminateUpdateResult.content?.[0]?.text ?? "", /may already have accepted the mutation/);
+    assert.match(indeterminateUpdateResult.content?.[0]?.text ?? "", /Do not retry the mutation automatically/);
+
+    const thrownReadback = await callTool({
+      id: 14,
+      messages,
+      name: "vrdex_event_create",
+      onMessage,
+      send,
+      stderr,
+      toolArgs: {
+        communitySlug: "basic-bit",
+        startAt: 1_798_761_600_000,
+        title: "Thrown Readback",
+      },
+    });
+    const thrownReadbackResult = thrownReadback.result as {
+      content?: Array<{ text?: string }>;
+      isError?: boolean;
+    };
+    assert.equal(thrownReadbackResult.isError, true);
+    assert.match(thrownReadbackResult.content?.[0]?.text ?? "", /write for slug "invalid-readback"/);
+    assert.match(thrownReadbackResult.content?.[0]?.text ?? "", /Do not retry the mutation automatically/);
+
+    assert.equal(fixture.captured.length, 16);
     assert.deepEqual(
       fixture.captured.map((request) => request.pathname),
       [
@@ -351,6 +413,10 @@ test("serves VRDex tools over stdio and calls the configured API base URL", asyn
         "/api/v0/events/club-night",
         "/api/v0/events",
         "/api/v0/events/missing-readback",
+        "/api/v0/events",
+        "/api/v0/events/club-night",
+        "/api/v0/events",
+        "/api/v0/events/invalid-readback",
       ],
     );
     assert.equal(fixture.captured[0]?.searchParams.get("q"), "club");
@@ -358,7 +424,13 @@ test("serves VRDex tools over stdio and calls the configured API base URL", asyn
     assert.equal(fixture.captured[0]?.searchParams.get("limit"), "2");
     assert.equal(fixture.captured[3]?.searchParams.get("limit"), "1");
     assert.equal(fixture.captured[5]?.searchParams.get("limit"), "1");
-    assert.equal(fixture.captured.every((request) => request.authorization === "Bearer vrdx_stdio_token"), true);
+    const anonymousReadbackIndexes = new Set([7, 9, 11, 15]);
+    fixture.captured.forEach((request, index) => {
+      assert.equal(
+        request.authorization,
+        anonymousReadbackIndexes.has(index) ? undefined : "Bearer vrdx_stdio_token",
+      );
+    });
     assert.equal(fixture.captured[6]?.method, "POST");
     assert.deepEqual(fixture.captured[6]?.body, {
       communitySlug: "basic-bit",

--- a/packages/vrdex-mcp/tests/stdio.test.ts
+++ b/packages/vrdex-mcp/tests/stdio.test.ts
@@ -157,7 +157,20 @@ test("serves VRDex tools over stdio and calls the configured API base URL", asyn
     send({ jsonrpc: "2.0", id: 2, method: "tools/list", params: {} });
 
     const tools = await waitForMessage(messages, onMessage, 2, stderr);
-    const listedTools = (tools.result as { tools: Array<{ name: string; outputSchema?: unknown }> }).tools;
+    const listedTools = (
+      tools.result as {
+        tools: Array<{
+          annotations?: {
+            destructiveHint?: boolean;
+            idempotentHint?: boolean;
+            openWorldHint?: boolean;
+            readOnlyHint?: boolean;
+          };
+          name: string;
+          outputSchema?: unknown;
+        }>;
+      }
+    ).tools;
 
     assert.deepEqual(
       listedTools.map((tool) => tool.name),
@@ -168,9 +181,23 @@ test("serves VRDex tools over stdio and calls the configured API base URL", asyn
         "vrdex_list_upcoming_events",
         "vrdex_get_world",
         "vrdex_list_active_worlds",
+        "vrdex_event_create",
+        "vrdex_event_update",
       ],
     );
     assert.equal(listedTools.every((tool) => !hasLegacySchemaId(tool.outputSchema)), true);
+    assert.deepEqual(listedTools.find((tool) => tool.name === "vrdex_event_create")?.annotations, {
+      destructiveHint: false,
+      idempotentHint: false,
+      openWorldHint: true,
+      readOnlyHint: false,
+    });
+    assert.deepEqual(listedTools.find((tool) => tool.name === "vrdex_event_update")?.annotations, {
+      destructiveHint: true,
+      idempotentHint: false,
+      openWorldHint: true,
+      readOnlyHint: false,
+    });
 
     const search = await callTool({
       id: 3,
@@ -244,8 +271,71 @@ test("serves VRDex tools over stdio and calls the configured API base URL", asyn
       stderr,
       toolArgs: { limit: 1 },
     });
+    const create = await callTool({
+      id: 9,
+      messages,
+      name: "vrdex_event_create",
+      onMessage,
+      send,
+      stderr,
+      toolArgs: {
+        communitySlug: "basic-bit",
+        startAt: 1_798_761_600_000,
+        title: "Created Club Night",
+      },
+    });
+    assert.deepEqual((create.result as { structuredContent: unknown }).structuredContent, {
+      canonicalUrl: `${fixture.origin}/events/created-club-night`,
+      event: {
+        id: "event_created",
+        slug: "created-club-night",
+        source: { label: "VRDex", sourceType: "manual" },
+        startAt: 1_798_761_600_000,
+        title: "Club Night",
+        watchSurfaceEnabled: false,
+      },
+      eventId: "event_created",
+      eventPath: "/events/created-club-night",
+      slug: "created-club-night",
+    });
+    const update = await callTool({
+      id: 10,
+      messages,
+      name: "vrdex_event_update",
+      onMessage,
+      send,
+      stderr,
+      toolArgs: {
+        slug: "club-night",
+        update: { summary: null },
+      },
+    });
+    assert.equal(
+      (update.result as { structuredContent?: { canonicalUrl?: string } }).structuredContent?.canonicalUrl,
+      `${fixture.origin}/events/club-night`,
+    );
+    const failedReadback = await callTool({
+      id: 11,
+      messages,
+      name: "vrdex_event_create",
+      onMessage,
+      send,
+      stderr,
+      toolArgs: {
+        communitySlug: "basic-bit",
+        startAt: 1_798_761_600_000,
+        title: "Readback Failure",
+      },
+    });
+    const failedReadbackResult = failedReadback.result as {
+      content?: Array<{ text?: string }>;
+      isError?: boolean;
+    };
+    assert.equal(failedReadbackResult.isError, true);
+    assert.match(failedReadbackResult.content?.[0]?.text ?? "", /write for slug "missing-readback"/);
+    assert.match(failedReadbackResult.content?.[0]?.text ?? "", /Do not retry the mutation automatically/);
 
-    assert.equal(fixture.captured.length, 6);
+    assert.equal(fixture.captured.length, 12);
     assert.deepEqual(
       fixture.captured.map((request) => request.pathname),
       [
@@ -255,6 +345,12 @@ test("serves VRDex tools over stdio and calls the configured API base URL", asyn
         "/api/v0/events/upcoming",
         "/api/v0/worlds/club-world",
         "/api/v0/worlds/active",
+        "/api/v0/events",
+        "/api/v0/events/created-club-night",
+        "/api/v0/events/club-night",
+        "/api/v0/events/club-night",
+        "/api/v0/events",
+        "/api/v0/events/missing-readback",
       ],
     );
     assert.equal(fixture.captured[0]?.searchParams.get("q"), "club");
@@ -262,10 +358,96 @@ test("serves VRDex tools over stdio and calls the configured API base URL", asyn
     assert.equal(fixture.captured[0]?.searchParams.get("limit"), "2");
     assert.equal(fixture.captured[3]?.searchParams.get("limit"), "1");
     assert.equal(fixture.captured[5]?.searchParams.get("limit"), "1");
+    assert.equal(fixture.captured.every((request) => request.authorization === "Bearer vrdx_stdio_token"), true);
+    assert.equal(fixture.captured[6]?.method, "POST");
+    assert.deepEqual(fixture.captured[6]?.body, {
+      communitySlug: "basic-bit",
+      startAt: 1_798_761_600_000,
+      title: "Created Club Night",
+    });
+    assert.equal(fixture.captured[8]?.method, "PATCH");
+    assert.deepEqual(fixture.captured[8]?.body, { summary: null });
   } finally {
     child.stdin.end();
     child.kill();
     lines.close();
     await fixture.close();
+  }
+});
+
+test("keeps event write tools hidden when local stdio has no bearer credential", async () => {
+  const messages: JsonRpcMessage[] = [];
+  const stderr: string[] = [];
+  const messageListeners = new Set<() => void>();
+  const repoRoot = fileURLToPath(new URL("../../../", import.meta.url));
+  const command = pnpmExecCommand(repoRoot);
+  const env: NodeJS.ProcessEnv = {
+    ...process.env,
+    VRDEX_API_BASE_URL: "http://127.0.0.1:1",
+  };
+
+  delete env.VRDEX_API_TOKEN;
+  delete env.VRDEX_BEARER_TOKEN;
+  delete env.VRDEX_OAUTH_ACCESS_TOKEN;
+  delete env.VRDEX_OAUTH_TOKEN_FILE;
+
+  const child = spawn(command.command, command.args, {
+    cwd: repoRoot,
+    env,
+    stdio: ["pipe", "pipe", "pipe"],
+  });
+  const lines = createInterface({ input: child.stdout });
+
+  function onMessage(listener: () => void) {
+    messageListeners.add(listener);
+  }
+
+  function send(message: JsonRpcMessage) {
+    child.stdin.write(`${JSON.stringify(message)}\n`);
+  }
+
+  lines.on("line", (line) => {
+    messages.push(JSON.parse(line) as JsonRpcMessage);
+
+    for (const listener of messageListeners) {
+      listener();
+    }
+  });
+
+  child.stderr.on("data", (chunk: Buffer) => {
+    stderr.push(chunk.toString("utf8"));
+  });
+
+  try {
+    send({
+      jsonrpc: "2.0",
+      id: 1,
+      method: "initialize",
+      params: {
+        capabilities: {},
+        clientInfo: { name: "vrdex-mcp-anonymous-test", version: "0.0.0" },
+        protocolVersion: "2025-06-18",
+      },
+    });
+
+    await waitForMessage(messages, onMessage, 1, stderr);
+    send({ jsonrpc: "2.0", method: "notifications/initialized", params: {} });
+    send({ jsonrpc: "2.0", id: 2, method: "tools/list", params: {} });
+
+    const tools = await waitForMessage(messages, onMessage, 2, stderr);
+    const names = (tools.result as { tools: Array<{ name: string }> }).tools.map((tool) => tool.name);
+
+    assert.deepEqual(names, [
+      "vrdex_search",
+      "vrdex_get_profile",
+      "vrdex_get_event",
+      "vrdex_list_upcoming_events",
+      "vrdex_get_world",
+      "vrdex_list_active_worlds",
+    ]);
+  } finally {
+    child.stdin.end();
+    child.kill();
+    lines.close();
   }
 });

--- a/scripts/smoke-vrdex-mcp-compat.ts
+++ b/scripts/smoke-vrdex-mcp-compat.ts
@@ -42,7 +42,7 @@ type HostedToolDescriptor = {
   name?: unknown;
 };
 
-const localExpectedTools = [
+const localReadTools = [
   "vrdex_search",
   "vrdex_get_profile",
   "vrdex_get_event",
@@ -50,7 +50,12 @@ const localExpectedTools = [
   "vrdex_get_world",
   "vrdex_list_active_worlds",
 ];
-const hostedExpectedTools = ["search", "fetch", ...localExpectedTools];
+const localExpectedTools = [
+  ...localReadTools,
+  "vrdex_event_create",
+  "vrdex_event_update",
+];
+const hostedExpectedTools = ["search", "fetch", ...localReadTools];
 
 function assertHostedPublicReadSecuritySchemes(tool: HostedToolDescriptor) {
   assert.equal(typeof tool._meta, "object", `Hosted tool ${String(tool.name)} is missing _meta.`);


### PR DESCRIPTION
[AGENT]

## Outcome

- adds authenticated local/private MCP tools for event create and update using the existing public API contracts
- reads every accepted write back through the public event API and returns the normalized event plus canonical URL
- keeps local anonymous stdio and the hosted anonymous MCP read-only
- documents the explicit operator approval, credential, readback, and first-real-event proof runbook

## Safety boundary

The tools are registered only by local stdio when a bearer credential is configured. API scope, resource, user-authority, and ownership enforcement remain server-side. A failed readback explicitly warns that the mutation may already have succeeded and must not be retried automatically.

No live Faceless event write or telemetry-provider change was performed. The first real event mutation remains gated on explicit action-time operator approval, so this PR advances rather than closes #184.

## Verification

- `pnpm --filter @basicbit/vrdex-mcp typecheck`
- `pnpm --filter @basicbit/vrdex-mcp test`
- `pnpm verify:api-contracts`
- `pnpm verify:vrdex-mcp`
- `pnpm verify:docs`
- `node --import tsx --test tests/scripts/mcp-compat-smoke-cli.test.ts`
