### PR TITLE
Add on-demand Vercel preview deploy

### DIFF
--- a/.github/workflows/vercel-preview-comment.yml
+++ b/.github/workflows/vercel-preview-comment.yml
@@ -9,12 +9,12 @@ permissions:
   actions: write
   contents: read
   issues: write
-  pull-requests: write
+  pull-requests: read
 
 jobs:
   queue-preview:
     name: Queue On-Demand Preview
-    if: ${{ github.event.issue.pull_request && (contains(github.event.comment.body, '@vrdex preview') || contains(github.event.comment.body, '/vercel-preview')) }}
+    if: ${{ github.event.issue.pull_request && contains(fromJSON('["OWNER","MEMBER","COLLABORATOR"]'), github.event.comment.author_association) && (contains(github.event.comment.body, '@vrdex preview') || contains(github.event.comment.body, '/vercel-preview')) }}
     runs-on: ubuntu-latest
     timeout-minutes: 5
 
@@ -99,21 +99,33 @@ jobs:
           PR_NUMBER: ${{ steps.request.outputs.pr_number }}
         with:
           script: |
+            const marker = "<!-- on-demand-vercel-preview-queue-failure-comment -->";
             const owner = context.repo.owner;
             const repo = context.repo.repo;
+            const issue_number = Number(process.env.PR_NUMBER);
             const runUrl = `https://github.com/${owner}/${repo}/actions/runs/${context.runId}`;
+            const body = [
+              marker,
+              "On-demand Vercel preview request could not be queued.",
+              `Workflow logs: ${runUrl}`,
+            ].join("\n");
 
             try {
-              await github.rest.issues.createComment({
+              const comments = await github.paginate(github.rest.issues.listComments, {
                 owner,
                 repo,
-                issue_number: Number(process.env.PR_NUMBER),
-                body: [
-                  "<!-- on-demand-vercel-preview-queue-failure-comment -->",
-                  "On-demand Vercel preview request could not be queued.",
-                  `Workflow logs: ${runUrl}`,
-                ].join("\n"),
+                issue_number,
+                per_page: 100,
               });
+              const existing = comments.find(
+                (comment) => comment.user?.type === "Bot" && comment.body?.includes(marker),
+              );
+
+              if (existing) {
+                await github.rest.issues.updateComment({ owner, repo, comment_id: existing.id, body });
+              } else {
+                await github.rest.issues.createComment({ owner, repo, issue_number, body });
+              }
             } catch (error) {
               core.warning(`Unable to post queue failure comment: ${error}`);
             }

--- a/.github/workflows/vercel-preview-comment.yml
+++ b/.github/workflows/vercel-preview-comment.yml
@@ -1,0 +1,130 @@
+name: Request On-Demand Vercel Preview
+
+on:
+  issue_comment:
+    types:
+      - created
+
+permissions:
+  actions: write
+  contents: read
+  issues: write
+  pull-requests: write
+
+jobs:
+  queue-preview:
+    name: Queue On-Demand Preview
+    if: ${{ github.event.issue.pull_request && (contains(github.event.comment.body, '@vrdex preview') || contains(github.event.comment.body, '/vercel-preview')) }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+
+    steps:
+      - name: Validate request
+        id: request
+        uses: actions/github-script@v9
+        with:
+          script: |
+            const body = context.payload.comment.body || "";
+            if (!/(^|\s)(@vrdex\s+preview|\/vercel-preview)(\s|$)/i.test(body)) {
+              core.setFailed("Comment does not contain an on-demand preview request.");
+              return;
+            }
+
+            const allowed = new Set(["OWNER", "MEMBER", "COLLABORATOR"]);
+            const association = context.payload.comment.author_association || "NONE";
+            if (!allowed.has(association)) {
+              core.setFailed(
+                `On-demand previews may only be requested by trusted collaborators. Got: ${association}`,
+              );
+              return;
+            }
+
+            const { data: pull } = await github.rest.pulls.get({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              pull_number: context.issue.number,
+            });
+
+            if (pull.head.repo?.full_name !== `${context.repo.owner}/${context.repo.repo}`) {
+              core.setFailed(
+                "On-demand previews only run for branches inside this repository. Mirror a fork PR to a trusted branch first.",
+              );
+              return;
+            }
+
+            if (pull.state !== "open") {
+              core.setFailed(
+                `On-demand previews only run for open pull requests. This one is ${pull.state}.`,
+              );
+              return;
+            }
+
+            core.setOutput("comment_id", String(context.payload.comment.id));
+            core.setOutput("pr_number", String(pull.number));
+
+      - name: Dispatch preview deployment
+        uses: actions/github-script@v9
+        env:
+          COMMENT_ID: ${{ steps.request.outputs.comment_id }}
+          PR_NUMBER: ${{ steps.request.outputs.pr_number }}
+        with:
+          script: |
+            try {
+              await github.rest.reactions.createForIssueComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                comment_id: Number(process.env.COMMENT_ID),
+                content: "eyes",
+              });
+            } catch (error) {
+              core.warning(`Unable to add reaction: ${error}`);
+            }
+
+            await github.rest.actions.createWorkflowDispatch({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              workflow_id: "vercel-preview-deploy.yml",
+              ref: context.payload.repository.default_branch,
+              inputs: {
+                pull_number: process.env.PR_NUMBER,
+                comment_id: process.env.COMMENT_ID,
+              },
+            });
+
+      - name: Report queue failure
+        if: failure() && steps.request.outcome == 'success'
+        uses: actions/github-script@v9
+        env:
+          COMMENT_ID: ${{ steps.request.outputs.comment_id }}
+          PR_NUMBER: ${{ steps.request.outputs.pr_number }}
+        with:
+          script: |
+            const owner = context.repo.owner;
+            const repo = context.repo.repo;
+            const runUrl = `https://github.com/${owner}/${repo}/actions/runs/${context.runId}`;
+
+            try {
+              await github.rest.issues.createComment({
+                owner,
+                repo,
+                issue_number: Number(process.env.PR_NUMBER),
+                body: [
+                  "<!-- on-demand-vercel-preview-queue-failure-comment -->",
+                  "On-demand Vercel preview request could not be queued.",
+                  `Workflow logs: ${runUrl}`,
+                ].join("\n"),
+              });
+            } catch (error) {
+              core.warning(`Unable to post queue failure comment: ${error}`);
+            }
+
+            try {
+              await github.rest.reactions.createForIssueComment({
+                owner,
+                repo,
+                comment_id: Number(process.env.COMMENT_ID),
+                content: "confused",
+              });
+            } catch (error) {
+              core.warning(`Unable to add failure reaction: ${error}`);
+            }

--- a/.github/workflows/vercel-preview-deploy.yml
+++ b/.github/workflows/vercel-preview-deploy.yml
@@ -1,0 +1,238 @@
+name: On-Demand Vercel Preview
+
+on:
+  workflow_dispatch:
+    inputs:
+      pull_number:
+        description: Pull request number to deploy a preview for.
+        required: true
+        type: string
+      comment_id:
+        description: Issue comment id that requested the preview.
+        required: false
+        type: string
+  workflow_call:
+    inputs:
+      pull_number:
+        description: Pull request number to deploy a preview for.
+        required: true
+        type: string
+      comment_id:
+        description: Issue comment id that requested the preview.
+        required: false
+        type: string
+    outputs:
+      deployment_url:
+        description: Preview deployment URL.
+        value: ${{ jobs.deploy-preview.outputs.deployment_url }}
+
+permissions:
+  contents: read
+  issues: write
+  pull-requests: write
+
+jobs:
+  deploy-preview:
+    name: Deploy On-Demand Preview
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    concurrency:
+      group: on-demand-vercel-preview-${{ inputs.pull_number }}
+      cancel-in-progress: true
+    outputs:
+      deployment_url: ${{ steps.deploy.outputs.url }}
+
+    steps:
+      - name: Resolve pull request
+        id: pr
+        uses: actions/github-script@v9
+        env:
+          INPUT_PULL_NUMBER: ${{ inputs.pull_number }}
+        with:
+          script: |
+            const raw = String(process.env.INPUT_PULL_NUMBER || "").trim();
+            const pullNumber = Number(raw);
+            if (!Number.isInteger(pullNumber) || pullNumber <= 0) {
+              core.setFailed("pull_number must be a positive integer.");
+              return;
+            }
+
+            const { data: pull } = await github.rest.pulls.get({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              pull_number: pullNumber,
+            });
+
+            if (pull.head.repo?.full_name !== `${context.repo.owner}/${context.repo.repo}`) {
+              core.setFailed(
+                "On-demand previews only run for branches inside this repository. Mirror a fork PR to a trusted branch first.",
+              );
+              return;
+            }
+
+            if (pull.state !== "open") {
+              core.setFailed(
+                `On-demand previews only run for open pull requests. This one is ${pull.state}.`,
+              );
+              return;
+            }
+
+            core.setOutput("head_sha", pull.head.sha);
+            core.setOutput("head_ref", pull.head.ref);
+            core.setOutput("pr_number", String(pull.number));
+
+      - name: Checkout
+        uses: actions/checkout@v6
+        with:
+          ref: ${{ steps.pr.outputs.head_sha }}
+
+      - name: Check Vercel deployment secrets
+        env:
+          VERCEL_TOKEN: ${{ secrets.VERCEL_TOKEN }}
+          VERCEL_ORG_ID: ${{ secrets.VERCEL_ORG_ID }}
+          VERCEL_PROJECT_ID: ${{ secrets.VERCEL_PROJECT_ID }}
+        run: |
+          set -euo pipefail
+
+          missing=()
+          if [ -z "$VERCEL_TOKEN" ]; then missing+=("VERCEL_TOKEN"); fi
+          if [ -z "$VERCEL_ORG_ID" ]; then missing+=("VERCEL_ORG_ID"); fi
+          if [ -z "$VERCEL_PROJECT_ID" ]; then missing+=("VERCEL_PROJECT_ID"); fi
+
+          if [ "${#missing[@]}" -gt 0 ]; then
+            printf '::error::Missing repository secrets for on-demand previews: %s\n' "${missing[*]}"
+            exit 1
+          fi
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v6
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: 24
+
+      - name: Deploy Vercel preview
+        id: deploy
+        env:
+          HEAD_REF: ${{ steps.pr.outputs.head_ref }}
+          HEAD_SHA: ${{ steps.pr.outputs.head_sha }}
+          PR_NUMBER: ${{ steps.pr.outputs.pr_number }}
+          VERCEL_TOKEN: ${{ secrets.VERCEL_TOKEN }}
+          VERCEL_ORG_ID: ${{ secrets.VERCEL_ORG_ID }}
+          VERCEL_PROJECT_ID: ${{ secrets.VERCEL_PROJECT_ID }}
+        run: |
+          set -euo pipefail
+          deployment_url=$(pnpm dlx vercel@54.4.1 deploy --target=preview --yes --token "$VERCEL_TOKEN" | tail -n 1)
+          if [ -z "$deployment_url" ]; then
+            echo "Vercel preview deployment did not return a URL." >&2
+            exit 1
+          fi
+
+          echo "url=$deployment_url" >> "$GITHUB_OUTPUT"
+          {
+            echo "## On-demand Vercel preview"
+            echo "- Pull request: #$PR_NUMBER"
+            echo "- Ref: \`$HEAD_REF\`"
+            echo "- Commit: \`$HEAD_SHA\`"
+            echo "- Deployment: $deployment_url"
+            echo "- Deployment check page: $deployment_url/deployment"
+          } >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Post preview comment
+        if: success()
+        uses: actions/github-script@v9
+        env:
+          COMMENT_ID: ${{ inputs.comment_id }}
+          DEPLOYMENT_URL: ${{ steps.deploy.outputs.url }}
+          HEAD_REF: ${{ steps.pr.outputs.head_ref }}
+          PR_NUMBER: ${{ steps.pr.outputs.pr_number }}
+        with:
+          script: |
+            const marker = "<!-- on-demand-vercel-preview-comment -->";
+            const owner = context.repo.owner;
+            const repo = context.repo.repo;
+            const issue_number = Number(process.env.PR_NUMBER);
+            const deploymentUrl = process.env.DEPLOYMENT_URL;
+
+            const body = [
+              marker,
+              "## On-demand Vercel preview",
+              `Branch \`${process.env.HEAD_REF}\`.`,
+              `Preview URL: ${deploymentUrl}`,
+              `Deployment check page: ${deploymentUrl}/deployment`,
+              "",
+              "Comment `@vrdex preview` or `/vercel-preview` on this pull request for a fresh deployment.",
+            ].join("\n");
+
+            const comments = await github.paginate(github.rest.issues.listComments, {
+              owner,
+              repo,
+              issue_number,
+              per_page: 100,
+            });
+            const existing = comments.find(
+              (comment) => comment.user?.type === "Bot" && comment.body?.includes(marker),
+            );
+
+            if (existing) {
+              await github.rest.issues.updateComment({ owner, repo, comment_id: existing.id, body });
+            } else {
+              await github.rest.issues.createComment({ owner, repo, issue_number, body });
+            }
+
+            const commentId = Number(process.env.COMMENT_ID || "0");
+            if (commentId > 0) {
+              try {
+                await github.rest.reactions.createForIssueComment({
+                  owner,
+                  repo,
+                  comment_id: commentId,
+                  content: "rocket",
+                });
+              } catch (error) {
+                core.warning(`Unable to add success reaction: ${error}`);
+              }
+            }
+
+      - name: Report failure on pull request
+        if: failure() && steps.pr.outcome == 'success'
+        uses: actions/github-script@v9
+        env:
+          COMMENT_ID: ${{ inputs.comment_id }}
+          PR_NUMBER: ${{ steps.pr.outputs.pr_number }}
+        with:
+          script: |
+            const owner = context.repo.owner;
+            const repo = context.repo.repo;
+            const runUrl = `https://github.com/${owner}/${repo}/actions/runs/${context.runId}`;
+            const body = [
+              "<!-- on-demand-vercel-preview-failure-comment -->",
+              "On-demand Vercel preview deploy failed.",
+              `Workflow logs: ${runUrl}`,
+            ].join("\n");
+
+            try {
+              await github.rest.issues.createComment({
+                owner,
+                repo,
+                issue_number: Number(process.env.PR_NUMBER),
+                body,
+              });
+            } catch (error) {
+              core.warning(`Unable to post failure comment: ${error}`);
+            }
+
+            const commentId = Number(process.env.COMMENT_ID || "0");
+            if (commentId > 0) {
+              try {
+                await github.rest.reactions.createForIssueComment({
+                  owner,
+                  repo,
+                  comment_id: commentId,
+                  content: "confused",
+                });
+              } catch (error) {
+                core.warning(`Unable to add failure reaction: ${error}`);
+              }
+            }

--- a/.github/workflows/vercel-preview-deploy.yml
+++ b/.github/workflows/vercel-preview-deploy.yml
@@ -29,7 +29,7 @@ on:
 permissions:
   contents: read
   issues: write
-  pull-requests: write
+  pull-requests: read
 
 jobs:
   deploy-preview:
@@ -203,22 +203,33 @@ jobs:
           PR_NUMBER: ${{ steps.pr.outputs.pr_number }}
         with:
           script: |
+            const marker = "<!-- on-demand-vercel-preview-failure-comment -->";
             const owner = context.repo.owner;
             const repo = context.repo.repo;
+            const issue_number = Number(process.env.PR_NUMBER);
             const runUrl = `https://github.com/${owner}/${repo}/actions/runs/${context.runId}`;
             const body = [
-              "<!-- on-demand-vercel-preview-failure-comment -->",
+              marker,
               "On-demand Vercel preview deploy failed.",
               `Workflow logs: ${runUrl}`,
             ].join("\n");
 
             try {
-              await github.rest.issues.createComment({
+              const comments = await github.paginate(github.rest.issues.listComments, {
                 owner,
                 repo,
-                issue_number: Number(process.env.PR_NUMBER),
-                body,
+                issue_number,
+                per_page: 100,
               });
+              const existing = comments.find(
+                (comment) => comment.user?.type === "Bot" && comment.body?.includes(marker),
+              );
+
+              if (existing) {
+                await github.rest.issues.updateComment({ owner, repo, comment_id: existing.id, body });
+              } else {
+                await github.rest.issues.createComment({ owner, repo, issue_number, body });
+              }
             } catch (error) {
               core.warning(`Unable to post failure comment: ${error}`);
             }

--- a/docs/deployment/vercel-preview.md
+++ b/docs/deployment/vercel-preview.md
@@ -69,6 +69,20 @@ When any gate is absent, the workflow writes the Convex E2E and preview OAuth
 token capability switches as `false` and omits the developer runtime secrets for
 that preview.
 
+## On-demand preview deploy
+
+The `Vercel Preview` job above runs inside `Baseline Checks` for every non-fork pull request commit. Two extra workflows add a second, lighter path for when a reviewer or an agent wants a preview URL without waiting for a full baseline run:
+
+- `.github/workflows/vercel-preview-comment.yml` listens for `issue_comment` and dispatches the deploy when a pull request comment contains `@vrdex preview` or `/vercel-preview`. It requires an `author_association` of `OWNER`, `MEMBER`, or `COLLABORATOR`, and refuses fork branches and non-open pull requests.
+- `.github/workflows/vercel-preview-deploy.yml` performs the deploy. Its only triggers are `workflow_dispatch` and `workflow_call`, so it cannot fire on `push` or `pull_request`. The `workflow_call` interface exposes a `deployment_url` output so a calling workflow can capture the link.
+
+This path reuses the existing `VERCEL_TOKEN`, `VERCEL_ORG_ID`, and `VERCEL_PROJECT_ID` repository secrets and adds no new ones. If any of the three is missing, the run fails and names the missing secrets instead of deploying partially.
+
+It differs from the `Baseline Checks` preview in two ways:
+
+- It runs `pnpm dlx vercel@54.4.1 deploy --target=preview --yes`, so Vercel builds remotely from the project's own Preview environment variables instead of uploading prebuilt output.
+- It does not create a `pr-<number>` Convex preview backend and injects no preview persistence, E2E, or developer-runtime values. Use the `Baseline Checks` preview when a review needs a per-pull-request Convex backend.
+
 ## Web environment
 
 Set these in the Vercel project as needed:


### PR DESCRIPTION
## What changed

Two new workflows give VRDex an on-demand Vercel preview that a human or an orchestrating workflow can invoke deliberately, instead of only getting one as a side effect of a full `Baseline Checks` run.

- `.github/workflows/vercel-preview-comment.yml`: listens for `issue_comment`, and when a pull request comment contains `@vrdex preview` or `/vercel-preview` it validates the request and dispatches the deploy. Authorization is `author_association` in `OWNER`, `MEMBER`, `COLLABORATOR`, enforced twice: once in the job-level `if:` so an untrusted comment never starts a runner, and once in the script as the authoritative check. It also refuses fork head branches and non-open pull requests.
- `.github/workflows/vercel-preview-deploy.yml`: does the deploy. Its trigger block contains only `workflow_dispatch` and `workflow_call`. The `workflow_call` interface exposes `deployment_url` as an output so a calling workflow can capture the link.
- `docs/deployment/vercel-preview.md`: one new section describing the path, its secrets, and how it differs from the existing preview.

Second commit (`c86f064`) applies review findings: the job-level authorization gate above, `pull-requests: write` downgraded to `read` in both workflows, and marker-based dedupe on both failure comments so a repeated `@vrdex preview` on a failing build updates one comment instead of stacking them.

### Overlap you should know about before merging

VRDex already deploys a Vercel preview on **every** non-fork pull request commit: the `vercel-preview` job inside `.github/workflows/baseline-checks.yml` (line 926), which also feeds `hosted-mcp-preview-smoke` and `pr-verification-report`. This PR does not remove, replace, or modify that job, and does not touch `baseline-checks.yml` at all.

So after this merges there are two preview paths. What this one adds that the existing one cannot do:

- Runs without a full `Baseline Checks` cycle, so a preview URL takes one job instead of the whole PR gate.
- Is reachable from `workflow_call`, so another workflow can invoke it and read `deployment_url`. The baseline job's outputs are only reachable from inside that workflow's own job graph.
- Is reachable from a PR comment.

What it deliberately does not do:

- It runs `pnpm dlx vercel@54.4.1 deploy --target=preview --yes`, so Vercel builds remotely from the project's own Preview environment variables. The baseline job uploads prebuilt output instead.
- It does not create a `pr-<number>` Convex preview backend and injects no preview persistence, E2E, or developer-runtime values. A review that needs a per-pull-request Convex backend still wants the `Baseline Checks` preview.

If the intent is to stop deploying a preview on every commit, that is a follow-up that has to edit `baseline-checks.yml` and re-home the `hosted-mcp-preview-smoke` dependency. That is a larger change with a required-check blast radius, and a separate agent session is currently active in this repo, so it is out of scope here.

## Secrets

No new secrets. The deploy reuses the three repository secrets `staging-deploy.yml` and the baseline preview job already use:

- `VERCEL_TOKEN`
- `VERCEL_ORG_ID`
- `VERCEL_PROJECT_ID`

If any of the three is absent the run fails and names the missing ones rather than deploying partially. No secret was created, read, printed, or modified in this PR.

## Activation

The deploy path is untested until its first manual invocation. It cannot be exercised from this PR branch, because `createWorkflowDispatch` targets the workflow file on the default branch. To activate it after merge:

1. Confirm `VERCEL_TOKEN`, `VERCEL_ORG_ID`, and `VERCEL_PROJECT_ID` exist as repository secrets. They already do if `Staging Deploy` works.
2. From the Actions tab, run `On-Demand Vercel Preview` with `pull_number` set to any open non-fork PR. This exercises the deploy without the comment path.
3. Then comment `@vrdex preview` on that same PR to exercise the dispatch path. Expect an eyes reaction, then a rocket reaction and a preview comment.

If step 2 fails on the remote Vercel build, the fix is to match the baseline job's prebuilt approach (`pnpm install --frozen-lockfile`, `vercel build --target=preview`, `vercel deploy --prebuilt`) rather than to add secrets.

## How it was verified locally

Workflows cannot be executed locally, so verification is parse, lint, shell behavior, and a manual trigger trace.

- `python -c "import yaml,sys; yaml.safe_load(open(sys.argv[1]))"` on both new files: both parse.
- `actionlint v1.7.12` on both new files: clean, no findings. `shellcheck` is not installed on this machine, so actionlint's embedded shellcheck pass did **not** run. The `run:` blocks were checked separately instead.
- `bash -n` on both non-trivial `run:` bodies: syntax OK.
- Executed the secret gate block directly with all three variables empty, output `::error::Missing repository secrets for on-demand previews: VERCEL_TOKEN VERCEL_ORG_ID VERCEL_PROJECT_ID` and exit 1. Executed it with all three set, exit 0.
- `pnpm dlx markdownlint-cli2@0.22.1 docs/deployment/vercel-preview.md` using the repo's `.markdownlint-cli2.jsonc`: 116 files linted, 0 errors.
- Did not run `pnpm verify:docs` in full. The Docusaurus build half needs a full workspace install, and the edit adds prose and a list with no new links or MDX. `pnpm lint:markdown`, the half that could realistically fail on this edit, was run as above.

After the review-fix commit:

- `actionlint` on both files again: clean, exit 0.
- Re-parsed both files with `yaml.safe_load` and asserted the resulting `permissions` maps: `pull-requests` is `read` in both.
- Extracted all six `github-script` bodies from the YAML and ran `node --check` on each wrapped as an async function body: all six parse.
- Ran the two failure-comment scripts as they are actually written in the YAML, against a stub Octokit, in three states each. No prior comment creates one. A prior bot comment carrying the marker updates that comment id and creates nothing. A human comment quoting the marker is ignored and a bot comment is created, so the `user.type === "Bot"` filter is doing work. Both files pass all three.
- Asserted the job-level gate against `CONTRIBUTOR`, `FIRST_TIME_CONTRIBUTOR`, `NONE`, `MANNEQUIN`, `undefined`, and empty string using GitHub's case-insensitive `contains` semantics: all rejected. `OWNER`, `MEMBER`, `COLLABORATOR`: all admitted.

That check is a scratch script, not a committed test. The repo has no harness for exercising workflow `github-script` bodies, and adding the first one for a comment-dedupe fix is more machinery than the fix warrants.

Trigger trace, done by reading the trigger blocks:

- `vercel-preview-deploy.yml` cannot fire on push, because its `on:` block contains exactly two keys, `workflow_dispatch` and `workflow_call`. There is no `push`, `pull_request`, `pull_request_target`, `schedule`, or `workflow_run` key, so no repository event other than an explicit dispatch or an explicit call from another workflow can start it.
- `vercel-preview-comment.yml` fires on `issue_comment: created` only, and its single job is gated on `github.event.issue.pull_request` being present, so comments on plain issues start nothing.
- Files changed are confined to two new files under `.github/workflows/` plus one existing docs file. `git status` before commit showed exactly those three paths and nothing else. No application code was touched.

## Self-reviewed risk list

- **Least sure: the remote build.** `staging-deploy.yml` proves `vercel deploy` without `--prebuilt` works for this project against the `staging` target, and I am assuming that carries to the `preview` target. It should, since the Vercel project's root directory and build command are target-independent, but I could not test it. This is the single most likely first-run failure.
- **Two preview deploys per PR is now possible.** Commenting `@vrdex preview` on a PR that is mid-baseline-run produces a second Vercel deployment for the same commit. That costs Vercel build minutes and produces two different URLs in the thread. The concurrency group only dedupes on-demand runs against each other, not against the baseline job.
- **A second bot comment.** The preview comment uses its own marker and updates in place, so it will not spam, but it sits alongside the consolidated `PR Verification Report` comment.
- **Fork safety.** Both workflows re-check that the PR head repo equals the current repo. The check is duplicated deliberately: the comment workflow's check does not protect a direct `workflow_dispatch` or a `workflow_call`, which are separate entry points into the same secrets.
- **`issue_comment` always runs from the default branch**, so this workflow's own behavior can only be changed by merging to `main`. That is the intended property, and it is also why the comment path cannot be tested pre-merge.
- **Comment body is never interpolated into a shell.** The trigger match happens inside `github-script`. Every value that reaches a `run:` block goes through `env:`, including the branch name, so a branch named with backticks or `$(...)` cannot inject.
- **`workflow_call` permissions are inherited from the caller.** A calling workflow that does not grant `issues: write` will still deploy and still return `deployment_url`, but the preview comment step will fail. The declared block covers the dispatch path.
- **The `pull-requests: read` downgrade is unexercised.** I traced every API call in both files and only `pulls.get` is pull-requests-scoped; comments and reactions on a PR are issue-scoped and covered by `issues: write`. If that read of GitHub's scope table is wrong, the symptom is a 403 on the comment or reaction step during the first activation run in the Activation section above, and the fix is one word.

## Declined findings

An adversarial review pass returned three findings. All three were applied; verification for each is in the section above.

1. *Authorization lives only in the script, not the job-level `if:`* (minor). Applied. This was the one that mattered: VRDex is public, so before this any account could start a runner holding a write-scoped `GITHUB_TOKEN` by commenting the trigger string. The script gate did hold, so nothing ever dispatched and no Vercel spend was possible, but one layer is the wrong shape for the only trigger in this repo that anonymous users can reach.
2. *`pull-requests: write` granted but never used* (nit). Applied to both files. `pulls.get` is the only pull-requests-scoped call and it needs `read`.
3. *Failure comments write a dedupe marker but never look it up* (nit). Applied to both files, reusing the marker/find/update block the success path already had.

Declined:

- **The optional `concurrency:` group on the comment workflow**, suggested alongside finding 1 to cap comment spam. Finding 1's own fix moots it: with the association check in the job-level `if:`, an untrusted comment now starts zero jobs, so the only actor who can spam the queue is a collaborator, and the queue job is a five-minute API-only job that dispatches the real work. The deploy workflow already has a per-PR `cancel-in-progress` group, which is where duplicate work would actually cost anything. Not filed as an issue: it is moot rather than deferred.

Two things I chose not to build, so a reviewer does not have to ask:

- **No `git_ref` input.** PerkCord's version accepts an arbitrary branch, tag, or SHA in addition to a PR number. Dropped it: the use case here is previewing a pull request, and the extra input doubles the resolution branching for a path nobody has asked for. Add it when someone needs a preview of a ref with no PR.
- **No target profile input.** PerkCord's `target_profile` selects between two Vercel projects and a Convex checkout-gate configuration. VRDex has one Vercel project, so porting the input would have produced a switch with one case.

