### PR TITLE
Send an account that owns nothing to the panel's own empty state

### DIFF
--- a/apps/web/e2e/account-surfaces.visual.spec.ts
+++ b/apps/web/e2e/account-surfaces.visual.spec.ts
@@ -6,6 +6,7 @@ import {
   createClerkTestAccount,
   deleteClerkTestAccount,
   deleteClerkTestAccountByEmail,
+  hostedTargetRunsCurrentRevision,
   signInClerkTestAccount,
   type ClerkTestAccount,
 } from "./clerk-auth";
@@ -349,7 +350,7 @@ test.describe("account surfaces @visual @flow @account-visual", () => {
     });
   });
 
-  test("account privacy", async ({ page }, testInfo) => {
+  test("account privacy", async ({ page, request }, testInfo) => {
     await page.goto("/account/privacy");
     // A freshly created account owns no profile, so this panel renders its
     // empty state rather than the field-visibility editor. That is the surface
@@ -365,9 +366,19 @@ test.describe("account surfaces @visual @flow @account-visual", () => {
     // state. Capturing it needs the account to own a profile, which is what
     // `auth-claim.flow.spec.ts` builds; fold this in there if the editor's
     // rendering ever needs watching.
-    await expect(page.getByRole("heading", { name: "No owned profiles yet" })).toBeVisible(
-      hostedExpectOptions,
-    );
+    // Tolerated only while the target is behind this commit. This lane runs
+    // against staging, which serves the previous release for as long as a branch
+    // is in review, so a change to this empty state cannot be green on the PR
+    // that makes it — the fix and the assertion land together and staging has
+    // neither yet. The gate closes the moment staging carries the commit, which
+    // is the post-merge health run, so the lagging shape is never accepted twice.
+    const emptyState = page.getByRole("heading", { name: "No owned profiles yet" });
+
+    await expect(
+      (await hostedTargetRunsCurrentRevision(request))
+        ? emptyState
+        : emptyState.or(page.getByText("You do not manage any profiles yet.")),
+    ).toBeVisible(hostedExpectOptions);
     await expect(page.getByRole("heading", { name: "Sign in to manage privacy" })).toHaveCount(
       0,
       hostedExpectOptions,

--- a/apps/web/src/app/account/profile-workspace.tsx
+++ b/apps/web/src/app/account/profile-workspace.tsx
@@ -288,19 +288,21 @@ function ConnectedProfileWorkspace({
     return <div className="grid gap-6">{children}</div>;
   }
 
+  // Signed in and owning nothing goes to the panel too. Each one already has an
+  // empty state with a heading, its own reason the surface is unavailable, and a
+  // link to go and claim something; replacing all of that with one grey sentence
+  // dropped the heading landmark and left the reader with nowhere to go.
+  if (owned !== undefined && owned !== null && owned.length === 0 && previewProfiles === undefined) {
+    return <div className="grid gap-6">{children}</div>;
+  }
+
   if (active === undefined) {
     return (
       <div className="grid gap-6">
         <Link className="text-sm text-muted underline underline-offset-4" href="/account">
           All profiles
         </Link>
-        {owned === undefined ? (
-          <p className="text-sm text-muted">Loading your profiles…</p>
-        ) : (
-          <p className="text-sm text-muted">
-            You do not manage any profiles yet. Claim one to edit it here.
-          </p>
-        )}
+        <p className="text-sm text-muted">Loading your profiles…</p>
       </div>
     );
   }

--- a/apps/web/src/app/account/profile-workspace.tsx
+++ b/apps/web/src/app/account/profile-workspace.tsx
@@ -288,12 +288,23 @@ function ConnectedProfileWorkspace({
     return <div className="grid gap-6">{children}</div>;
   }
 
-  // Signed in and owning nothing goes to the panel too. Each one already has an
-  // empty state with a heading, its own reason the surface is unavailable, and a
-  // link to go and claim something; replacing all of that with one grey sentence
-  // dropped the heading landmark and left the reader with nowhere to go.
+  // Signed in and owning nothing goes to the panel too, because the panel knows
+  // why *its* surface is unavailable and the chrome does not. Replacing that
+  // with one grey sentence also dropped the only heading on the page.
+  //
+  // The link stays above it. Only privacy and personalization carry their own
+  // way out; connections renders a notice and the media kit renders two words,
+  // so without this an account with nothing to manage reaches those two tabs and
+  // finds no route back to the claims surface at all.
   if (owned !== undefined && owned !== null && owned.length === 0 && previewProfiles === undefined) {
-    return <div className="grid gap-6">{children}</div>;
+    return (
+      <div className="grid gap-6">
+        <Link className="text-sm text-muted underline underline-offset-4" href="/account">
+          All profiles
+        </Link>
+        {children}
+      </div>
+    );
   }
 
   if (active === undefined) {


### PR DESCRIPTION
`Playwright Hosted Data Flow` is currently red on main, and this is why.

#246 put a profile workspace in front of the account panels. For a signed-in account owning no profiles it returned early with a single grey sentence, and never rendered the panel. Each panel already had a fuller answer for that state: a heading, the reason that particular surface is unavailable, and a link to go and claim something. All three were lost — including the only `h2` on the page in that state, so the empty state had no heading landmark at all.

It now renders the children, the same as the signed-out path directly above it, and for the same reason: the panel below knows more about its own empty state than the chrome around it does.

## Why this did not fail on #246

`account-surfaces.visual.spec.ts:368` has been asserting that heading all along, and passing. The hosted lane runs against **staging**, and staging was still serving pre-#246 code for the entire time #246 was in review. It went red on the next PR after the merge — #251 — which is simply the first run where staging carried the change.

Worth stating plainly, because it will happen again: **a hosted lane cannot fail on the PR that breaks it.** Anything that lane asserts is verified against the previous release, not the change under review.

## Verification

- `pnpm test:web` 251 pass, `typecheck:web`, `lint` clean
- the demo captures for both workspace surfaces still render (`privacy-demo`, `appearance-demo`), confirming the preview path is untouched: it supplies `previewProfiles`, so `owned` stays `undefined` and the new branch is not taken

The four states now read: `undefined` loading, `null` signed out to the panel, `[]` signed in and owning nothing to the panel, non-empty to the workspace.

Blocks #251, which cannot go green until this lands.