### PR TITLE
Exclude Media Kit fixtures from production smoke

### DIFF
--- a/apps/web/e2e/media-kit.visual.spec.ts
+++ b/apps/web/e2e/media-kit.visual.spec.ts
@@ -6,7 +6,7 @@ test.beforeEach(async ({ page }) => {
   await prepareVisualPage(page);
 });
 
-test("owner media-kit editor @visual", async ({ page }, testInfo) => {
+test("owner media-kit editor @visual @fixture", async ({ page }, testInfo) => {
   await page.goto("/account/media-kit");
   await expect(page.getByRole("heading", { name: "Media kit", exact: true })).toBeVisible();
   await expect(page.getByRole("heading", { name: "Public gallery" })).toBeVisible();
@@ -19,7 +19,7 @@ test("owner media-kit editor @visual", async ({ page }, testInfo) => {
   await captureRouteScreenshot(page, testInfo, "media-kit-editor");
 });
 
-test("owner upload failure stays beside the publish control", async ({ page }) => {
+test("owner upload failure stays beside the publish control @fixture", async ({ page }) => {
   await page.goto("/account/media-kit");
   await page.getByLabel("Add image").setInputFiles({
     name: "synthetic.png",
@@ -37,7 +37,7 @@ test("owner upload failure stays beside the publish control", async ({ page }) =
   );
 });
 
-test("owner profile switch clears an unsubmitted upload", async ({ page }) => {
+test("owner profile switch clears an unsubmitted upload @fixture", async ({ page }) => {
   await page.goto("/account/media-kit");
   await page.getByLabel("Add image").setInputFiles({
     name: "synthetic.png",
@@ -52,7 +52,7 @@ test("owner profile switch clears an unsubmitted upload", async ({ page }) => {
   await expect(page.getByText("synthetic.png", { exact: true })).toHaveCount(0);
 });
 
-test("removed profile cannot inherit a staged upload", async ({ page }) => {
+test("removed profile cannot inherit a staged upload @fixture", async ({ page }) => {
   await page.goto("/account/media-kit");
   await page.getByLabel("Add image").setInputFiles({
     name: "transfer.png",
@@ -96,7 +96,7 @@ test("removed profile cannot inherit a staged upload", async ({ page }) => {
   await expect(page.getByText("last-profile.png", { exact: true })).toHaveCount(0);
 });
 
-test("owner profile switch stays locked during upload", async ({ page }) => {
+test("owner profile switch stays locked during upload @fixture", async ({ page }) => {
   await page.goto("/account/media-kit");
   await page.getByLabel("Add image").setInputFiles({
     name: "slow.png",
@@ -114,7 +114,7 @@ test("owner profile switch stays locked during upload", async ({ page }) => {
   await expect(page.getByLabel("Profile", { exact: true })).toHaveValue("demo-profile");
 });
 
-test("owner restore keeps status and focus in the active gallery", async ({ page }) => {
+test("owner restore keeps status and focus in the active gallery @fixture", async ({ page }) => {
   await page.goto("/account/media-kit");
   await page.getByRole("button", { name: "Restore" }).click();
 
@@ -122,7 +122,7 @@ test("owner restore keeps status and focus in the active gallery", async ({ page
   await expect(page.locator("#active-aurora-removed")).toBeFocused();
 });
 
-test("owner preview failure can retry", async ({ page }) => {
+test("owner preview failure can retry @fixture", async ({ page }) => {
   await page.goto("/account/media-kit");
 
   const preview = page.getByRole("img", {
@@ -139,7 +139,7 @@ test("owner preview failure can retry", async ({ page }) => {
   ).toBeVisible();
 });
 
-test("public profile media kit @visual", async ({ page }, testInfo) => {
+test("public profile media kit @visual @fixture", async ({ page }, testInfo) => {
   await page.goto("/p/playwright-dj-aurora");
   const mediaKit = page.getByRole("heading", { name: "Media kit" }).locator("xpath=ancestor::section");
   await expect(mediaKit.getByRole("heading", { name: "Profile image" })).toHaveCount(1);


### PR DESCRIPTION
[AGENT]

## What changed

Marks every synthetic Media Kit browser scenario with `@fixture`.

## Why

The production smoke selector excludes fixture tests, but six Media Kit fixture scenarios were untagged. After PR #197 deployed with the feature correctly disabled, those scenarios ran against production and failed while waiting for fixture-only editor controls.

## Impact

Production smoke returns to read-only hosted coverage. Media Kit fixture behavior and desktop/mobile visual coverage remain unchanged.

## Verification

- Web lint
- Media Kit browser suite: 16 passed
- Hosted selector: 0 Media Kit fixture tests
- Visual selector: 4 Media Kit cases across desktop/mobile

Failure evidence: https://github.com/BASIC-BIT/VRDex/actions/runs/30230806601