### PR TITLE
Drop the invalid git-branch flag from the staging env pull

### DIFF
--- a/.github/workflows/staging-deploy.yml
+++ b/.github/workflows/staging-deploy.yml
@@ -149,9 +149,17 @@ jobs:
           pending_env="$RUNNER_TEMP/vrdex-vercel-staging-pending.env"
           trap 'rm -f "$pending_env"' EXIT
 
+          # No `--git-branch`. Vercel rejects a git branch unless the target is
+          # `preview` — it answers `Invalid request: target must be "preview"
+          # when specifying a gitBranch` — and `staging` is a custom
+          # environment, so a branch is not a selector here at all.
+          #
+          # The audit step above looks like it contradicts this, and does not:
+          # its `--git-branch main` is an argument to
+          # `check-staging-runtime-env.mjs`, which uses it to ignore variables
+          # scoped to another branch. It never reaches the Vercel CLI.
           pnpm dlx vercel@54.4.1 env pull "$pending_env" \
             --environment=staging \
-            --git-branch main \
             --yes \
             --token "$VERCEL_TOKEN" > /dev/null
 

--- a/tests/scripts/clerk-issuer-match.test.ts
+++ b/tests/scripts/clerk-issuer-match.test.ts
@@ -20,12 +20,6 @@ test("decodes the frontend API host a publishable key encodes", () => {
 });
 
 /**
- * A bare host normalises to the same string as the decoded key host, so
- * comparing hosts alone reports success — while `convex/auth.config.ts` passes
- * the bare value through verbatim and matches no token issuer. The variable is
- * named `..._DOMAIN`, which makes that an easy value to enter.
- */
-/**
  * Clerk keys encode `host$`. One encoding only `host` — truncated, or re-entered
  * by hand — decodes to the same string, so both comparisons passed while
  * `ClerkProvider` and the middleware could not use the key at all.
@@ -74,6 +68,12 @@ test("rejects a publishable key with noncanonical padding", () => {
   assert.throws(() => decodeClerkKeyHost(`pk_test_${canonical}=`), /not canonically encoded/);
 });
 
+/**
+ * A bare host normalises to the same string as the decoded key host, so
+ * comparing hosts alone reports success — while `convex/auth.config.ts` passes
+ * the bare value through verbatim and matches no token issuer. The variable is
+ * named `..._DOMAIN`, which makes that an easy value to enter.
+ */
 test("rejects an issuer that is not an https origin", () => {
   assert.throws(() => issuerHost("example.clerk.accounts.dev"), /must be an https origin/);
   assert.throws(() => issuerHost("http://example.clerk.accounts.dev"), /must be an https origin/);
@@ -112,11 +112,10 @@ test("reports no key when the target serves none", async () => {
 });
 
 /**
- * The missing-key result is what `--allow-missing-key` forgives, so an
- * unreachable target must not produce it. A transient 500 or a
- * deployment-protection 401 folded into the same answer would let a stale or
- * cross-instance issuer be written and deployed before the post-deploy check
- * could report the outage.
+ * A missing key and an unreachable page are different answers, and callers act
+ * on that difference. Folding a transient 500 or a deployment-protection 401
+ * into the same `null` would let an unreachable target read as "this page
+ * carried no key".
  */
 test("throws rather than reporting no key when a fetch fails", async () => {
   await assert.rejects(

--- a/tests/scripts/staging-runtime-env.test.ts
+++ b/tests/scripts/staging-runtime-env.test.ts
@@ -247,6 +247,12 @@ test("staging deploy parses and audits main before provider mutation", () => {
   assert.doesNotMatch(steps[preCheckIndex]?.if ?? "", /rotation/);
   assert.match(steps[preCheckIndex]?.run ?? "", /--publishable-key/);
   assert.match(steps[preCheckIndex]?.run ?? "", /vercel@[0-9.]+ env pull/);
+  // Never with `--git-branch`. Vercel rejects a branch unless the target is
+  // `preview`, and `staging` is a custom environment — passing one failed the
+  // step outright, which took staging deploys down until it was removed. The
+  // audit step's `--git-branch main` is an argument to the node script, not to
+  // the Vercel CLI, so only this step's invocation is constrained.
+  assert.doesNotMatch(steps[preCheckIndex]?.run ?? "", /env pull[\s\S]*?--git-branch/);
 
   // The authoritative pass, against what actually shipped, with no such escape.
   assert.ok(keyCheckIndex > vercelDeployIndex);


### PR DESCRIPTION
## Staging cannot deploy

The first run of #237 on `main` failed at `Verify the staging Clerk issuer before mutating Convex`:

```text
Error: Invalid request: `target` must be "preview" when specifying a `gitBranch`
```

`vercel env pull` was given both `--environment=staging` and `--git-branch main`. Vercel accepts a git branch only when the target is `preview`, and `staging` is a custom environment, so a branch is not a selector there at all.

**Nothing has reached staging since #237 merged.** The check failed *closed*, before writing anything to Convex, so no deployment was left half-changed — the fail-closed design did its job — but the environment is frozen until this lands.

## Why I got it wrong

The audit step immediately above passes `--git-branch main` and works. It looks like precedent and isn't: that argument goes to `check-staging-runtime-env.mjs`, which uses it to ignore variables scoped to another branch. It never reaches the Vercel CLI. I copied the flag across on the assumption it was CLI-level.

This is also the exact invocation I flagged as unverifiable when #237 went up — `vercel env pull --environment=staging` against a custom environment, with no way to exercise it locally. The flag shape was wrong in a way only a real run could show.

`staging-runtime-env.test.ts` now asserts the pull carries no `--git-branch`, so this cannot return.

## Also included

Two stale comments #237 left in `tests/scripts/clerk-issuer-match.test.ts`: a docblock orphaned above the wrong test when another was inserted before it, and one still describing `--allow-missing-key`, which that PR removed. No behaviour change.

## Verification

`test:scripts` (195), markdown, and YAML parse all green. The failure mode itself is only reproducible against Vercel, so the next staging run after merge is the proof — it should get past the pre-deploy check and on to the issuer comparison, which already passed against the served key on an earlier run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
