### PR TITLE
Count colliding vocabulary labels once and check ownership before reading private aliases

### DIFF
--- a/convex/_profilePrivacy.ts
+++ b/convex/_profilePrivacy.ts
@@ -39,16 +39,21 @@ export async function listOwnedPrivacyProfiles(db: DatabaseReader, userId: Id<"u
     .sort((first, second) => first.displayName.localeCompare(second.displayName));
 }
 
+export async function assertProfilePrivacyOwner(
+  db: DatabaseReader,
+  profile: Doc<"profiles">,
+  userId: Id<"users">,
+) {
+  if (profile.claimState === "unclaimed" || !(await userOwnsProfile(db, profile._id, userId))) {
+    throw new Error("Only a claimed profile owner can update profile privacy.");
+  }
+}
+
 export async function applyProfileFieldVisibilityUpdate(
   db: DatabaseWriter,
   input: ProfilePrivacyUpdateInput,
 ) {
-  if (
-    input.profile.claimState === "unclaimed" ||
-    !(await userOwnsProfile(db, input.profile._id, input.userId))
-  ) {
-    throw new Error("Only a claimed profile owner can update profile privacy.");
-  }
+  await assertProfilePrivacyOwner(db, input.profile, input.userId);
 
   const fieldVisibility = normalizeProfileFieldVisibility(input.fieldVisibility);
 

--- a/convex/_vocabulary.ts
+++ b/convex/_vocabulary.ts
@@ -105,13 +105,21 @@ export async function recordVocabularyTerms(
   candidates: VocabularyCandidate[],
   now: number,
 ) {
+  // Deduplicated by scoped key here rather than at each call site. Distinct labels
+  // can canonicalize to one key -- "Drum & Bass" and "Drum and Bass" -- and a search
+  // document stores that key once, so incrementing per candidate would overstate the
+  // count against a single later release. Every caller gets this for free.
+  const seen = new Set<string>();
+
   for (const candidate of candidates) {
     const label = normalizeVocabularyLabel(candidate.label ?? "");
     const key = createVocabularyKey(label);
 
-    if (!key) {
+    if (!key || seen.has(`${candidate.scope}:${key}`)) {
       continue;
     }
+
+    seen.add(`${candidate.scope}:${key}`);
 
     const aliases = normalizeVocabularyAliases(candidate.aliases);
 
@@ -161,12 +169,18 @@ export async function releaseVocabularyTerms(
   candidates: VocabularyCandidate[],
   now: number,
 ) {
+  // Same deduplication as recordVocabularyTerms: releasing a shared key twice would
+  // erase another contributor's usage.
+  const seen = new Set<string>();
+
   for (const candidate of candidates) {
     const key = createVocabularyKey(normalizeVocabularyLabel(candidate.label ?? ""));
 
-    if (!key) {
+    if (!key || seen.has(`${candidate.scope}:${key}`)) {
       continue;
     }
+
+    seen.add(`${candidate.scope}:${key}`);
 
     const existing = await db
       .query("vocabularyTerms")
@@ -197,12 +211,16 @@ export async function releaseVocabularyKeys(
   scopedKeys: string[],
   now: number,
 ) {
+  const seen = new Set<string>();
+
   for (const scopedKey of scopedKeys) {
     const separator = scopedKey.indexOf(":");
 
-    if (separator <= 0) {
+    if (separator <= 0 || seen.has(scopedKey)) {
       continue;
     }
+
+    seen.add(scopedKey);
 
     const scope = scopedKey.slice(0, separator) as VocabularyCandidate["scope"];
     const key = scopedKey.slice(separator + 1);

--- a/convex/profilePrivacy.ts
+++ b/convex/profilePrivacy.ts
@@ -10,6 +10,7 @@ import { canReadProfile } from "./_profilePermissions";
 import { assertIdentityNotSuppressed } from "./_suppressions";
 import {
   applyProfileFieldVisibilityUpdate,
+  assertProfilePrivacyOwner,
   listOwnedPrivacyProfiles,
 } from "./_profilePrivacy";
 import {
@@ -52,6 +53,11 @@ export const updateFieldVisibility = mutation({
     if (profile === null) {
       throw new Error("Profile not found.");
     }
+
+    // Before the suppression guard reads private aliases: a non-owner must get the
+    // ordinary owner-authority error, not IDENTITY_SUPPRESSED, which would tell them
+    // the profile stores a suppressed identity they cannot see.
+    await assertProfilePrivacyOwner(ctx.db, profile, userId);
 
     // Making a private alias visible is itself an act of surfacing. Without this,
     // an accepted name-only suppression could be bypassed by storing the name as a

--- a/convex/seedImports.ts
+++ b/convex/seedImports.ts
@@ -1076,30 +1076,16 @@ async function publishCandidate(ctx: MutationCtx, args: PublishCandidateArgs) {
         (candidate) => `${candidate.scope}:${createVocabularyKey(candidate.label ?? "")}`,
       ),
     );
-    // Deduplicated by scoped key, like the world path. Distinct labels can
-    // canonicalize to one key -- "Drum & Bass" and "Drum and Bass" -- and the search
-    // document stores that key once, so recording both would increment twice
-    // against a single later release.
-    const introducedVocabulary = [
-      ...new Map(
-        vocabularyAfter
-          .map((candidate) => [
-            `${candidate.scope}:${createVocabularyKey(candidate.label ?? "")}`,
-            candidate,
-          ] as const)
-          .filter(([scopedKey]) => !vocabularyBefore.has(scopedKey)),
-      ).values(),
-    ];
-    const removedVocabulary = [
-      ...new Map(
-        vocabularyBeforeCandidates
-          .map((candidate) => [
-            `${candidate.scope}:${createVocabularyKey(candidate.label ?? "")}`,
-            candidate,
-          ] as const)
-          .filter(([scopedKey]) => !afterKeys.has(scopedKey)),
-      ).values(),
-    ];
+    // Colliding labels are deduplicated inside the vocabulary helpers, so both
+    // sides of the delta can stay a plain filter.
+    const introducedVocabulary = vocabularyAfter.filter(
+      (candidate) =>
+        !vocabularyBefore.has(`${candidate.scope}:${createVocabularyKey(candidate.label ?? "")}`),
+    );
+    const removedVocabulary = vocabularyBeforeCandidates.filter(
+      (candidate) =>
+        !afterKeys.has(`${candidate.scope}:${createVocabularyKey(candidate.label ?? "")}`),
+    );
 
     await Promise.all([
       upsertSearchDocument(ctx.db, createProfileSearchDocument(profile)),

--- a/tests/backend/search-discovery.test.ts
+++ b/tests/backend/search-discovery.test.ts
@@ -18,7 +18,88 @@ import {
   sortSearchResults,
   toPublicSearchResult,
 } from "../../convex/_searchDocuments";
-import { createVocabularyKey, collectVocabularyKeys, SEEDED_VOCABULARY_TERMS } from "../../convex/_vocabulary";
+import {
+  createVocabularyKey,
+  collectVocabularyKeys,
+  recordVocabularyTerms,
+  releaseVocabularyTerms,
+  SEEDED_VOCABULARY_TERMS,
+} from "../../convex/_vocabulary";
+
+function createVocabularyDb(rows: Array<Record<string, unknown>>) {
+  const db = {
+    query(table: string) {
+      assert.equal(table, "vocabularyTerms");
+
+      return {
+        withIndex(_index: string, builder: (query: unknown) => unknown) {
+          const values: Record<string, unknown> = {};
+          const query = {
+            eq(field: string, value: unknown) {
+              values[field] = value;
+              return query;
+            },
+          };
+
+          builder(query);
+
+          return {
+            async unique() {
+              return (
+                rows.find((row) =>
+                  Object.entries(values).every(([field, value]) => row[field] === value),
+                ) ?? null
+              );
+            },
+          };
+        },
+      };
+    },
+    async patch(id: string, patch: Record<string, unknown>) {
+      Object.assign(rows.find((row) => row._id === id) as Record<string, unknown>, patch);
+    },
+    async insert(_table: string, row: Record<string, unknown>) {
+      rows.push({ ...row, _id: `term${rows.length}` });
+    },
+  };
+
+  return { db, rows };
+}
+
+describe("vocabulary usage counts", () => {
+  // Distinct labels can canonicalize to one key, but the search document stores that
+  // key once. Counting per label would inflate the term, and a later release of the
+  // same profile would then erase another profile's contribution.
+  const colliding = [
+    { scope: "profile_tag" as const, label: "Drum & Bass" },
+    { scope: "profile_tag" as const, label: "Drum and Bass" },
+  ];
+
+  it("counts colliding labels once when recording", async () => {
+    const store = createVocabularyDb([]);
+
+    await recordVocabularyTerms(store.db as never, colliding, 5);
+
+    assert.equal(store.rows.length, 1);
+    assert.equal(store.rows[0].key, createVocabularyKey("Drum & Bass"));
+    assert.equal(store.rows[0].usageCount, 1);
+  });
+
+  it("releases colliding labels once", async () => {
+    const store = createVocabularyDb([
+      {
+        _id: "term0",
+        scope: "profile_tag",
+        key: createVocabularyKey("Drum & Bass"),
+        usageCount: 2,
+      },
+    ]);
+
+    await releaseVocabularyTerms(store.db as never, colliding, 5);
+
+    assert.equal(store.rows[0].usageCount, 1);
+  });
+});
 
 describe("vocabulary normalization", () => {
   it("normalizes obvious duplicate terms into stable keys", () => {


### PR DESCRIPTION
Follow-up to #222 — the three P2 review comments that landed after it merged.

## Vocabulary double-counting (2 of the 3)

`convex/migrations.ts:175` and `convex/suppressions.ts:363` were flagged separately, but they are the same defect: distinct labels can canonicalize to one scoped key (`Drum & Bass` / `Drum and Bass`) while the search document stores that key once, so counting per label inflates `usageCount` and a single later release erases another profile's contribution.

#222 fixed this at the seed-publication call site only. Every other caller — the publish migration, the suppression retraction, claim creation, profile updates, events, search rebuild — still counted per label. So the fix moved into `recordVocabularyTerms`, `releaseVocabularyTerms`, and `releaseVocabularyKeys`; the seed-publication delta goes back to a plain filter now that the helpers own the invariant.

## Ownership before the suppression guard (the third)

`updateFieldVisibility` read private aliases into `assertIdentityNotSuppressed` before `applyProfileFieldVisibilityUpdate` performed the ownership check, so a signed-in non-owner of a publicly readable profile could receive `IDENTITY_SUPPRESSED` instead of the ordinary owner-authority error — telling them the profile stores a suppressed identity they cannot see.

The ownership assertion is now `assertProfilePrivacyOwner`, called before the guard in the mutation and still called inside `applyProfileFieldVisibilityUpdate`, so there is one definition and the guard cannot precede it.

## Verification

- `pnpm typecheck:backend` clean
- `pnpm test:backend` — 393 pass / 0 fail (2 new: colliding labels count once on record and on release)

🤖 Generated with [Claude Code](https://claude.com/claude-code)