### PR TITLE
Make the VRCLinking cleanup bootstrap runnable on Windows

### DIFF
--- a/docs/backend/vrclinking-api.md
+++ b/docs/backend/vrclinking-api.md
@@ -191,8 +191,21 @@ It needs two Convex variables and one Vercel variable, and is inert without
 them — which is where every deployment that has never delegated a key sits:
 
 ```bash
-pnpm ops:bootstrap-vrclinking-cleanup -- --target prod --site-url https://vrdex.net --deployment-url <vercel-deployment-url>
+pnpm ops:bootstrap-vrclinking-cleanup --target prod --site-url https://vrdex.net --deployment-url <vercel-deployment-url>
 ```
+
+Staging is the same script against the shared development backend and Vercel's
+custom `staging` environment, which is not the default:
+
+```bash
+pnpm ops:bootstrap-vrclinking-cleanup --target dev --site-url https://staging.vrdex.net --deployment-url <vercel-deployment-url> --vercel-environment staging
+```
+
+Both were enabled on 2026-08-06 and verified by running
+`vrclinkingCredentials:sweepAbandonedDelegationKeys` against each backend and
+reading the runtime log for the request it makes. `configured: true` alone is not
+that proof: `swept` is `0` both when there is nothing to retire and when the POST
+was rejected, so the status code is the thing to look at.
 
 That generates the shared bearer, sets both Convex variables and the matching
 Vercel one, and prints none of them — neither provider receives it as a process

--- a/scripts/bootstrap-vrclinking-cleanup.mjs
+++ b/scripts/bootstrap-vrclinking-cleanup.mjs
@@ -83,16 +83,27 @@ export function parseArgs(argv) {
     "--deployment-url is required: the running deployment must be redeployed to pick up the new token.",
   );
 
-  // Shape-checked because Windows needs `shell: true` to reach the `.cmd` shims
-  // for `pnpm` and `npx`, and a shell concatenates rather than escapes. The
-  // bearer never travels this way — it goes to stdin — so what is left to guard
-  // is these three operator-supplied strings. `target` is already a whitelist;
-  // both URLs have to parse as URLs, and the environment is a bare name.
+  // Constrained, not merely parsed, because Windows needs `shell: true` to
+  // reach the `.cmd` shims for `pnpm` and `npx`, and a shell concatenates rather
+  // than escapes. `new URL()` is no defence on its own: `&`, `|` and `%` are all
+  // legal in a path or query and all mean something to `cmd.exe`, so a URL
+  // pasted from the wrong place could run a second command holding the
+  // operator's Vercel and Convex credentials.
+  //
+  // The bearer never travels this way, since it goes to stdin. What does is
+  // these three strings, so each is held to the narrowest shape that still
+  // admits every real value: `target` is a whitelist, the environment is a bare
+  // name, and both URLs are an https origin with an optional plain path. Vercel
+  // deployment URLs and site origins carry no query, so none is allowed.
   for (const [flag, value] of [
     ["--site-url", options.siteUrl],
     ["--deployment-url", options.deploymentUrl],
   ]) {
     assert.doesNotThrow(() => new URL(value), `${flag} must be a URL.`);
+    assert.ok(
+      /^https:\/\/[A-Za-z0-9.-]+(?::\d+)?(?:\/[A-Za-z0-9._~/-]*)?$/.test(value),
+      `${flag} must be an https origin with an optional plain path, and nothing a shell could read as a second command.`,
+    );
   }
 
   assert.ok(

--- a/scripts/bootstrap-vrclinking-cleanup.mjs
+++ b/scripts/bootstrap-vrclinking-cleanup.mjs
@@ -83,13 +83,48 @@ export function parseArgs(argv) {
     "--deployment-url is required: the running deployment must be redeployed to pick up the new token.",
   );
 
+  // Shape-checked because Windows needs `shell: true` to reach the `.cmd` shims
+  // for `pnpm` and `npx`, and a shell concatenates rather than escapes. The
+  // bearer never travels this way — it goes to stdin — so what is left to guard
+  // is these three operator-supplied strings. `target` is already a whitelist;
+  // both URLs have to parse as URLs, and the environment is a bare name.
+  for (const [flag, value] of [
+    ["--site-url", options.siteUrl],
+    ["--deployment-url", options.deploymentUrl],
+  ]) {
+    assert.doesNotThrow(() => new URL(value), `${flag} must be a URL.`);
+  }
+
+  assert.ok(
+    /^[a-z0-9_-]+$/i.test(options.vercelEnvironment),
+    "--vercel-environment must be a plain environment name.",
+  );
+
   return options;
 }
 
-function run(command, args, label, input) {
-  const result = spawnSync(command, args, { encoding: "utf8", shell: false, ...(input === undefined ? {} : { input }) });
+/**
+ * `pnpm` and `npx` are `.cmd` shims on Windows, and Node refuses to spawn those
+ * without a shell — so `shell: false` made this script unrunnable on the one
+ * machine an operator actually holds. A shell costs nothing here that matters:
+ * the bearer is written to stdin and never appears in `args`, which is the whole
+ * reason `shell: false` was chosen in the first place. What travels through the
+ * shell is a target name, two URLs, and an environment name.
+ */
+const SPAWN_THROUGH_SHELL = process.platform === "win32";
 
-  assert.equal(result.status, 0, `${label} failed: ${result.stderr?.trim() || result.stdout?.trim()}`);
+function run(command, args, label, input) {
+  const result = spawnSync(command, args, {
+    encoding: "utf8",
+    shell: SPAWN_THROUGH_SHELL,
+    ...(input === undefined ? {} : { input }),
+  });
+
+  assert.equal(
+    result.status,
+    0,
+    `${label} failed: ${result.stderr?.trim() || result.stdout?.trim() || result.error?.message || "no output"}`,
+  );
 }
 
 function main() {
@@ -143,22 +178,25 @@ function main() {
       options.vercelEnvironment,
       "--force",
     ],
-    { input: token, encoding: "utf8", shell: false },
+    { input: token, encoding: "utf8", shell: SPAWN_THROUGH_SHELL },
   );
 
   assert.equal(
     vercel.status,
     0,
-    `Setting VRCLINKING_CLEANUP_TOKEN in Vercel failed: ${vercel.stderr?.trim()}`,
+    `Setting VRCLINKING_CLEANUP_TOKEN in Vercel failed: ${vercel.stderr?.trim() || vercel.error?.message || "no output"}`,
   );
 
   // Vercel applies an environment change to future deployments only, so the
   // running function still holds the old token — or none — until it is rebuilt.
   // Convex is already posting the new one, so skipping this leaves the sweep
   // answering 401 daily with nothing surfacing it.
+  // `--target`, not `--yes`: `vercel redeploy` has never accepted the latter,
+  // so this step failed every time it was reached and left the two providers
+  // holding a token the running function did not have.
   run(
     "npx",
-    ["--yes", "vercel@latest", "redeploy", options.deploymentUrl, "--yes"],
+    ["--yes", "vercel@latest", "redeploy", options.deploymentUrl, "--target", options.vercelEnvironment],
     "Redeploying so the new token reaches the running function",
   );
 

--- a/tests/scripts/vrclinking-cleanup-bootstrap.test.ts
+++ b/tests/scripts/vrclinking-cleanup-bootstrap.test.ts
@@ -48,6 +48,48 @@ test("refuses a target that is not a known deployment", () => {
 });
 
 /**
+ * Windows cannot spawn the `pnpm` and `npx` shims without a shell, and a shell
+ * concatenates its arguments rather than escaping them. `new URL()` is not a
+ * defence: every string below parses cleanly, and each one carries something
+ * `cmd.exe` reads as a second command or a variable to expand. They would run
+ * holding the operator's Vercel and Convex credentials.
+ */
+test("refuses URLs a shell could read as a second command", () => {
+  const hostile = [
+    "https://x.vercel.app/a&whoami",
+    "https://x.vercel.app/a|whoami",
+    "https://x.vercel.app/a%USERPROFILE%",
+    "https://x.vercel.app/a>out",
+    "https://x.vercel.app/?q=a&b",
+    'https://x.vercel.app/a"b',
+    "https://x.vercel.app/a^b",
+  ];
+
+  for (const value of hostile) {
+    assert.doesNotThrow(() => new URL(value), `${value} should still parse as a URL`);
+    assert.throws(
+      () =>
+        parseArgs(["--target", "prod", "--site-url", "https://vrdex.net", "--deployment-url", value]),
+      /nothing a shell could read as a second command/,
+      value,
+    );
+  }
+
+  // The shapes actually used stay accepted: a bare origin, a subdomain, and the
+  // generated Vercel deployment hostname.
+  for (const value of [
+    "https://vrdex.net",
+    "https://staging.vrdex.net",
+    "https://vr-dex-917snupst-basicbit.vercel.app",
+  ]) {
+    assert.deepEqual(
+      parseArgs(["--target", "prod", "--site-url", value, "--deployment-url", value]).deploymentUrl,
+      value,
+    );
+  }
+});
+
+/**
  * Both names, because the sweep is inert unless both are present and the cron
  * reports that state nowhere an operator sees.
  */


### PR DESCRIPTION
Found by running `ops:bootstrap-vrclinking-cleanup` for the first time against real deployments, at BASIC's request to enable the sweep in all environments. Three bugs, in the order they bite.

**`shell: false` cannot reach `pnpm` or `npx` on Windows.** Both are `.cmd` shims, and Node refuses to spawn those without a shell. The script died at its first step with `status: null` on the only machine an operator actually holds, so it had never run anywhere.

`shell: false` was a deliberate choice to keep the bearer out of `argv`, and that property is unchanged: the token is written to stdin and never appears in `args`. What the shell now concatenates is a target name, two URLs, and an environment name, so those are shape-checked in `parseArgs` rather than trusted.

**`vercel redeploy` has never accepted `--yes`.** It takes `--target`. This is the last step, so it failed *after* both Convex and Vercel had been given the new token, leaving precisely the half-applied state the preflight immediately above it exists to prevent: Convex posting a bearer the running function has never seen, and the sweep answering 401 daily with nothing surfacing it. I hit that state on production and repaired it by hand.

**The documented invocation had a `--` separator**, which pnpm 10 forwards to the script as a literal argument instead of consuming, so the copy-pasteable command in the runbook failed with `Unknown option: --`.

## Enabled and verified

Both environments are now live, and the runbook records the staging invocation, which is not obvious: `--target dev` against the shared development backend, plus `--vercel-environment staging` for Vercel's custom environment.

Verification was the cron action itself plus the runtime log, because `configured: true` is not proof on its own. `swept` reads `0` both when there is nothing to retire and when the POST was rejected, so the status code is the thing to look at:

- production: `POST /api/account/vrclinking-delegation/sweep` -> 200 on `vrdex.net`, and 401 for an unauthenticated probe
- staging: 200 on `staging.vrdex.net`

Follow-on from #246.