### PR TITLE
Keep app sessions across browser restarts

### DIFF
--- a/apps/web/e2e/auth-session.flow.spec.ts
+++ b/apps/web/e2e/auth-session.flow.spec.ts
@@ -1,0 +1,331 @@
+import {
+  expect,
+  test,
+  type APIRequestContext,
+  type Browser,
+  type BrowserContext,
+  type Page,
+} from "@playwright/test";
+
+test.describe.configure({ mode: "serial" });
+
+const DAY_SECONDS = 24 * 60 * 60;
+
+function e2eBrowserToken() {
+  const token =
+    process.env.VRDEX_E2E_BROWSER_TOKEN ??
+    (process.env.PLAYWRIGHT_BASE_URL
+      ? undefined
+      : "local-playwright-token");
+
+  if (!token) {
+    throw new Error(
+      "VRDEX_E2E_BROWSER_TOKEN must be set for hosted auth-session runs.",
+    );
+  }
+
+  return token;
+}
+
+function e2eIdentity(testInfo: {
+  project: { name: string };
+  workerIndex: number;
+  repeatEachIndex: number;
+}) {
+  const suffix = [
+    "session",
+    testInfo.project.name,
+    testInfo.workerIndex,
+    testInfo.repeatEachIndex,
+    Date.now(),
+  ]
+    .join("-")
+    .replace(/[^a-z0-9]+/gi, "-")
+    .toLowerCase()
+    .slice(0, 80);
+
+  return {
+    email: `${suffix}@e2e.vrdex.local`,
+    password: `VRDex-${suffix}-password-12345`,
+  };
+}
+
+async function createVerifiedAccount({
+  page,
+  request,
+  token,
+  email,
+  password,
+}: {
+  page: Page;
+  request: APIRequestContext;
+  token: string;
+  email: string;
+  password: string;
+}) {
+  await page.goto("/sign-in");
+  await page.getByRole("button", { name: "Use email and password" }).click();
+  await page.getByRole("button", { name: "Create account" }).click();
+  await page.getByLabel("Email").fill(email);
+  await page.getByLabel("Password").fill(password);
+  await page.getByRole("button", { name: "Create account" }).click();
+  await expect(
+    page.getByText(new RegExp(`Check ${email} for a verification code`, "i")),
+  ).toBeVisible();
+
+  const codeResponse = await request.post("/api/e2e/auth", {
+    headers: { "x-vrdex-e2e-token": token },
+    data: { action: "consume-code", email },
+  });
+  await expect(codeResponse).toBeOK();
+  const { code } = (await codeResponse.json()) as { code: string };
+
+  await page.getByLabel("Verification code").fill(code);
+  await Promise.all([
+    page.waitForURL(/\/account$/),
+    page.getByRole("button", { name: "Verify email" }).click(),
+  ]);
+  await expect(page.getByRole("heading", { name: email })).toBeVisible();
+}
+
+async function cleanupAccount(
+  request: APIRequestContext,
+  token: string,
+  email: string,
+) {
+  await request.delete("/api/e2e/auth", {
+    headers: { "x-vrdex-e2e-token": token },
+    data: { email },
+  });
+}
+
+async function setSessionState(
+  request: APIRequestContext,
+  token: string,
+  email: string,
+  state:
+    | "absolute_expired"
+    | "inactive_expired"
+    | "invalid_refresh"
+    | "revoked",
+  now: number,
+) {
+  const response = await request.post("/api/e2e/auth", {
+    headers: { "x-vrdex-e2e-token": token },
+    data: {
+      action: "set-session-state",
+      email,
+      state,
+      now,
+    },
+  });
+  await expect(response).toBeOK();
+}
+
+async function forceRefresh(page: Page) {
+  return await page.evaluate(async () => {
+    const response = await fetch("/api/auth", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({
+        action: "auth:signIn",
+        args: { refreshToken: "dummy" },
+      }),
+    });
+
+    return {
+      ok: response.ok,
+      body: (await response.json()) as {
+        tokens: { token: string; refreshToken: string } | null;
+      },
+    };
+  });
+}
+
+function authCookies(context: BrowserContext) {
+  return context
+    .cookies()
+    .then((cookies) =>
+      cookies.filter((cookie) => cookie.name.includes("__convexAuth")),
+    );
+}
+
+async function createAuthenticatedContext({
+  browser,
+  request,
+  token,
+  email,
+  password,
+}: {
+  browser: Browser;
+  request: APIRequestContext;
+  token: string;
+  email: string;
+  password: string;
+}) {
+  const context = await browser.newContext();
+  const page = await context.newPage();
+  await createVerifiedAccount({
+    page,
+    request,
+    token,
+    email,
+    password,
+  });
+  return { context, page };
+}
+
+test(
+  "remembered session survives restart, deployment hydration, rotation, concurrent tabs, and sign-out @flow",
+  async ({ browser, request }, testInfo) => {
+    test.setTimeout(90_000);
+    test.skip(
+      Boolean(process.env.PLAYWRIGHT_BASE_URL) &&
+        process.env.VRDEX_ENABLE_E2E_AUTH_HELPERS !== "true",
+      "Hosted auth E2E helpers are not enabled for this target.",
+    );
+
+    const token = e2eBrowserToken();
+    const { email, password } = e2eIdentity(testInfo);
+    let firstContext: BrowserContext | undefined;
+    let restartedContext: BrowserContext | undefined;
+
+    try {
+      ({ context: firstContext } = await createAuthenticatedContext({
+        browser,
+        request,
+        token,
+        email,
+        password,
+      }));
+
+      const cookiesBeforeRefresh = await authCookies(firstContext);
+      expect(cookiesBeforeRefresh).toHaveLength(2);
+      for (const cookie of cookiesBeforeRefresh) {
+        expect(cookie.httpOnly).toBe(true);
+        expect(cookie.sameSite).toBe("Lax");
+        expect(cookie.path).toBe("/");
+        expect(cookie.expires).toBeGreaterThan(
+          Date.now() / 1_000 + 29 * DAY_SECONDS,
+        );
+        expect(cookie.expires).toBeLessThan(
+          Date.now() / 1_000 + 31 * DAY_SECONDS,
+        );
+      }
+
+      const refreshCookieBefore = cookiesBeforeRefresh.find((cookie) =>
+        cookie.name.includes("RefreshToken"),
+      )?.value;
+      const firstPage = firstContext.pages()[0]!;
+      await firstPage.route("**/api/auth", (route) =>
+        route.abort("failed"),
+      );
+      const transientRefreshFailed = await forceRefresh(firstPage).then(
+        () => false,
+        () => true,
+      );
+      expect(transientRefreshFailed).toBe(true);
+      expect(await authCookies(firstContext)).toEqual(cookiesBeforeRefresh);
+      await firstPage.unroute("**/api/auth");
+      await firstPage.reload();
+      await expect(
+        firstPage.getByRole("heading", { name: email }),
+      ).toBeVisible();
+
+      const refreshResult = await forceRefresh(firstPage);
+      expect(refreshResult.ok).toBe(true);
+      expect(refreshResult.body.tokens).not.toBeNull();
+      const refreshCookieAfter = (await authCookies(firstContext)).find(
+        (cookie) => cookie.name.includes("RefreshToken"),
+      )?.value;
+      expect(refreshCookieAfter).toBeTruthy();
+      expect(refreshCookieAfter).not.toBe(refreshCookieBefore);
+
+      const persistentCookies = await authCookies(firstContext);
+      await firstContext.close();
+      firstContext = undefined;
+
+      restartedContext = await browser.newContext({
+        storageState: {
+          cookies: persistentCookies,
+          origins: [],
+        },
+      });
+      const restoredPage = await restartedContext.newPage();
+      await restoredPage.goto("/account");
+      await expect(
+        restoredPage.getByRole("heading", { name: email }),
+      ).toBeVisible();
+
+      const siblingPage = await restartedContext.newPage();
+      await siblingPage.goto("/");
+      await expect(
+        siblingPage.getByRole("link", { name: "Account" }),
+      ).toBeVisible();
+
+      await restoredPage.getByRole("button", { name: "Sign out" }).click();
+      await expect(
+        siblingPage.getByRole("link", { name: "Sign in" }),
+      ).toBeVisible();
+
+      await restoredPage.goto("/account");
+      await expect(restoredPage).toHaveURL(/\/sign-in\?returnTo=/);
+      expect(await authCookies(restartedContext)).toHaveLength(0);
+    } finally {
+      await firstContext?.close();
+      await restartedContext?.close();
+      await cleanupAccount(request, token, email);
+    }
+  },
+);
+
+for (const state of [
+  "inactive_expired",
+  "absolute_expired",
+  "invalid_refresh",
+  "revoked",
+] as const) {
+  test(`${state} session fails closed without retaining browser credentials @flow`, async ({
+    browser,
+    request,
+  }, testInfo) => {
+    test.setTimeout(60_000);
+    test.skip(
+      Boolean(process.env.PLAYWRIGHT_BASE_URL) &&
+        process.env.VRDEX_ENABLE_E2E_AUTH_HELPERS !== "true",
+      "Hosted auth E2E helpers are not enabled for this target.",
+    );
+
+    const token = e2eBrowserToken();
+    const identity = e2eIdentity(testInfo);
+    let context: BrowserContext | undefined;
+
+    try {
+      const authenticated = await createAuthenticatedContext({
+        browser,
+        request,
+        token,
+        ...identity,
+      });
+      context = authenticated.context;
+
+      await setSessionState(
+        request,
+        token,
+        identity.email,
+        state,
+        Date.UTC(2020, 0, 1),
+      );
+      const refreshResult = await forceRefresh(authenticated.page);
+      expect(refreshResult.ok).toBe(true);
+      expect(refreshResult.body.tokens).toBeNull();
+      expect(await authCookies(context)).toHaveLength(0);
+
+      await authenticated.page.goto("/account");
+      await expect(authenticated.page).toHaveURL(/\/sign-in\?returnTo=/);
+    } finally {
+      await context?.close();
+      await cleanupAccount(request, token, identity.email);
+    }
+  });
+}

--- a/apps/web/e2e/auth-session.flow.spec.ts
+++ b/apps/web/e2e/auth-session.flow.spec.ts
@@ -176,7 +176,7 @@ async function createAuthenticatedContext({
 }
 
 test(
-  "remembered session survives restart, deployment hydration, rotation, concurrent tabs, and sign-out @flow",
+  "remembered session survives restart, deployment hydration, rotation, concurrent tabs, and sign-out @flow @fixture",
   async ({ browser, request }, testInfo) => {
     test.setTimeout(90_000);
     test.skip(
@@ -285,7 +285,7 @@ for (const state of [
   "invalid_refresh",
   "revoked",
 ] as const) {
-  test(`${state} session fails closed without retaining browser credentials @flow`, async ({
+  test(`${state} session fails closed without retaining browser credentials @flow @fixture`, async ({
     browser,
     request,
   }, testInfo) => {

--- a/apps/web/src/app/ConvexClientProvider.tsx
+++ b/apps/web/src/app/ConvexClientProvider.tsx
@@ -1,16 +1,53 @@
 "use client";
 
 import { ConvexAuthNextjsProvider } from "@convex-dev/auth/nextjs";
-import { ConvexReactClient } from "convex/react";
-import type { ReactNode } from "react";
+import { ConvexReactClient, useConvexAuth } from "convex/react";
+import { usePostHog } from "posthog-js/react";
+import { useEffect, useRef, type ReactNode } from "react";
+
+import {
+  authLifecycleEvent,
+  type AuthSessionLifecycleState,
+} from "@/lib/auth-session";
 
 const convexUrl = process.env.NEXT_PUBLIC_CONVEX_URL;
 const convex = convexUrl ? new ConvexReactClient(convexUrl) : null;
+
+function AuthLifecycleTelemetry() {
+  const { isAuthenticated, isLoading } = useConvexAuth();
+  const posthog = usePostHog();
+  const previousState = useRef<AuthSessionLifecycleState | null>(null);
+
+  useEffect(() => {
+    const currentState: AuthSessionLifecycleState = isLoading
+      ? "restoring"
+      : isAuthenticated
+        ? "authenticated"
+        : "anonymous";
+    const lifecycleEvent = authLifecycleEvent(
+      previousState.current,
+      currentState,
+    );
+
+    previousState.current = currentState;
+
+    if (lifecycleEvent !== null) {
+      posthog?.capture(lifecycleEvent.event, lifecycleEvent.properties);
+    }
+  }, [isAuthenticated, isLoading, posthog]);
+
+  return null;
+}
 
 export function ConvexClientProvider({ children }: { children: ReactNode }) {
   if (!convex) {
     return children;
   }
 
-  return <ConvexAuthNextjsProvider client={convex}>{children}</ConvexAuthNextjsProvider>;
+  return (
+    <ConvexAuthNextjsProvider client={convex}>
+      <AuthLifecycleTelemetry />
+      {children}
+    </ConvexAuthNextjsProvider>
+  );
 }

--- a/apps/web/src/app/account/account-session-boundary.tsx
+++ b/apps/web/src/app/account/account-session-boundary.tsx
@@ -1,0 +1,15 @@
+"use client";
+
+import { useConvexAuth } from "convex/react";
+
+import { AccountPanel } from "./account-panel";
+
+export function AccountSessionBoundary() {
+  const { isLoading } = useConvexAuth();
+
+  if (isLoading) {
+    return <p className="text-sm text-muted">Loading account…</p>;
+  }
+
+  return <AccountPanel />;
+}

--- a/apps/web/src/app/account/account-session-boundary.tsx
+++ b/apps/web/src/app/account/account-session-boundary.tsx
@@ -4,7 +4,9 @@ import { useConvexAuth } from "convex/react";
 
 import { AccountPanel } from "./account-panel";
 
-export function AccountSessionBoundary() {
+const convexUrl = process.env.NEXT_PUBLIC_CONVEX_URL;
+
+function ConnectedAccountSessionBoundary() {
   const { isLoading } = useConvexAuth();
 
   if (isLoading) {
@@ -12,4 +14,12 @@ export function AccountSessionBoundary() {
   }
 
   return <AccountPanel />;
+}
+
+export function AccountSessionBoundary() {
+  if (!convexUrl) {
+    return <AccountPanel />;
+  }
+
+  return <ConnectedAccountSessionBoundary />;
 }

--- a/apps/web/src/app/account/page.tsx
+++ b/apps/web/src/app/account/page.tsx
@@ -1,4 +1,4 @@
-import { AccountPanel } from "./account-panel";
+import { AccountSessionBoundary } from "./account-session-boundary";
 import { BrandLink, PageContainer, PageNav, PageShell } from "@/components/ui/page-shell";
 import { redirect } from "next/navigation";
 import { profileClaimPath, profileClaimSlugFromInput } from "@/lib/profile-claim";
@@ -29,7 +29,7 @@ export default async function AccountPage({
           <h1 className="text-3xl font-semibold sm:text-4xl">Account</h1>
         </header>
 
-        <AccountPanel />
+        <AccountSessionBoundary />
       </PageContainer>
     </PageShell>
   );

--- a/apps/web/src/app/api/e2e/auth/route.ts
+++ b/apps/web/src/app/api/e2e/auth/route.ts
@@ -71,6 +71,33 @@ export async function POST(request: NextRequest) {
     return NextResponse.json(result);
   }
 
+  if (action === "set-session-state") {
+    const state =
+      body.state === "absolute_expired" ||
+      body.state === "inactive_expired" ||
+      body.state === "invalid_refresh" ||
+      body.state === "revoked"
+        ? body.state
+        : null;
+    const now = typeof body.now === "number" ? body.now : Number.NaN;
+
+    if (state === null || !Number.isFinite(now)) {
+      return e2eError("Invalid E2E auth session state.", 400);
+    }
+
+    const result = await convexClient().mutation(
+      api.e2e.setAuthSessionStateByEmail,
+      {
+        secret: convexSecret,
+        email,
+        state,
+        now,
+      },
+    );
+
+    return NextResponse.json(result);
+  }
+
   return e2eError("Unsupported E2E auth helper action.", 400);
 }
 

--- a/apps/web/src/lib/auth-session.ts
+++ b/apps/web/src/lib/auth-session.ts
@@ -1,0 +1,72 @@
+const SECOND_MS = 1_000;
+const MINUTE_MS = 60 * SECOND_MS;
+const DAY_MS = 24 * 60 * MINUTE_MS;
+
+export const AUTH_JWT_DURATION_MS = 60 * MINUTE_MS;
+export const AUTH_SESSION_INACTIVE_DURATION_MS = 30 * DAY_MS;
+export const AUTH_SESSION_TOTAL_DURATION_MS = 90 * DAY_MS;
+export const AUTH_SESSION_COOKIE_MAX_AGE_SECONDS =
+  AUTH_SESSION_INACTIVE_DURATION_MS / SECOND_MS;
+
+export type AuthSessionLifecycleState =
+  | "anonymous"
+  | "authenticated"
+  | "restoring";
+
+export type AuthSessionValidity =
+  | "active"
+  | "absolute_expired"
+  | "inactive_expired"
+  | "revoked";
+
+export function authSessionValidityAt({
+  now,
+  sessionExpiresAt,
+  refreshExpiresAt,
+  refreshCredentialPresent,
+}: {
+  now: number;
+  sessionExpiresAt: number;
+  refreshExpiresAt: number;
+  refreshCredentialPresent: boolean;
+}): AuthSessionValidity {
+  if (!refreshCredentialPresent) {
+    return "revoked";
+  }
+
+  if (now >= sessionExpiresAt) {
+    return "absolute_expired";
+  }
+
+  if (now >= refreshExpiresAt) {
+    return "inactive_expired";
+  }
+
+  return "active";
+}
+
+export function authLifecycleEvent(
+  previous: AuthSessionLifecycleState | null,
+  current: AuthSessionLifecycleState,
+) {
+  if (current === "restoring" || previous === current) {
+    return null;
+  }
+
+  if (previous === null || previous === "restoring") {
+    return {
+      event: "auth_session_restore_completed" as const,
+      properties: {
+        outcome: current,
+      },
+    };
+  }
+
+  return {
+    event: "auth_session_state_changed" as const,
+    properties: {
+      from: previous,
+      to: current,
+    },
+  };
+}

--- a/apps/web/src/middleware.ts
+++ b/apps/web/src/middleware.ts
@@ -9,41 +9,49 @@ import {
   isProtectedRoute,
   protectedRouteSignInPath,
 } from "./lib/protected-route-redirect";
+import { AUTH_SESSION_COOKIE_MAX_AGE_SECONDS } from "./lib/auth-session";
 
 const authMiddleware = process.env.NEXT_PUBLIC_CONVEX_URL
-  ? convexAuthNextjsMiddleware(async (request, { convexAuth }) => {
-      const { pathname, search } = request.nextUrl;
-      const allowFixtureDemos =
-        process.env.NODE_ENV !== "production" &&
-        process.env.VRDEX_ENABLE_PLAYWRIGHT_FIXTURES === "true";
+  ? convexAuthNextjsMiddleware(
+      async (request, { convexAuth }) => {
+        const { pathname, search } = request.nextUrl;
+        const allowFixtureDemos =
+          process.env.NODE_ENV !== "production" &&
+          process.env.VRDEX_ENABLE_PLAYWRIGHT_FIXTURES === "true";
 
-      if (!isProtectedRoute(pathname, { allowFixtureDemos })) {
+        if (!isProtectedRoute(pathname, { allowFixtureDemos })) {
+          return NextResponse.next();
+        }
+
+        const expectedE2eToken = process.env.VRDEX_E2E_BROWSER_TOKEN?.trim();
+        const requestE2eToken = request.cookies.get("vrdex_e2e_token")?.value;
+
+        if (
+          hasE2eSubmitBypass({
+            pathname,
+            helpersEnabled: process.env.VRDEX_ENABLE_E2E_HELPERS === "true",
+            expectedToken: expectedE2eToken,
+            requestToken: requestE2eToken,
+          })
+        ) {
+          return NextResponse.next();
+        }
+
+        if (!(await convexAuth.isAuthenticated())) {
+          return nextjsMiddlewareRedirect(
+            request,
+            protectedRouteSignInPath(pathname, search),
+          );
+        }
+
         return NextResponse.next();
-      }
-
-      const expectedE2eToken = process.env.VRDEX_E2E_BROWSER_TOKEN?.trim();
-      const requestE2eToken = request.cookies.get("vrdex_e2e_token")?.value;
-
-      if (
-        hasE2eSubmitBypass({
-          pathname,
-          helpersEnabled: process.env.VRDEX_ENABLE_E2E_HELPERS === "true",
-          expectedToken: expectedE2eToken,
-          requestToken: requestE2eToken,
-        })
-      ) {
-        return NextResponse.next();
-      }
-
-      if (!(await convexAuth.isAuthenticated())) {
-        return nextjsMiddlewareRedirect(
-          request,
-          protectedRouteSignInPath(pathname, search),
-        );
-      }
-
-      return NextResponse.next();
-    })
+      },
+      {
+        cookieConfig: {
+          maxAge: AUTH_SESSION_COOKIE_MAX_AGE_SECONDS,
+        },
+      },
+    )
   : function middleware() {
       return NextResponse.next();
     };

--- a/convex/_authSession.ts
+++ b/convex/_authSession.ts
@@ -1,0 +1,6 @@
+const MINUTE_MS = 60 * 1_000;
+const DAY_MS = 24 * 60 * MINUTE_MS;
+
+export const AUTH_JWT_DURATION_MS = 60 * MINUTE_MS;
+export const AUTH_SESSION_INACTIVE_DURATION_MS = 30 * DAY_MS;
+export const AUTH_SESSION_TOTAL_DURATION_MS = 90 * DAY_MS;

--- a/convex/_generated/api.d.ts
+++ b/convex/_generated/api.d.ts
@@ -15,6 +15,7 @@ import type * as _apiRateLimitEvents from "../_apiRateLimitEvents.js";
 import type * as _apiTokens from "../_apiTokens.js";
 import type * as _apiWriteAuditEvents from "../_apiWriteAuditEvents.js";
 import type * as _authRedirects from "../_authRedirects.js";
+import type * as _authSession from "../_authSession.js";
 import type * as _billing from "../_billing.js";
 import type * as _communityAuthority from "../_communityAuthority.js";
 import type * as _communityTelemetry from "../_communityTelemetry.js";
@@ -107,6 +108,7 @@ declare const fullApi: ApiFromModules<{
   _apiTokens: typeof _apiTokens;
   _apiWriteAuditEvents: typeof _apiWriteAuditEvents;
   _authRedirects: typeof _authRedirects;
+  _authSession: typeof _authSession;
   _billing: typeof _billing;
   _communityAuthority: typeof _communityAuthority;
   _communityTelemetry: typeof _communityTelemetry;

--- a/convex/auth.ts
+++ b/convex/auth.ts
@@ -7,6 +7,11 @@ import { convexAuth } from "@convex-dev/auth/server";
 
 import { internal } from "./_generated/api";
 import { siteRelativeRedirectUrl } from "./_authRedirects";
+import {
+  AUTH_JWT_DURATION_MS,
+  AUTH_SESSION_INACTIVE_DURATION_MS,
+  AUTH_SESSION_TOTAL_DURATION_MS,
+} from "./_authSession";
 
 function requiredEnv(name: string): string {
   const value = process.env[name]?.trim();
@@ -86,6 +91,13 @@ const SesOtp = Email({
 });
 
 export const { auth, signIn, signOut, store, isAuthenticated } = convexAuth({
+  session: {
+    inactiveDurationMs: AUTH_SESSION_INACTIVE_DURATION_MS,
+    totalDurationMs: AUTH_SESSION_TOTAL_DURATION_MS,
+  },
+  jwt: {
+    durationMs: AUTH_JWT_DURATION_MS,
+  },
   providers: [
     Discord({
       authorization: {

--- a/convex/e2e.ts
+++ b/convex/e2e.ts
@@ -264,6 +264,73 @@ export const linkDiscordAccountByEmail = mutation({
   },
 });
 
+export const setAuthSessionStateByEmail = mutation({
+  args: {
+    secret: v.string(),
+    email: v.string(),
+    state: v.union(
+      v.literal("absolute_expired"),
+      v.literal("inactive_expired"),
+      v.literal("invalid_refresh"),
+      v.literal("revoked"),
+    ),
+    now: v.number(),
+  },
+  handler: async (ctx, args) => {
+    requireE2eAuthHelper(args.secret);
+
+    const email = normalizeE2eEmail(args.email);
+    const user = await userByEmail(ctx, email);
+
+    if (user === null) {
+      throw new Error("E2E user not found.");
+    }
+
+    const sessions = await ctx.db
+      .query("authSessions")
+      .withIndex("userId", (query) => query.eq("userId", user._id))
+      .collect();
+    const session = [...sessions].sort(
+      (left, right) => right._creationTime - left._creationTime,
+    )[0];
+
+    if (session === undefined) {
+      throw new Error("E2E auth session not found.");
+    }
+
+    const refreshTokens = await ctx.db
+      .query("authRefreshTokens")
+      .withIndex("sessionId", (query) => query.eq("sessionId", session._id))
+      .collect();
+
+    if (args.state === "absolute_expired") {
+      await ctx.db.patch(session._id, { expirationTime: args.now - 1 });
+    } else if (args.state === "inactive_expired") {
+      await Promise.all(
+        refreshTokens
+          .filter((token) => token.firstUsedTime === undefined)
+          .map((token) =>
+            ctx.db.patch(token._id, { expirationTime: args.now - 1 }),
+          ),
+      );
+    } else if (args.state === "invalid_refresh") {
+      await Promise.all(
+        refreshTokens
+          .filter((token) => token.firstUsedTime === undefined)
+          .map((token) => ctx.db.delete(token._id)),
+      );
+    } else {
+      await Promise.all(refreshTokens.map((token) => ctx.db.delete(token._id)));
+      await ctx.db.delete(session._id);
+    }
+
+    return {
+      state: args.state,
+      affectedRefreshTokens: refreshTokens.length,
+    };
+  },
+});
+
 export const cleanupAuthUserByEmail = mutation({
   args: {
     secret: v.string(),

--- a/docs/README.md
+++ b/docs/README.md
@@ -13,6 +13,7 @@ This repo keeps durable markdown under `docs/` so product, developer, engineerin
 - `docs/planning/README.md` - product, architecture, roadmap, backlog, and issue-planning docs; treat as engineering until promoted
 - `docs/agentic/README.md` - software-factory, onboarding, control-loop, and agent workflow docs; treat as engineering/operator context
 - `docs/backend/convex-bootstrap.md` - backend bootstrap workflow and structure notes
+- `docs/backend/auth-sessions.md` - first-party web session lifetime, refresh, revocation, and deployment contract
 - `docs/backend/billing-foundation.md` - first-pass Stripe billing state, env names, and follow-up integration direction
 - `docs/backend/event-schema.md` - event records, participant links, media links, and world-association notes
 - `docs/developers/partner-agent-skill.md` - Docusaurus-visible canonical partner-agent guidance

--- a/docs/backend/auth-sessions.md
+++ b/docs/backend/auth-sessions.md
@@ -1,0 +1,116 @@
+# App authentication sessions
+
+Status: `Current recommendation` implemented for new sessions.
+
+This contract covers first-party VRDex web sessions created through Discord,
+Google, or email/password. Provider access-token expiry is not the VRDex app
+session lifetime. The browser stores VRDex's refresh credential in an
+HTTP-only cookie; bearer tokens must not be moved to `localStorage` by
+application code.
+
+## Session contract
+
+| Boundary | Contract |
+| --- | --- |
+| JWT access token | 1 hour |
+| Inactivity timeout | 30 days since the latest successful refresh |
+| Remembered browser cookie | 30 days, renewed when tokens rotate |
+| Absolute lifetime | 90 days from sign-in |
+| Silent refresh | Middleware refreshes near JWT expiry and rotates the one-time refresh token |
+| Explicit sign-out | Deletes the current backend session and its refresh-token tree, then clears browser state |
+| Refresh-token reuse | Reuse outside the library's concurrency window invalidates the affected refresh-token subtree |
+| Sensitive actions | Require recent authentication when step-up support is added; do not shorten every routine session |
+| Preview/staging | Separate Convex deployment, issuer, signing keys, callback host, cookies, and accounts from production |
+
+The cookie remains host-only with `Secure`, `HttpOnly`, `SameSite=Lax`, and
+`Path=/` on hosted HTTPS origins. No `Domain` attribute is set, so a session
+for `vrdex.net` is not sent to generated Vercel previews, `staging.vrdex.net`,
+or `db.vrdex.net`. OAuth callbacks use the Convex HTTP Actions host, then return
+an application code to the web origin; provider tokens do not become web
+session cookies.
+
+## Why this is explicit
+
+`@convex-dev/auth` 0.0.92 defaults backend sessions to 30 days total, refresh
+tokens to 30 days of inactivity, and JWTs to 1 hour. Its Next.js middleware
+defaults auth cookies to browser-session cookies unless `cookieConfig.maxAge`
+is supplied. A browser restart could therefore discard the server-readable
+refresh token while the backend session was still active.
+
+VRDex sets both sides explicitly:
+
+- `convex/_authSession.ts` owns backend JWT, inactivity, and absolute limits.
+- `apps/web/src/lib/auth-session.ts` owns the matching browser cookie limit and
+  sanitized lifecycle classification.
+- `apps/web/src/middleware.ts` supplies the remembered-cookie configuration.
+
+Changing one duration requires changing the matching constants and tests
+together. Existing backend session records keep the expiration time written
+when they were created; the 90-day cap applies to sessions created after the
+backend change deploys.
+
+## Revocation and account lifecycle
+
+Current explicit sign-out revokes only the current session. A future
+multi-device session-management surface should list devices without exposing
+tokens and support revoking one session or all sessions. Global revocation,
+account deletion, and security-sensitive linked-account changes must delete
+all `authSessions` and `authRefreshTokens` for the account.
+
+Removing or revoking a Discord or Google grant does not silently extend third-
+party access. It also must not sign a user out merely because an optional
+provider API token expired. Require provider reauthorization only for a feature
+that actually needs fresh provider access. Account access continues through
+another linked method when policy allows it.
+
+Step-up authentication remains separate work. Billing, credential issuance,
+account deletion, ownership transfer, and sign-in-method changes should
+eventually require a recent authentication timestamp even when the ordinary
+session is valid.
+
+## Deployment and key rotation
+
+Keep `SITE_URL`, `CONVEX_SITE_URL`, `JWT_PRIVATE_KEY`, and `JWKS` deployment-
+scoped. Preview callbacks must never mint production sessions. Vercel
+deployment URLs should not be used as the production smoke base URL.
+
+Rotating the Convex Auth signing key can invalidate JWTs that have at most one
+hour remaining. Treat rotation as an owner action: stage the new key pair,
+deploy consistently, monitor refresh failures, and expect silent refresh to
+mint a new JWT when the existing refresh session remains valid. Do not rotate
+provider credentials or Convex keys as part of an application PR.
+
+## Observability
+
+The client emits only:
+
+- `auth_session_restore_completed` with `authenticated` or `anonymous`;
+- `auth_session_state_changed` with the previous and next coarse state.
+
+These events contain no token, provider payload, email, user ID, redirect URL,
+or account secret. Token refresh failures remain server errors until the auth
+library exposes a sanitized reason hook; never log raw JWTs or refresh tokens.
+
+## Verification
+
+Clock-controlled tests cover active, inactivity-expired, absolute-expired, and
+revoked classifications. Browser coverage must retain:
+
+- persistent cookie attributes and browser restart;
+- silent refresh and rotation;
+- cold client state after a deployment/reload;
+- concurrent tabs and explicit sign-out;
+- inactivity and absolute expiry;
+- invalid or revoked refresh sessions;
+- transient failure without destructive client-state clearing.
+
+Production inspection is read-only and sanitized. Compare aggregate session
+durations, active/expired counts, and environment variable names; never export
+user records or token identifiers into issue or PR evidence.
+
+## Upstream references
+
+- [Convex Auth configuration](https://github.com/get-convex/convex-auth/blob/7fcda87ead1918f5b537e1e423698209f1d48747/src/server/types.ts)
+- [Convex Auth session implementation](https://github.com/get-convex/convex-auth/blob/7fcda87ead1918f5b537e1e423698209f1d48747/src/server/implementation/sessions.ts)
+- [Convex Auth refresh-token implementation](https://github.com/get-convex/convex-auth/blob/7fcda87ead1918f5b537e1e423698209f1d48747/src/server/implementation/refreshTokens.ts)
+- [Convex Auth Next.js cookie options](https://github.com/get-convex/convex-auth/blob/7fcda87ead1918f5b537e1e423698209f1d48747/src/nextjs/server/cookies.ts)

--- a/docs/deployment/convex-environments.md
+++ b/docs/deployment/convex-environments.md
@@ -129,6 +129,11 @@ Production Convex Auth env names:
 - `JWKS`: Convex Auth public key set matching `JWT_PRIVATE_KEY`
 - `AWS_SES_REGION`, `AWS_SES_FROM_EMAIL`, `AWS_ACCESS_KEY_ID`, and `AWS_SECRET_ACCESS_KEY`: production SES sender configuration for email/password verification
 
+Session durations are code-owned rather than dashboard-owned. See
+[`docs/backend/auth-sessions.md`](../backend/auth-sessions.md). Do not add
+`AUTH_SESSION_TOTAL_DURATION_MS` or `AUTH_SESSION_INACTIVE_DURATION_MS` as
+undocumented deployment overrides.
+
 The production authenticated smoke lane does not require Convex E2E helpers and should not enable them in production. It reuses the normal production Auth configuration above and only supplies a pre-authenticated browser storage state from GitHub Actions.
 
 GitHub Actions repository settings for the optional authenticated smoke:

--- a/docs/deployment/vercel-preview.md
+++ b/docs/deployment/vercel-preview.md
@@ -238,6 +238,7 @@ Current production auth status:
 - Discord OAuth app `VRDex` uses client ID `1516492492189466625` and allows `https://db.vrdex.net/api/auth/callback/discord`.
 - Discord sign-in from `https://vrdex.net/sign-in` returns to an authenticated `https://vrdex.net/account` session.
 - Convex production includes `JWT_PRIVATE_KEY` and matching `JWKS`, required for Convex Auth to mint web session cookies after OAuth callbacks.
+- App sessions use the explicit remembered-session contract in [`docs/backend/auth-sessions.md`](../backend/auth-sessions.md): 30 days of inactivity, a 90-day absolute cap for newly created sessions, and one-hour JWT rotation.
 
 ### Production authenticated account smoke
 

--- a/docs/engineering/service-map.md
+++ b/docs/engineering/service-map.md
@@ -18,7 +18,7 @@ Use this page as the high-level map between VRDex services, docs, and implementa
 | Service | Purpose | Related Docs |
 | --- | --- | --- |
 | Vercel | Hosted web deployments, preview deployments, staging helpers. | [Vercel preview deployment](../deployment/vercel-preview.md), [Self-hosting and IaC](../developers/self-hosting-and-iac.md) |
-| Convex | Application data, functions, auth integration, local backend verification. | [Convex bootstrap](../backend/convex-bootstrap.md), [Convex environments](../deployment/convex-environments.md) |
+| Convex | Application data, functions, auth integration, local backend verification. | [Convex bootstrap](../backend/convex-bootstrap.md), [App auth sessions](../backend/auth-sessions.md), [Convex environments](../deployment/convex-environments.md) |
 | AWS SES | Auth email sender and domain email verification. | [SES auth email](../deployment/ses-auth-email.md), [AWS service baseline](../deployment/aws-baseline.md) |
 | AWS S3 | Private profile asset storage baseline. | [AWS service baseline](../deployment/aws-baseline.md) |
 | Route 53 | DNS records for hosted domains, SES, and future provider-owned records. | [AWS service baseline](../deployment/aws-baseline.md), [Self-hosting and IaC](../developers/self-hosting-and-iac.md) |

--- a/tests/web/auth-session.test.ts
+++ b/tests/web/auth-session.test.ts
@@ -1,0 +1,106 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+
+import {
+  AUTH_JWT_DURATION_MS as BACKEND_JWT_DURATION_MS,
+  AUTH_SESSION_INACTIVE_DURATION_MS as BACKEND_INACTIVE_DURATION_MS,
+  AUTH_SESSION_TOTAL_DURATION_MS as BACKEND_TOTAL_DURATION_MS,
+} from "../../convex/_authSession";
+import {
+  AUTH_JWT_DURATION_MS,
+  AUTH_SESSION_COOKIE_MAX_AGE_SECONDS,
+  AUTH_SESSION_INACTIVE_DURATION_MS,
+  AUTH_SESSION_TOTAL_DURATION_MS,
+  authLifecycleEvent,
+  authSessionValidityAt,
+} from "../../apps/web/src/lib/auth-session";
+
+const DAY_MS = 24 * 60 * 60 * 1_000;
+
+describe("app session contract", () => {
+  it("keeps the browser and backend inactivity windows aligned", () => {
+    assert.equal(AUTH_JWT_DURATION_MS, 60 * 60 * 1_000);
+    assert.equal(AUTH_SESSION_INACTIVE_DURATION_MS, 30 * DAY_MS);
+    assert.equal(AUTH_SESSION_TOTAL_DURATION_MS, 90 * DAY_MS);
+    assert.equal(
+      AUTH_SESSION_COOKIE_MAX_AGE_SECONDS * 1_000,
+      AUTH_SESSION_INACTIVE_DURATION_MS,
+    );
+    assert.equal(BACKEND_JWT_DURATION_MS, AUTH_JWT_DURATION_MS);
+    assert.equal(
+      BACKEND_INACTIVE_DURATION_MS,
+      AUTH_SESSION_INACTIVE_DURATION_MS,
+    );
+    assert.equal(BACKEND_TOTAL_DURATION_MS, AUTH_SESSION_TOTAL_DURATION_MS);
+  });
+
+  it("uses a clock-controlled inactivity boundary", () => {
+    const now = Date.UTC(2026, 6, 26);
+
+    assert.equal(
+      authSessionValidityAt({
+        now,
+        sessionExpiresAt: now + 60 * DAY_MS,
+        refreshExpiresAt: now + 1,
+        refreshCredentialPresent: true,
+      }),
+      "active",
+    );
+    assert.equal(
+      authSessionValidityAt({
+        now: now + 1,
+        sessionExpiresAt: now + 60 * DAY_MS,
+        refreshExpiresAt: now + 1,
+        refreshCredentialPresent: true,
+      }),
+      "inactive_expired",
+    );
+  });
+
+  it("enforces the absolute boundary even after recent activity", () => {
+    const now = Date.UTC(2026, 6, 26);
+
+    assert.equal(
+      authSessionValidityAt({
+        now,
+        sessionExpiresAt: now,
+        refreshExpiresAt: now + 30 * DAY_MS,
+        refreshCredentialPresent: true,
+      }),
+      "absolute_expired",
+    );
+  });
+
+  it("treats a missing or revoked refresh credential as revoked", () => {
+    const now = Date.UTC(2026, 6, 26);
+
+    assert.equal(
+      authSessionValidityAt({
+        now,
+        sessionExpiresAt: now + 90 * DAY_MS,
+        refreshExpiresAt: now + 30 * DAY_MS,
+        refreshCredentialPresent: false,
+      }),
+      "revoked",
+    );
+  });
+
+  it("emits sanitized lifecycle events only after restoration settles", () => {
+    assert.equal(authLifecycleEvent(null, "restoring"), null);
+    assert.deepEqual(authLifecycleEvent("restoring", "authenticated"), {
+      event: "auth_session_restore_completed",
+      properties: { outcome: "authenticated" },
+    });
+    assert.equal(
+      authLifecycleEvent("authenticated", "authenticated"),
+      null,
+    );
+    assert.deepEqual(authLifecycleEvent("authenticated", "anonymous"), {
+      event: "auth_session_state_changed",
+      properties: {
+        from: "authenticated",
+        to: "anonymous",
+      },
+    });
+  });
+});


### PR DESCRIPTION
[AGENT]

## Summary

VRDex backend sessions were valid for up to 30 days, but the Next.js integration used browser-session cookies because `cookieConfig.maxAge` was unset. Closing the browser could therefore delete the only server-readable refresh credential while its Convex session remained active. On restart, middleware saw an anonymous request and hydration settled as signed out.

This PR makes the first-party session contract explicit:

- one-hour JWTs with silent refresh and one-time refresh-token rotation;
- a 30-day inactivity window and remembered browser cookie;
- a 90-day absolute maximum for newly created sessions;
- host-only `Secure`, `HttpOnly`, `SameSite=Lax`, `Path=/` cookies on hosted HTTPS origins;
- current-session revocation on explicit sign-out;
- staging, preview, and production isolation through existing origin and Convex deployment boundaries.

It also avoids a false signed-out account state while auth restoration is pending and adds coarse lifecycle telemetry without tokens, provider payloads, emails, user IDs, or redirect URLs.

## Evidence and scope

- Installed stack inspected at its locked runtime versions: `@convex-dev/auth` 0.0.92, `@auth/core` 0.37.4, Convex 1.32.0, Next.js 16.1.6.
- Official source at the installed Convex Auth commit confirms: 30-day default backend total lifetime, 30-day refresh inactivity, one-hour JWTs, rotating one-time refresh tokens, and browser-session cookies when `cookieConfig.maxAge` is absent.
- Sanitized read-only production sampling found backend sessions and refresh records with the expected 30-day durations; no duration override exists in the production Convex environment.
- Production and staging use distinct web origins, callback hosts, Convex deployments, issuers, and signing keys. The host-only cookie does not cross into generated previews, staging, or `db.*` callback hosts.
- No service worker or application cache layer participates in authentication.
- Current Convex Auth 0.0.94 was compared with the locked 0.0.92 implementation; its auth-relevant changes do not include a cookie/session-lifetime fix, so this PR does not bundle a dependency upgrade.

Provider access-token expiry is intentionally independent from the VRDex app session. This change does not weaken CSRF or session-fixation controls, store bearer credentials in localStorage, or make sessions immortal.

## Verification

- `pnpm verify:docs`
- `pnpm lint:web`
- `pnpm typecheck:web`
- `pnpm test:web` — 188 passed
- `pnpm build:web`
- `pnpm typecheck:backend`
- `pnpm test:backend` — 274 passed
- `pnpm test:temporal-runtime` — 14 passed
- `pnpm test:temporal-inference` — 7 passed
- `pnpm --filter web exec playwright test e2e/auth-session.flow.spec.ts --project=desktop-chromium` — 5 passed

The browser suite covers restart restoration, persistent cookie attributes, silent rotation, cold client hydration after deployment/reload, transient network failure, concurrent tabs, explicit sign-out, inactivity expiry, absolute expiry, invalid refresh credentials, and revoked sessions.

The aggregate `pnpm verify` path was also exercised. Its OpenAPI freshness check initially encountered a Windows line-ending mismatch and the first web build could not reach Google Fonts from the restricted environment; regeneration and the network-enabled production build both passed. The final staged `pnpm check:backend:generated` gate passed.

## Security and rollout

Existing sessions retain the expiration timestamp written at creation; the 90-day absolute maximum applies to sessions created after deployment. Existing browser sessions may need one final sign-in if their session cookie has already been discarded.

No provider dashboard, production environment variable, secret, key, account, or database mutation is part of this PR. Deployment is the only required owner action. Keep `SITE_URL`, `CONVEX_SITE_URL`, `JWT_PRIVATE_KEY`, and `JWKS` stable and deployment-scoped.

Global revocation, per-device session management, and recent-authentication step-up for sensitive actions remain explicit follow-up work. Current sign-out revokes the current session and its refresh-token tree.
