### PR TITLE
Allow profile asset CORS and lifecycle applies

### DIFF
--- a/infra/terraform/state-mgmt/main.tf
+++ b/infra/terraform/state-mgmt/main.tf
@@ -256,16 +256,20 @@ data "aws_iam_policy_document" "github_actions_terraform" {
       "s3:GetLifecycleConfiguration",
       "s3:GetReplicationConfiguration",
       "s3:ListBucket",
+      "s3:PutBucketCORS",
       "s3:PutBucketPolicy",
       "s3:PutBucketTagging",
       "s3:PutBucketPublicAccessBlock",
       "s3:PutBucketOwnershipControls",
       "s3:PutEncryptionConfiguration",
+      "s3:PutLifecycleConfiguration",
+      "s3:DeleteBucketCORS",
       "s3:DeleteBucketPolicy",
       "s3:DeleteBucketTagging",
       "s3:DeleteBucketPublicAccessBlock",
       "s3:DeleteBucketOwnershipControls",
       "s3:DeleteBucketEncryption",
+      "s3:DeleteLifecycleConfiguration",
     ]
 
     resources = [local.profile_asset_bucket_arn]


### PR DESCRIPTION
[AGENT]

## Summary

- allow the Terraform CI bootstrap role to write and remove the profile-assets bucket CORS configuration
- allow the same role to write and remove the quarantine lifecycle configuration

## Production evidence

The automatic profile-assets apply after #214 failed with explicit `s3:PutBucketCORS` and `s3:PutLifecycleConfiguration` authorization errors. A local bootstrap plan against the existing state showed exactly one in-place IAM policy update, with no additions or deletions, and that policy update was applied successfully. The checked-in profile-assets workflow was then rerun against merged main.

## Verification

- `terraform -chdir=infra/terraform/state-mgmt fmt -check`
- `terraform -chdir=infra/terraform/state-mgmt validate`
- `terraform -chdir=infra/terraform/profile-assets validate`
- bootstrap plan: 0 add, 1 in-place change, 0 destroy
