### PR TITLE
Manage the Clerk production DNS records as code

### DIFF
--- a/infra/terraform/web-domains/main.tf
+++ b/infra/terraform/web-domains/main.tf
@@ -41,3 +41,48 @@ resource "aws_route53_record" "production_www" {
   ttl     = var.web_dns_record_ttl
   records = [var.vercel_a_record_value]
 }
+
+# Clerk production instance records. Gated on `manage_clerk_dns` so the stack
+# stays appliable before the Clerk production instance exists, and so a partial
+# set is never created — Clerk issues no certificate until all five resolve.
+locals {
+  clerk_records = var.manage_clerk_dns ? {
+    frontend_api = {
+      name   = var.clerk_frontend_api_subdomain
+      target = "frontend-api.clerk.services"
+    }
+    accounts = {
+      name   = var.clerk_accounts_subdomain
+      target = "accounts.clerk.services"
+    }
+    mail = {
+      name   = var.clerk_mail_subdomain
+      target = var.clerk_mail_target
+    }
+    dkim1 = {
+      name   = "clk._domainkey"
+      target = var.clerk_dkim1_target
+    }
+    dkim2 = {
+      name   = "clk2._domainkey"
+      target = var.clerk_dkim2_target
+    }
+  } : {}
+}
+
+resource "aws_route53_record" "clerk" {
+  for_each = local.clerk_records
+
+  zone_id = local.route53_zone_id
+  name    = "${each.value.name}.${var.hosted_zone_name}"
+  type    = "CNAME"
+  ttl     = var.web_dns_record_ttl
+  records = [each.value.target]
+
+  lifecycle {
+    precondition {
+      condition     = each.value.target != null
+      error_message = "manage_clerk_dns is true but the ${each.key} target is unset. Clerk issues these per instance; copy them from Configure > Domains."
+    }
+  }
+}

--- a/infra/terraform/web-domains/variables.tf
+++ b/infra/terraform/web-domains/variables.tf
@@ -66,11 +66,17 @@ variable "tags" {
 #
 # The mail records are Clerk's own sender identity, unrelated to the SES stack:
 # SES is retired for authentication, and Clerk sends its verification mail.
+#
+# Every value here is a checked-in default rather than a `terraform.tfvars`
+# entry, because tfvars is gitignored and CI has none. Gating these behind an
+# operator-supplied variable meant only an out-of-band apply could create them —
+# and this stack applies from main, so the next CI run destroyed them as
+# orphaned state. They are public DNS records, not secrets; anyone can dig them.
 
 variable "manage_clerk_dns" {
-  description = "Create the Clerk production CNAME records. Leave false until the Clerk production instance exists."
+  description = "Create the Clerk production CNAME records."
   type        = bool
-  default     = false
+  default     = true
 }
 
 variable "clerk_frontend_api_subdomain" {
@@ -92,19 +98,19 @@ variable "clerk_mail_subdomain" {
 }
 
 variable "clerk_mail_target" {
-  description = "Clerk-issued mail CNAME target, e.g. mail.<id>.clerk.services. Instance-specific."
+  description = "Clerk-issued mail CNAME target. Instance-specific but not secret: it is a public DNS record."
   type        = string
-  default     = null
+  default     = "mail.49kratywlj1f.clerk.services"
 }
 
 variable "clerk_dkim1_target" {
-  description = "Clerk-issued DKIM CNAME target for clk._domainkey, e.g. dkim1.<id>.clerk.services."
+  description = "Clerk-issued DKIM CNAME target for clk._domainkey."
   type        = string
-  default     = null
+  default     = "dkim1.49kratywlj1f.clerk.services"
 }
 
 variable "clerk_dkim2_target" {
-  description = "Clerk-issued DKIM CNAME target for clk2._domainkey, e.g. dkim2.<id>.clerk.services."
+  description = "Clerk-issued DKIM CNAME target for clk2._domainkey."
   type        = string
-  default     = null
+  default     = "dkim2.49kratywlj1f.clerk.services"
 }

--- a/infra/terraform/web-domains/variables.tf
+++ b/infra/terraform/web-domains/variables.tf
@@ -57,3 +57,54 @@ variable "tags" {
   type        = map(string)
   default     = {}
 }
+
+# Clerk production instance DNS. Clerk issues the Frontend API and Account
+# Portal certificates only once all five records resolve, and
+# `CLERK_JWT_ISSUER_DOMAIN` on the Convex production deployment must be
+# `https://${clerk_frontend_api_subdomain}.${hosted_zone_name}` — the same host
+# the production publishable key encodes.
+#
+# The mail records are Clerk's own sender identity, unrelated to the SES stack:
+# SES is retired for authentication, and Clerk sends its verification mail.
+
+variable "manage_clerk_dns" {
+  description = "Create the Clerk production CNAME records. Leave false until the Clerk production instance exists."
+  type        = bool
+  default     = false
+}
+
+variable "clerk_frontend_api_subdomain" {
+  description = "Subdomain for the Clerk Frontend API. Must match the host encoded in the production publishable key."
+  type        = string
+  default     = "clerk"
+}
+
+variable "clerk_accounts_subdomain" {
+  description = "Subdomain for the Clerk Account Portal."
+  type        = string
+  default     = "accounts"
+}
+
+variable "clerk_mail_subdomain" {
+  description = "Subdomain Clerk sends authentication email from."
+  type        = string
+  default     = "clkmail"
+}
+
+variable "clerk_mail_target" {
+  description = "Clerk-issued mail CNAME target, e.g. mail.<id>.clerk.services. Instance-specific."
+  type        = string
+  default     = null
+}
+
+variable "clerk_dkim1_target" {
+  description = "Clerk-issued DKIM CNAME target for clk._domainkey, e.g. dkim1.<id>.clerk.services."
+  type        = string
+  default     = null
+}
+
+variable "clerk_dkim2_target" {
+  description = "Clerk-issued DKIM CNAME target for clk2._domainkey, e.g. dkim2.<id>.clerk.services."
+  type        = string
+  default     = null
+}


### PR DESCRIPTION
Adds the five Clerk production CNAMEs to the Route 53 stack that already owns `vrdex.net`, so the Clerk production instance can finish deploying.

`CLERK_JWT_ISSUER_DOMAIN` is `https://clerk.vrdex.net`, confirmed by decoding the production publishable key rather than assuming the subdomain. It is already set on Convex production, and `Deploy Convex Production` is green.

## Why this needs to merge before the records exist

I applied the first commit from this branch. It worked — and two minutes later the merge-triggered Terraform workflow ran on `main`, whose config has no Clerk resources, found five orphaned entries in the shared S3 state, and destroyed them:

```
Plan: 0 to add, 0 to change, 5 to destroy
```

The second commit fixes the underlying flaw. The record targets were in `terraform.tfvars`, which is gitignored, so CI could never supply them and `manage_clerk_dns` would always default false on `main`. That made an out-of-band apply the only way to create the records and guaranteed the next `main` run would remove them. They are checked-in defaults now — every one is a public DNS record, and the instance id in the mail targets is not a secret.

`terraform plan` with no tfvars now yields `Plan: 5 to add, 0 to change, 0 to destroy`, which is what CI runs.

## After merge

1. Clerk → Domains → **Verify configuration** until 5/5; certificates issue automatically
2. Confirm `https://clerk.vrdex.net/v1/environment` returns 200 — it currently fails TLS
3. **Only then** promote the Vercel production deployment

Do not promote before step 2. `vrdex.net` currently serves the working pre-Clerk build; the new build is deployed but unaliased. Promoting while `clerk.vrdex.net` has no certificate points every user at a frontend API that cannot serve TLS.

🤖 Generated with [Claude Code](https://claude.com/claude-code)