### PR TITLE
Fix terminal text flash in theme transition

### DIFF
--- a/apps/web/e2e/theme-transition.spec.ts
+++ b/apps/web/e2e/theme-transition.spec.ts
@@ -1,0 +1,156 @@
+import { expect, test, type Page } from "@playwright/test";
+
+type Theme = "dark" | "light";
+
+type ThemeSample = {
+  elapsed: number;
+  heading: string;
+  mutedText: string;
+  transitionActive: boolean;
+};
+
+async function setTheme(page: Page, theme: Theme) {
+  await page.evaluate(async (nextTheme) => {
+    window.localStorage.setItem("vrdex-theme", nextTheme);
+    document.documentElement.dataset.theme = nextTheme;
+    document.documentElement.style.colorScheme = nextTheme;
+    void document.documentElement.offsetWidth;
+    await new Promise<void>((resolve) => requestAnimationFrame(() => resolve()));
+    await new Promise<void>((resolve) => requestAnimationFrame(() => resolve()));
+  }, theme);
+}
+
+async function themeColors(page: Page, theme: Theme) {
+  return await page.evaluate((nextTheme) => {
+    const heading = document.querySelector("h1");
+    const mutedText = document.querySelector(".text-muted");
+
+    if (!(heading instanceof HTMLElement) || !(mutedText instanceof HTMLElement)) {
+      throw new Error("Theme transition color targets were not rendered.");
+    }
+
+    document.documentElement.dataset.theme = nextTheme;
+    document.documentElement.style.colorScheme = nextTheme;
+
+    return {
+      heading: getComputedStyle(heading).color,
+      mutedText: getComputedStyle(mutedText).color,
+    };
+  }, theme);
+}
+
+async function sampleThemeTransition(page: Page): Promise<ThemeSample[]> {
+  return await page.evaluate(async () => {
+    const heading = document.querySelector("h1");
+    const mutedText = document.querySelector(".text-muted");
+    const toggle = document.querySelector('button[aria-label="Toggle color theme"]');
+
+    if (
+      !(heading instanceof HTMLElement) ||
+      !(mutedText instanceof HTMLElement) ||
+      !(toggle instanceof HTMLButtonElement)
+    ) {
+      throw new Error("Theme transition sample targets were not rendered.");
+    }
+
+    const renderedHeading = heading;
+    const renderedMutedText = mutedText;
+    const startedAt = performance.now();
+    const samples: ThemeSample[] = [];
+
+    return await new Promise<ThemeSample[]>((resolve) => {
+      function sample() {
+        const elapsed = performance.now() - startedAt;
+        samples.push({
+          elapsed,
+          heading: getComputedStyle(renderedHeading).color,
+          mutedText: getComputedStyle(renderedMutedText).color,
+          transitionActive: document.documentElement.dataset.themeTransition === "true",
+        });
+
+        if (elapsed >= 800) {
+          resolve(samples);
+          return;
+        }
+
+        requestAnimationFrame(sample);
+      }
+
+      requestAnimationFrame(sample);
+      toggle.click();
+    });
+  });
+}
+
+function rgbDistance(color: string, target: string) {
+  const channels = (value: string) => value.match(/\d+(?:\.\d+)?/g)?.slice(0, 3).map(Number);
+  const actualChannels = channels(color);
+  const targetChannels = channels(target);
+
+  if (!actualChannels || !targetChannels) {
+    throw new Error(`Expected RGB colors, received ${color} and ${target}.`);
+  }
+
+  return Math.hypot(...actualChannels.map((channel, index) => channel - targetChannels[index]));
+}
+
+function expectContinuousFinalColor(samples: ThemeSample[], key: "heading" | "mutedText", target: string) {
+  const distances = samples.map((sample) => rgbDistance(sample[key], target));
+
+  for (let index = 1; index < distances.length; index += 1) {
+    expect(
+      distances[index],
+      `${key} moved away from its final color at ${samples[index].elapsed.toFixed(1)}ms`,
+    ).toBeLessThanOrEqual(distances[index - 1] + 2);
+  }
+
+  expect(distances.at(-1), `${key} did not settle on its final color`).toBeLessThanOrEqual(2);
+}
+
+function expectIntermediateColor(
+  samples: ThemeSample[],
+  key: "heading" | "mutedText",
+  initial: string,
+  target: string,
+) {
+  expect(
+    samples.some((sample) => rgbDistance(sample[key], initial) > 2 && rgbDistance(sample[key], target) > 2),
+    `${key} did not interpolate between its initial and final colors`,
+  ).toBe(true);
+}
+
+for (const initialTheme of ["light", "dark"] as const) {
+  test(`${initialTheme} theme reaches its opposite without a terminal text-color reset`, async ({ page }) => {
+    await page.emulateMedia({ colorScheme: initialTheme, reducedMotion: "no-preference" });
+    await page.goto("/sign-in");
+    await setTheme(page, initialTheme);
+
+    const initialColors = await themeColors(page, initialTheme);
+    const targetTheme = initialTheme === "light" ? "dark" : "light";
+    const targetColors = await themeColors(page, targetTheme);
+    await setTheme(page, initialTheme);
+
+    const samples = await sampleThemeTransition(page);
+
+    expectIntermediateColor(samples, "heading", initialColors.heading, targetColors.heading);
+    expectIntermediateColor(samples, "mutedText", initialColors.mutedText, targetColors.mutedText);
+    expectContinuousFinalColor(samples, "heading", targetColors.heading);
+    expectContinuousFinalColor(samples, "mutedText", targetColors.mutedText);
+    expect(samples.some((sample) => !sample.transitionActive)).toBe(true);
+    await expect(page.locator("html")).toHaveAttribute("data-theme", targetTheme);
+    expect(await page.evaluate(() => window.localStorage.getItem("vrdex-theme"))).toBe(targetTheme);
+  });
+}
+
+test("reduced motion applies the final theme without color interpolation", async ({ page }) => {
+  await page.emulateMedia({ colorScheme: "light", reducedMotion: "reduce" });
+  await page.goto("/sign-in");
+  await setTheme(page, "light");
+
+  const targetColors = await themeColors(page, "dark");
+  await setTheme(page, "light");
+  await page.getByRole("button", { name: "Toggle color theme" }).click();
+
+  await expect(page.locator("h1")).toHaveCSS("color", targetColors.heading);
+  await expect(page.locator(".text-muted").first()).toHaveCSS("color", targetColors.mutedText);
+});

--- a/apps/web/src/app/globals.css
+++ b/apps/web/src/app/globals.css
@@ -1,5 +1,167 @@
 @import "tailwindcss";
 
+@property --background {
+  syntax: "<color>";
+  inherits: true;
+  initial-value: #08090d;
+}
+
+@property --foreground {
+  syntax: "<color>";
+  inherits: true;
+  initial-value: #f5f7fb;
+}
+
+@property --canvas {
+  syntax: "<color>";
+  inherits: true;
+  initial-value: #0b0d12;
+}
+
+@property --canvas-muted {
+  syntax: "<color>";
+  inherits: true;
+  initial-value: #0f131a;
+}
+
+@property --surface {
+  syntax: "<color>";
+  inherits: true;
+  initial-value: rgba(17, 22, 30, 0.82);
+}
+
+@property --surface-muted {
+  syntax: "<color>";
+  inherits: true;
+  initial-value: rgba(25, 31, 40, 0.72);
+}
+
+@property --surface-strong {
+  syntax: "<color>";
+  inherits: true;
+  initial-value: #151b24;
+}
+
+@property --surface-elevated {
+  syntax: "<color>";
+  inherits: true;
+  initial-value: #1b232e;
+}
+
+@property --muted {
+  syntax: "<color>";
+  inherits: true;
+  initial-value: #98a3b3;
+}
+
+@property --subtle {
+  syntax: "<color>";
+  inherits: true;
+  initial-value: #647080;
+}
+
+@property --inverse {
+  syntax: "<color>";
+  inherits: true;
+  initial-value: #08090d;
+}
+
+@property --accent {
+  syntax: "<color>";
+  inherits: true;
+  initial-value: #8ed8ff;
+}
+
+@property --accent-strong {
+  syntax: "<color>";
+  inherits: true;
+  initial-value: #c7ecff;
+}
+
+@property --accent-muted {
+  syntax: "<color>";
+  inherits: true;
+  initial-value: rgba(142, 216, 255, 0.14);
+}
+
+@property --danger {
+  syntax: "<color>";
+  inherits: true;
+  initial-value: #ff8a8a;
+}
+
+@property --danger-strong {
+  syntax: "<color>";
+  inherits: true;
+  initial-value: #ffd6d6;
+}
+
+@property --success {
+  syntax: "<color>";
+  inherits: true;
+  initial-value: #8ee6ae;
+}
+
+@property --success-strong {
+  syntax: "<color>";
+  inherits: true;
+  initial-value: #d6ffe4;
+}
+
+@property --warning {
+  syntax: "<color>";
+  inherits: true;
+  initial-value: #ffd47a;
+}
+
+@property --warning-strong {
+  syntax: "<color>";
+  inherits: true;
+  initial-value: #fff0bd;
+}
+
+@property --info {
+  syntax: "<color>";
+  inherits: true;
+  initial-value: #8ed8ff;
+}
+
+@property --info-strong {
+  syntax: "<color>";
+  inherits: true;
+  initial-value: #d6f2ff;
+}
+
+@property --border {
+  syntax: "<color>";
+  inherits: true;
+  initial-value: rgba(229, 235, 244, 0.14);
+}
+
+@property --border-strong {
+  syntax: "<color>";
+  inherits: true;
+  initial-value: rgba(229, 235, 244, 0.24);
+}
+
+@property --focus {
+  syntax: "<color>";
+  inherits: true;
+  initial-value: rgba(142, 216, 255, 0.38);
+}
+
+@property --media {
+  syntax: "<color>";
+  inherits: true;
+  initial-value: #020307;
+}
+
+@property --media-raised {
+  syntax: "<color>";
+  inherits: true;
+  initial-value: #172033;
+}
+
 :root {
   --background: #08090d;
   --foreground: #f5f7fb;
@@ -175,16 +337,27 @@ body {
   min-height: 100vh;
 }
 
+:root[data-theme-transition="true"] {
+  transition-duration: 650ms !important;
+  transition-property:
+    --background, --foreground, --canvas, --canvas-muted, --surface, --surface-muted, --surface-strong,
+    --surface-elevated, --muted, --subtle, --inverse, --accent, --accent-strong, --accent-muted, --danger,
+    --danger-strong, --success, --success-strong, --warning, --warning-strong, --info, --info-strong, --border,
+    --border-strong, --focus, --media, --media-raised !important;
+  transition-timing-function: ease-in-out !important;
+}
+
 :root[data-theme-transition="true"] body,
 :root[data-theme-transition="true"] body *,
 :root[data-theme-transition="true"] body *::before,
 :root[data-theme-transition="true"] body *::after {
   transition-duration: 650ms !important;
-  transition-property: background-color, border-color, box-shadow, color, fill, stroke !important;
+  transition-property: box-shadow !important;
   transition-timing-function: ease-in-out !important;
 }
 
 @media (prefers-reduced-motion: reduce) {
+  :root[data-theme-transition="true"],
   :root[data-theme-transition="true"] body,
   :root[data-theme-transition="true"] body *,
   :root[data-theme-transition="true"] body *::before,


### PR DESCRIPTION
[AGENT]

## Summary

- animate the shared color design tokens once at the root instead of independently transitioning inherited `color` on every descendant
- keep the existing 650 ms easing, theme persistence, toggle behavior, shadow interpolation, and reduced-motion behavior
- add frame-by-frame Chromium coverage for light→dark and dark→light, including inherited and explicit semantic text colors

## Root cause

The global transition rule applied `color` to every nested element. Descendants independently transitioned inherited color; when a child reached the target at 650 ms, it reset to its still-transitioning parent color, producing the visible terminal flash. Registered root color tokens give every consumer the same continuous interpolated value and avoid the nested reset.

## Verification

- `pnpm verify:web` (lint, typecheck, and 177 web tests passed; production build passed on a network-enabled rerun for configured Google Fonts)
- focused transition suite: 6/6 passed on desktop and mobile Chromium in both directions plus reduced motion
- existing persisted dark-theme visual test: passed
- retained browser videos and inspected 6 fps contact sheets for both directions; no terminal reset observed