### PR TITLE
Document VRDex personas and jobs to be done

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -63,7 +63,7 @@ Prefer explicit labels in docs:
 
 ## Public product copy rule
 
-- Status: owner-directed proposal. BASIC must approve this exact wording before this change merges.
+- Status: locked decision. BASIC approved this wording on 2026-07-27.
 - Use `VR Johnny` as BASIC's internal tone-risk stress test: a stand-in for one ordinary VR-community user who may reject copy that feels corporate, patronizing, AI-promotional, AI-generated, or slop-like. It is not a demographic category, observed evidence, or a claim that all VR users react alike.
 - Every substantive new word of public-facing product or website prose must be evaluated through the VR Johnny lens.
 - Obvious one- or two-word utility labels and exact strings matching an already-approved pattern may proceed. When in doubt, treat copy as reviewable.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -61,6 +61,20 @@ Prefer explicit labels in docs:
 - Contextual surfaces should appear only when they match the moment. A watch surface belongs to an event that is currently watchable, not every event that happens to have a stream link.
 - Time displays should feel seamless. Public event schedule times should render in the viewer's local timezone across the app, including event cards, event pages, and set times; do not show a separate canonical event-timezone value or a duplicate "Your time" line unless the user explicitly needs timezone-authoring context.
 
+## Public product copy rule
+
+- Status: owner-directed proposal. BASIC must approve this exact wording before this change merges.
+- Use `VR Johnny` as BASIC's internal tone-risk stress test: a stand-in for one ordinary VR-community user who may reject copy that feels corporate, patronizing, AI-promotional, AI-generated, or slop-like. It is not a demographic category, observed evidence, or a claim that all VR users react alike.
+- Every substantive new word of public-facing product or website prose must be evaluated through the VR Johnny lens.
+- Obvious one- or two-word utility labels and exact strings matching an already-approved pattern may proceed. When in doubt, treat copy as reviewable.
+- New taglines, marketing copy, onboarding or help prose, explanatory cards, empty-state prose, profile or media-kit guidance, and other authored sentences require BASIC's review of the exact copy before shipping unless BASIC already approved that exact copy.
+- Do not foreground or mention AI to users without explicit owner direction.
+- Fable and blind review may improve a draft but cannot substitute for BASIC's approval.
+- Preserve existing approved copy unless a task has a concrete reason to change it. Do not invent explanatory prose because a layout has space.
+- This rule applies to public-facing product copy. It does not apply to code, tests, internal engineering prose, accessibility names that must be explicit, or required safety and legal text.
+- A task that changes public prose must show the exact proposed wording in its handoff and identify BASIC's approval before shipping.
+- `VR Johnny` can veto or simplify tone; it cannot be cited as evidence for adding, prioritizing, or designing features.
+
 ## Repo opinionation
 
 - This repo is intentionally opinionated toward software-factory principles and agent-first delivery.

--- a/docs/planning/README.md
+++ b/docs/planning/README.md
@@ -13,6 +13,8 @@ Planning docs capture product, architecture, roadmap, and backlog decisions befo
 - `docs/planning/public-api-and-mcp-platform.md` - executable plan for public API, API tokens, OAuth apps, rate limiting, Swagger/OpenAPI docs, and hosted/private MCP
 - `docs/planning/homepage-discovery-direction.md` - homepage, search/discovery, event-calendar, privacy, personalization, and persona direction
 - `docs/planning/unified-search-views.md` - unified search architecture, typed purpose-specific views, and DJ Lookup compatibility direction
+- `docs/planning/personas.md` - internal behavioral personas, VR Johnny taste lens, evidence limits, and public-copy review contract
+- `docs/planning/jobs-to-be-done.md` - prioritized user goals, journey matrix, product-concept boundaries, and filter/preset decision rules
 - `docs/planning/ui-quality-direction.md` - cross-app UI quality, public profile, auth/account, submission, streaming, and status-surface direction
 - `docs/planning/calendar-integration.md` - Google Calendar import/export/sync direction for event workflows
 - `docs/planning/restreaming-media-control.md` - restreaming, VRCDN-first media control, worker architecture, CDN economics, and Discord operator-control direction

--- a/docs/planning/jobs-to-be-done.md
+++ b/docs/planning/jobs-to-be-done.md
@@ -1,0 +1,423 @@
+# Jobs To Be Done And Product Journeys
+
+## Status
+
+Current recommendation for near-term product prioritization and journey design.
+
+This document is intentionally separate from
+`docs/planning/personas.md`. A job to be done is a concrete goal in a session.
+It is not a stable identity, role, persona, or demographic segment.
+
+## Prioritized Jobs
+
+### J1. Find a known person or community and judge the result
+
+When I already know who I need, help me find the canonical record, useful
+links, and trust context quickly so I can act without searching across Discord
+and link pages.
+
+Current recommended journey:
+
+1. Enter an exact name, alias, or handle.
+2. See one canonical person or community result with a useful sparse fallback.
+3. Show claim/control verification, fact provenance, freshness, and public
+   surfacing as separate dimensions.
+4. Open the canonical profile or a contextual claim path.
+
+Primary surfaces: Search, DJ view, public profiles, Claim.
+
+### J2. Assemble a reusable lineup or identity packet
+
+When I am coordinating a lineup, booking, promotion, or event, help me combine
+canonical links, genres, and logos with event-scoped stream and schedule facts
+without re-entering the same data or storing temporary event facts on a
+profile.
+
+Current recommended journey:
+
+1. Paste or search one or more names.
+2. Resolve canonical profiles and flag uncertain or missing matches.
+3. In DJ view, foreground public genres and music, stream, and contact links
+   without changing identity semantics. `DJ` describes the profiles shown; it
+   does not classify the person using the view.
+4. Join public, reusable profile assets and links with the current event or
+   slot facts in an export packet.
+5. Preserve missing and imported provenance instead of filling gaps.
+
+Primary surfaces: DJ view, bulk lookup, Media Kit, event slots and exports.
+
+### J3. Claim, correct, and control a representation
+
+When a profile represents me or my community, help me prove appropriate
+control, review what came from others, and decide what is public.
+
+Current recommended journey:
+
+1. Start from the exact profile rather than choosing person/community again.
+2. Sign in and verify email.
+3. Use a verification method appropriate to a person or community.
+4. Resolve success, pending, conflict, recovery, correction, or opt-out.
+5. Continue to profile editing, visibility, or media-kit management.
+
+Primary surfaces: Claim, handoff, Account, profile editor, privacy controls.
+
+Community claimant eligibility, authority evidence, conflicts, recovery, and
+singleton-owner precedence remain claim-domain rules. Staff tags alone never
+grant claim authority.
+
+### J4. Publish and maintain a canonical person or community page
+
+When I own a profile, help me keep a trustworthy, expressive page that other
+people and workflows can reuse.
+
+Current recommended journey:
+
+1. Confirm identity facts, role descriptions, links, and source state.
+2. Add or manage public media with accessible descriptions.
+3. Choose field visibility and public surfacing.
+4. Preview public presentation and compact search/event presentation.
+5. Update facts as roles, links, or staff change.
+
+Primary surfaces: onboarding, Account, profile editing, Media Kit, public
+profile.
+
+### J5. Publish or coordinate an event and its contributions
+
+When I operate an event, help me connect a community, world, schedule, people,
+and contribution slots so the same facts can power public pages and exports.
+
+Current recommended journey:
+
+1. Create, import, or review an event.
+2. Associate broad participants separately from timed contribution slots.
+3. Record a scoped role, confirmation state, and source for each slot.
+4. Reuse canonical profiles, links, and media.
+5. Publish event, Discord, calendar, and watch outputs as appropriate.
+
+Primary surfaces: community and event tools, slots, Discord/calendar exports,
+public event pages.
+
+### J6. Discover what is happening now or soon
+
+When I do not have a specific name, help me understand what is happening in my
+local time and move from an event to its people, community, world, or watch
+path.
+
+Current limitation:
+
+- The direction is established, but content density and ranking evidence are
+  not yet strong enough to make broad discovery the root experience.
+
+Primary surfaces: `/discovery`, event schedule, event/community/world pages.
+
+### J7. Submit or correct somebody else's record safely
+
+When I have public facts I am allowed to share, help me submit or stage them
+without presenting them as owner-confirmed.
+
+Current recommended journey:
+
+1. Authenticate and select a person or community record.
+2. Submit only allowed public fields from a source whose use VRDex is
+   authorized to review.
+3. Review and match against existing, opted-out, or suppressed identities.
+4. Keep imported candidates private until explicit review permits publication.
+5. Provide claim, correction, merge, and opt-out paths.
+
+Primary surfaces: community submission, reviewed imports, concierge handoff,
+moderation.
+
+The detailed safety contract remains in
+`docs/planning/seed-import-model.md`: prohibited private contacts, raw provider
+identifiers, private notes, and unreviewed assertions never become public.
+Internal review evidence, public source category, submitter identity, and the
+owner-visible audit trail require separate visibility rules. Publication also
+needs bounded writes, duplicate/impersonation checks, reporting, appeal, and
+emergency suppression.
+
+### J8. Stop a harmful or unauthorized representation
+
+When a record, asset, association, or public fact is invasive, false, or
+unauthorized, help me report it and get urgent harm contained without forcing
+me to prove ownership first.
+
+Current recommended journey:
+
+1. Report from the affected surface or a direct support entry.
+2. Identify the exact record, field, asset, or association without collecting
+   more sensitive data than the report requires.
+3. Apply emergency suppression when the risk threshold is met.
+4. Show bounded status and a path to add evidence, appeal, or resolve a
+   dispute.
+5. Preserve private audit evidence while keeping the harmful fact out of public
+   surfaces and exports.
+
+Primary surfaces: report/correction entry, moderation, suppression, claim and
+ownership disputes.
+
+This is a safety-critical journey, not evidence that harm reports are a common
+market segment.
+
+## Cross-Persona Journey Matrix
+
+Personas are defined in `docs/planning/personas.md`.
+
+The cells below are unvalidated review prompts, not audience assignments or
+feature priorities.
+
+| Job | Utility-first user | Representation-conscious user | Privacy-conscious user | Evidence-sensitive user |
+| --- | --- | --- | --- | --- |
+| J1 direct lookup | Speed and density | Sees how identity renders | Requires suppression everywhere | Provenance and confidence |
+| J2 reusable packet | No re-entry | Supplies approved assets | Controls public contact/media | Needs current, attributable facts |
+| J3 claim/control | Wants low ceremony | Needs meaningful ownership | Needs correction and opt-out | Needs honest verification meaning |
+| J4 maintain page | Values reusable output | Wants voice and polish | Visibility and deletion | Reads owner-confirmed state |
+| J5 coordinate event | Structured reuse | Controls contribution display | No inferred attendance | Scoped role/source facts |
+| J6 discover soon | Wants local-time utility | Wants contextual exposure | Rejects creepy personalization | Needs honest ranking labels |
+| J7 seed/correct | Efficient reviewed input | Must retain final authority | Faces risk from bad submissions | Uses source/review labels |
+| J8 stop harm | Direct bounded reporting | Representation can be corrected | Urgent containment without ownership | Sees clear disposition |
+
+## Concept Boundaries
+
+| Concept | Product treatment | Must not become |
+| --- | --- | --- |
+| Human or community identity | First-class `person` or `community` profile, independent of the account that may claim it | Persona, role, or account type |
+| Research persona | Internal behavioral/taste hypothesis | Public segment, filter, analytics property, or feature requirement |
+| Session intent / JTBD | Route, entry point, workflow, or typed preset | Permanent user classification |
+| Person role | Owner-authored and visibility-controlled dynamic `person_role` vocabulary such as DJ, VJ, performer, organizer, photographer, or world creator | Verified credential, permission, or availability claim |
+| Community category/subtype | Dynamic vocabulary such as venue, collective, promoter, or agency | Giant hard-coded taxonomy |
+| Community staff role | Small role/capability authorization model with singleton owner | Public identity tag |
+| Event participant association | Broad scoped connection between an entity and event; role and time are not required | Attendance or performance claim |
+| Event contribution slot | Scoped record with role, time, source, and confirmation | Permanent profile role |
+| Genre or self-expression tag | Dynamic public vocabulary with provenance and visibility | Eligibility fact |
+| Availability or bookability | Remain out of schema until a real workflow defines owner, scope, validity window, visibility, and stale-state behavior | Inference from role, links, or recent events |
+| Verification | Identity/control and provenance state; potentially field-level later | Blanket proof that every profile fact or role is true |
+| Presentation view | Built-in display or search view over the same canonical records | Duplicate data model or separate product silo |
+
+Locked decision:
+
+- A person can hold several roles, change roles, stop offering a service, join
+  community staff, or attend an event without changing identity.
+- `DJ`, `VJ`, `performer`, `organizer`, `venue`, `promoter`, `photographer`,
+  `world creator`, `staff`, and `attendee` must not all share one field:
+  some describe people, some communities, some permissions, and some scoped
+  event participation.
+- Self-attestation and reviewed/imported provenance may be useful public facts,
+  but neither is role verification.
+
+## Surface Implications
+
+### Search And DJ Links
+
+Current recommendation:
+
+- Use one search architecture with typed, closed state.
+- Ship two built-in presentation views: `standard` and `dj`.
+- Keep `view=dj` person-only and foreground visible genres plus music, stream,
+  and contact links, but do not make a DJ role tag an index-enforced
+  eligibility rule yet.
+- Preserve exact-name matches and useful sparse/imported fallbacks.
+- Show profile/source trust consistently across standard and DJ presentation.
+- Keep bulk pasted lineups session-local; do not place them in public URLs or
+  analytics.
+- Do not add a public search DSL, user-authored view definitions, or a second
+  DJ-specific result store.
+
+### Claim
+
+Current recommendation:
+
+- Claim starts from a specific profile; the record already determines person
+  versus community.
+- Keep login, email verification, claim authority, identity verification, fact
+  provenance, visibility, publication, suppression, and freshness separate.
+- Search may provide a narrow contextual claim entry but must not own claim
+  state or verification behavior.
+- Sparse/imported profiles need claim, correction, dispute, merge, and opt-out
+  paths before broad publication becomes a growth tactic.
+
+### Media Kit
+
+Current recommendation:
+
+- People and communities share one media-asset system.
+- Media supports J2 and J4: owner management, reusable public assets, ordering,
+  featured presentation, downloads, and accessibility metadata.
+- Compact search cards consume a stable identity/media projection rather than
+  the whole gallery.
+- Imported or community-provided assets retain provenance and never imply
+  owner approval.
+- Uploaders must assert authority to share an asset; source/right provenance,
+  subject reporting, and takedown remain required even while full licensing
+  workflow stays deferred.
+- Do not expand into video/audio, bulk DAM, complex collaboration, licensing,
+  or AI-authored metadata without a separate proven job.
+
+### Onboarding And Profile Editing
+
+Current recommendation:
+
+- Organize entry and progress around a selected job, not a persona quiz.
+- Do not ask users to select one permanent role during onboarding.
+- Let owners describe several public roles and change them over time.
+- Keep availability absent until there is a concrete owner-authored workflow.
+- Treat profile completeness as contextual: a DJ packet, community page, or
+  event contribution may require different fields.
+- Do not invent explanatory prose to make an unfinished flow feel complete;
+  follow the public-copy rule in `docs/planning/personas.md`.
+
+### Trust, Abuse, And Spam
+
+Current recommendation:
+
+- Enforce suppression and field visibility before indexing, filtering,
+  rendering, exporting, or associating profiles.
+- Keep source and review state for imported, community-submitted, concierge,
+  moderator, and owner-authored facts.
+- Do not infer a role from outbound links, event names, posters, media, or
+  group membership.
+- Treat vocabulary spam and alias merging as moderation work before exposing
+  arbitrary user-created terms as global filters.
+- Treat impersonation, doxxing, harassment, malicious provenance, duplicate
+  claims, and coordinated submissions as abuse cases, not taxonomy quality.
+- Missing or stale data must remain missing or stale; do not synthesize a
+  reassuring value.
+
+### International And Accessibility
+
+Current recommendation:
+
+- Render event and slot times in the viewer's local timezone.
+- Preserve Unicode names and reviewed aliases; do not silently translate,
+  anglicize, or merge role/category terms.
+- Do not offer language, region, or timezone filters until data is normalized,
+  owner-controlled, sufficiently dense, and privacy-reviewed.
+- Search, filter, claim, and media flows must remain keyboard and screen-reader
+  usable; trust state cannot depend on color or iconography alone.
+- Public media needs meaningful alternatives where the media conveys content.
+- Short public copy still must be explicit enough for accessibility names and
+  error recovery.
+- Review zoom and reflow, focus order, reduced motion, touch targets,
+  accessible live status/error announcements, locale formatting, daylight
+  saving transitions, right-to-left layouts, and cross-language aliases before
+  claiming international or accessibility readiness.
+
+## Filter And Preset Recommendations
+
+### Justified now
+
+| Control | Recommendation | Reason |
+| --- | --- | --- |
+| Query | Ship | Direct lookup is the current root job |
+| Entity type | Ship `all`, `person`, `community`, `world`, `event` in standard search | First-class schema distinction with backend filtering |
+| Standard view | Ship | Generic identity/entity lookup |
+| DJ view | Ship as a typed person presentation preset | Repo-evidenced operator job without claiming strict DJ eligibility |
+| Trust/source presentation | Show and use cautiously in ranking; do not default to a filter | Users need context, while a filter could hide useful sparse records |
+| Event time presets | Use on event/discovery surfaces when data exists | Serves now/soon discovery without becoming a profile identity facet |
+
+### Justified after evidence
+
+| Control | Evidence gate |
+| --- | --- |
+| Role filters such as DJ, VJ, photographer | Normalized aliases, provenance policy, abuse handling, sufficient public density, and an owner decision about inclusion semantics |
+| Genre facets | Sufficient normalized public coverage and evidence that users narrow rather than merely read genres |
+| Community subtype/category | Real distribution across non-club communities and reviewed vocabulary |
+| Region/timezone | Normalized owner-authored data, privacy review, international semantics, and sufficient density |
+| Availability/bookability | A concrete workflow defining scope, validity window, staleness, visibility, and owner authority |
+| Language/locale | Localization strategy and owner-authored data; never inferred |
+| Saved/personal views | Repeated behavior and a privacy model for saved intent |
+| Stored declarative presets | At least three materially different proven built-in views or a real no-deploy moderation need |
+
+### Not justified
+
+- public or executable search DSL
+- persona filters
+- demographic or sensitive-attribute inference
+- role inference from links, event history, or media
+- attendance, private presence, or friend-context filters without explicit
+  consent and a dedicated privacy review
+- popularity, trending, or paid ranking without safe documented data and
+  labeling policy
+
+## Filter Decision Rule
+
+A new public filter or preset may be proposed only when all of these are true:
+
+1. A named current JTBD requires narrowing or presentation that ordinary query
+   and entity type cannot provide.
+2. The underlying field has sufficient public data density in the complete
+   corpus, not only a fixture or first result page.
+3. The field has defined owner, source, visibility, suppression, moderation,
+   and stale-state semantics.
+4. Multi-role people and people changing roles do not become misclassified.
+5. The label works for international and accessible use without implying
+   verification, eligibility, popularity, or availability.
+6. The expected success signal and privacy-safe telemetry are defined.
+7. The same goal cannot be met more safely by a presentation preset, contextual
+   entry point, or result-card field.
+8. A named decision owner records the measured corpus denominator, coverage and
+   error thresholds, abuse sample, and evaluation window.
+
+If any condition fails, keep the concept as display metadata, a dynamic tag, a
+private operator tool, or an interview question rather than adding a filter.
+
+## Analytics Implications
+
+Repository evidence:
+
+- Existing analytics are deliberately sparse and avoid raw search terms,
+  profile slugs, private fields, and raw account identifiers.
+
+Current recommendation:
+
+- Do not assign persona labels to users in PostHog.
+- Measure journeys and outcomes, not inferred identities.
+- Preserve current search/claim event boundaries and add only events needed to
+  answer a named decision.
+- Candidate next signals are lookup-to-useful-result, bulk-lookup completion,
+  seed/handoff-to-claim conversion, and media-kit management completion.
+- Event names should record surface, view, entity type, bounded outcome, and
+  source category only when privacy-safe; never raw content or sensitive
+  attributes.
+- Analytics absence must remain `unknown`, not evidence that a job or filter is
+  unwanted.
+
+## Out Of Scope
+
+- a full booking marketplace that replaces specialized booking systems
+- a free-edit wiki for rich biographies about other people
+- a growth-marketing directory driven by opaque recommendations, trending
+  claims, or paid ranking
+- a rigid professional credential directory where self-expression roles imply
+  qualification
+- a universal social feed
+
+DJ workflows remain in scope when they solve the current operator job, but
+must use the shared identity model without losing their operator value.
+
+## Threat Actors And Abuse Cases
+
+- data-harvesting clients seeking private presence, attendance, membership, or
+  sensitive traits
+- impersonators or hostile submitters creating false, duplicate, or invasive
+  records
+- coordinated vocabulary, alias, review, report, or claim abuse
+- malicious sources attempting to launder private or false data through
+  provenance labels
+
+These are adversaries the privacy, moderation, authorization, and rate-limit
+systems must resist, not users whose feature requests are merely out of scope.
+
+## Open Owner Decisions
+
+- When, if ever, should role assertions gain field-level attestation?
+- What provenance states may qualify for strict role filtering?
+- Which role aliases should be reviewed and normalized first?
+- What real data density is enough to add genre or community-category facets?
+- Does owner-authored availability belong in VRDex core or an integration?
+- Which event/discovery time presets fit international users and current data?
+- Should approved public copy eventually have a lightweight inventory, or is
+  exact approval evidence in each task handoff sufficient?
+- When should localization move from preservation of names/local time into
+  translated product UI?
+- Should the DJ preset remain person-only, and how should duos, collectives, or
+  community-operated acts appear without creating a second identity model?

--- a/docs/planning/personas.md
+++ b/docs/planning/personas.md
@@ -1,0 +1,240 @@
+# Product Personas And Taste Lenses
+
+## Status
+
+Current recommendation. Personas describe expected tastes, trust needs, and
+reactions; jobs to be done describe session goals and journeys. Neither is a
+feature requirement, public label, search facet, or schema field. Jobs are
+documented separately in `docs/planning/jobs-to-be-done.md`.
+
+## Evidence Labels
+
+- `Repository evidence`: verified in the repository, current product surface, or
+  an adjacent active task.
+- `Fable judgment`: product or taste judgment from the isolated Fable 5 review.
+- `Assumption`: a useful hypothesis that still needs interviews or analytics.
+- `Open owner decision`: a choice BASIC has not locked.
+
+## Evidence And Limitations
+
+Repository evidence:
+
+- VRDex covers identity, profiles, events, and scene operations. Near term, it
+  helps operators reuse approved links, assets, genres, set times, and
+  publishing materials
+  (`docs/planning/product-direction.md`).
+- People and communities are first-class profile entities. Profile identity,
+  account ownership, claim state, publication state, provenance, and field
+  visibility are already separate concepts
+  (`docs/backend/profile-schema.md`).
+- Current surfaces include direct search and DJ Lookup, public person and
+  community profiles, claim/linking, event and world pages, reviewed seed
+  imports, and early media-kit support.
+- The active Unified Search task treats DJ Lookup as a typed presentation
+  preset over one search system. It does not treat `DJ` as a verified
+  credential or strict eligibility fact.
+- The active Media Kit task is building owner management over existing
+  file-backed profile assets without changing search's identity projection.
+- Current analytics cover bounded search, lookup, discovery, claim, and
+  temporal-service events. They do not establish persona prevalence or user
+  motivations (`docs/agentic/product-analytics-and-feature-flags.md`).
+
+Limitations:
+
+- No user interviews, demographic study, persona survey, or persona-level
+  behavioral analysis was available.
+- Maintainer-authored archetypes and product choices are directional evidence,
+  not proof that real users fit a segment.
+- No synthetic analytics or user quotes were created for this work.
+- Accessibility and international needs are derived from general product
+  obligations, viewer-local time behavior, and known schema/UI constraints;
+  they are not backed by a dedicated VRDex accessibility or localization
+  study.
+- The isolated Fable 5 pass was read-only and used repository evidence. Its
+  conclusions are judgments, not observed user research.
+
+## Independent Fable Pass
+
+Audit record:
+
+- session: `f081c00b-ff47-41fe-b456-ed7ce25c3992`
+- requested and returned model: `claude-fable-5`
+- repository access: read-only `Read`, `Glob`, and `Grep` in plan mode, with no
+  settings sources or MCP servers
+- synthesis and VR Johnny review: same isolated session with tools disabled
+- context prompt SHA-256:
+  `d62c3708b093eb6bcdd7669bc631675dbdb0cb8b346833240f343de66066a40b`
+- synthesis prompt SHA-256:
+  `eecc7f5116a0dc608360dd16c866371ea1d7c649186afb0c1959535925d9355a`
+
+## Provisional Behavioral Lenses
+
+These personas are deliberately role-agnostic. The same person may be a DJ,
+organizer, attendee, community staff member, and photographer at different
+times without becoming a different identity or persona. They are unordered
+research lenses until interviews or analytics justify prevalence or priority.
+
+### 1. Utility-First User
+
+`Assumption`
+
+Values direct utility, compact facts, task-familiar language validated across
+relevant communities and locales, and outputs that save a concrete step.
+Tolerates dense operator surfaces when density is useful. Reacts poorly to
+generic marketing, repeated data entry, ceremonial onboarding, and
+explanations that delay the task.
+
+Likely trust tests:
+
+- notices whether links and assets are current, attributable, and easy to reuse
+- tests lookup with stable names and sparse profiles
+- reacts when profile-provided, imported, and verified facts look equivalent
+
+Likely reactions:
+
+- positive when VRDex behaves like a dependable scene utility
+- negative when it behaves like a corporate landing page or forces every job
+  through one generic dashboard
+
+### 2. Representation-Conscious User
+
+`Assumption`
+
+Pays close attention to how a person or community is represented, whether
+viewing their own record or helping maintain a community record. Values
+tasteful control over public identity, links, media, visibility, and
+presentation. Reacts poorly to ugly defaults, lost attribution, content that
+speaks in somebody's voice without consent, or a claim flow that does not lead
+to meaningful control.
+
+Likely trust tests:
+
+- notices when ownership and verification are conflated
+- expects imported or community-submitted facts to remain reviewable
+- checks whether visibility controls survive every surface
+- rejects media-kit presentation that is either generic or a raw page builder
+
+### 3. Privacy-Conscious User
+
+`Repository evidence` supports the concern; the persona framing remains an
+`Assumption`.
+
+Evaluates VRDex first as a possible listing, tracking, ranking, or inference
+surface. May value a profile while rejecting broad discovery, contact
+exposure, public attendance claims, inferred presence, or opaque
+personalization.
+
+Likely trust tests:
+
+- checks whether opt-out and suppression propagate across connected surfaces
+- looks for source and visibility boundaries around public facts
+- expects private signals to stay private by default
+- tests whether correction, dispute, claim, and deletion paths are real
+
+Likely reactions:
+
+- one privacy leak across connected surfaces can outweigh many assurances
+- effective controls and restrained labels build more trust than reassurance
+  copy
+
+### 4. Evidence-Sensitive User
+
+`Assumption`
+
+Notices provenance, claim/control state, freshness, and gaps across many jobs.
+Reacts poorly when sparse imported profiles look as authoritative as claimed
+rich profiles or when self-expression is presented as verified eligibility.
+
+Likely trust tests:
+
+- distinguishes claim/control, fact source and attestation, public visibility,
+  and freshness without treating them as one status
+- notices when role tags imply authorization, qualification, or availability
+- distrusts inferred values that fill missing data
+
+## Taste Lens: VR Johnny
+
+`Owner-directed proposal; BASIC must approve this exact wording before this
+change merges`.
+
+VR Johnny is BASIC's owner-authored tone-risk stress test: a stand-in for one
+ordinary VR-community user who may reject copy that feels corporate,
+patronizing, AI-promotional, AI-generated, or slop-like. It is not a
+demographic category, a claim about all VR users, or observed evidence. The
+owner-provided name does not encode gender, a cultural majority, or one
+preferred VR subculture.
+
+Use VR Johnny only as a product-copy and design-taste stress test:
+
+- ask whether new public prose sounds direct, human, and appropriate to the
+  surface without assuming one scene dialect
+- remove, shorten, or plain-speak prose that sounds promotional, patronizing,
+  synthetic, or written merely to fill space
+- prefer useful data, direct labels, and owner/community content
+- never cite VR Johnny as evidence for adding, prioritizing, or designing a
+  feature
+- never turn VR Johnny into a public label, segment, filter, analytics
+  property, or schema field
+
+`Fable judgment`: treat VR Johnny as a veto lens, not a behavioral segment,
+median user, or source of evidence.
+
+## Public Product Copy Rule
+
+`Owner-directed proposal; BASIC must approve this exact wording before this
+change merges`.
+
+The canonical operational copy is in `AGENTS.md`. It is repeated here so the
+persona artifact remains self-contained; update both copies together.
+
+- Every substantive new word of public-facing product or website prose must be
+  evaluated through the VR Johnny lens.
+- Obvious one- or two-word utility labels and exact strings matching an
+  already-approved pattern may proceed. When in doubt, treat copy as
+  reviewable.
+- New taglines, marketing copy, onboarding or help prose, explanatory cards,
+  empty-state prose, profile or media-kit guidance, and other authored
+  sentences require BASIC's review of the exact copy before shipping unless
+  BASIC already approved that exact copy.
+- Do not foreground or mention AI to users without explicit owner direction.
+- Fable and blind review may improve a draft but cannot substitute for BASIC's
+  approval.
+- Preserve existing approved copy unless a task has a concrete reason to
+  change it. Do not invent explanatory prose because a layout has space.
+- This rule applies to public-facing product copy. It does not apply to code,
+  tests, internal engineering prose, accessibility names that must be
+  explicit, or required safety and legal text.
+- A task that changes public prose must show the exact proposed wording in its
+  handoff and identify BASIC's approval before shipping.
+
+This rule does not authorize silent changes to existing public copy.
+
+## Cross-Persona Needs And Failure Modes
+
+These cells are unvalidated reaction prompts. System invariants such as
+suppression, visibility, accessibility, and provenance apply to everybody;
+their placement in one column never makes them persona-specific.
+
+| Need | Utility-first user | Representation-conscious user | Privacy-conscious user | Evidence-sensitive user | Common failure |
+| --- | --- | --- | --- | --- | --- |
+| Direct identity lookup | Speed and dense useful facts | Canonical self-presentation | No hidden resurfacing | Provenance and gaps | A generic or stale result looks authoritative |
+| Sparse/imported profiles | Useful minimal fallback | Clear path to claim and correct | Publication restraint and opt-out | Import source is visible | Seeded graveyard of thin, unclaimed profiles |
+| Claimed rich profiles | Reusable links and assets | Control and polish | Field visibility | Owner-confirmed facts | Claim appears to verify every field |
+| People and communities | Familiar task language | Appropriate owner controls | Same privacy guarantees | Clear entity type | Community staff roles are mistaken for identity tags |
+| Multi-role lives | One identity reused across work | Owner-editable expression | No inferred role history | Scoped role provenance | One role becomes a permanent account class |
+| International use | Local time and portable output | Local language and names survive | Region is not overexposed | Time and source are legible | Freeform region becomes a proxy for sensitive traits |
+| Accessibility | Keyboard-efficient workflows | Meaningful media descriptions | No privacy loss through alternatives | Trust state is not color-only | Sparse or decorative media has unusable alternatives |
+
+## Interview Targets
+
+Interview later:
+
+- operators who currently assemble lineups, links, assets, and timestamps
+- owners of claimed profiles and recipients of concierge/handoff profiles
+- people or communities who were listed by somebody else
+- users who rejected or abandoned comparable community tools because of tone,
+  privacy, or trust
+- non-club communities to test whether current personas generalize beyond the
+  DJ/event wedge
+- international and disabled users before adding location, language, media,
+  or interaction assumptions

--- a/docs/planning/personas.md
+++ b/docs/planning/personas.md
@@ -154,8 +154,7 @@ Likely trust tests:
 
 ## Taste Lens: VR Johnny
 
-`Owner-directed proposal; BASIC must approve this exact wording before this
-change merges`.
+`Locked decision; BASIC approved this wording on 2026-07-27`.
 
 VR Johnny is BASIC's owner-authored tone-risk stress test: a stand-in for one
 ordinary VR-community user who may reject copy that feels corporate,
@@ -181,8 +180,7 @@ median user, or source of evidence.
 
 ## Public Product Copy Rule
 
-`Owner-directed proposal; BASIC must approve this exact wording before this
-change merges`.
+`Locked decision; BASIC approved this wording on 2026-07-27`.
 
 The canonical operational copy is in `AGENTS.md`. It is repeated here so the
 persona artifact remains self-contained; update both copies together.


### PR DESCRIPTION
## Summary

- add separate durable persona and Jobs To Be Done references
- define VR Johnny as an internal taste and anti-slop stress test, not a demographic segment or feature-requirements persona
- document cross-persona journeys, trust and abuse concerns, product-concept boundaries, and evidence labels
- recommend which Search and DJ views or filters are justified now, later, or not by current evidence
- add the approved public product-copy rule to the agent-facing repository guidance

## Why

VRDex needs a stable contract that separates human identity, roles, session intent, eligibility, self-expression, personas, and concrete user jobs. Without that boundary, future teams could turn speculative archetypes into schema fields or filters and conflate profile control with trust or verification.

The references incorporate current Search, Claim, and Media Kit direction while leaving those implementations unchanged. They explicitly cover sparse and claimed profiles, people and communities, multi-role users, role changes, self-attestation, verification, abuse, accessibility, and international use.

## Impact

This is a documentation and agent-guidance change only. It does not add product features, mutate production data, or publish new site copy. BASIC approved the public-copy contract wording on 2026-07-27.

## Validation

- `pnpm lint:markdown`
- `pnpm build:docs`
- `git diff --check`
- isolated read-only Fable 5 product/taste review
- independent slop and stereotype review