### PR TITLE
Fit the carried migration state to the command line, not to a count

### DIFF
--- a/apps/web/e2e/profile-submission.flow.spec.ts
+++ b/apps/web/e2e/profile-submission.flow.spec.ts
@@ -67,19 +67,36 @@ test("profile submission writes through to public profile and discovery @flow", 
     await page.getByLabel("Aliases").fill(`Flow ${runSuffix}`);
     await page.getByLabel("Tags", { exact: true }).or(page.getByLabel("Shared tags", { exact: true })).first().fill("playwright, data-flow");
 
-    // Shared staging only ever serves `main`, so it renders the freeform role
-    // input this branch replaces until this merges. `hostedTargetRunsCurrentRevision`
-    // is true for every local run and for the post-merge health lane, and false
-    // exactly while the target genuinely is behind -- so the new controls are
-    // asserted everywhere they exist, and the tolerance expires on merge rather
-    // than living on as a permanent excuse.
+    // Driven by what the page actually renders, not by which revision the target
+    // is meant to be on.
+    //
+    // This branched on `hostedTargetRunsCurrentRevision` alone and fell back to
+    // the freeform input, on the reasoning that the helper is false exactly while
+    // staging is behind. It is not: it is false on every branch that is not the
+    // deployed revision, which is every pull request. So the moment the role
+    // checkboxes reached staging the fallback stopped being a safety net and
+    // became a guaranteed 30s wait for a control that no longer exists anywhere.
+    //
+    // The revision check still earns its place, one line down: once the target
+    // provably runs this commit, the old shape is not tolerated at all, so this
+    // cannot quietly go on accepting a regression.
+    const roleCheckbox = page.getByRole("checkbox", { name: "DJ", exact: true });
+    const rendersRoleCheckboxes = (await roleCheckbox.count()) > 0;
+
     if (await hostedTargetRunsCurrentRevision(request)) {
+      expect(
+        rendersRoleCheckboxes,
+        "target runs this revision, so it must render the role checkboxes",
+      ).toBe(true);
+    }
+
+    if (rendersRoleCheckboxes) {
       // Roles are checkboxes over a fixed vocabulary with a freeform field
       // beside it. Checking DJ is also what reveals the stream inputs, which is
       // why roles are asked for before links.
       const streamUrl = page.getByLabel("Stream");
       await expect(streamUrl).toHaveCount(0);
-      await page.getByRole("checkbox", { name: "DJ", exact: true }).check();
+      await roleCheckbox.check();
       await expect(streamUrl).toBeVisible();
       await page.getByLabel("Other roles").fill("Test profile");
 
@@ -93,6 +110,7 @@ test("profile submission writes through to public profile and discovery @flow", 
       await streamUrl.fill(`https://panel.vrcdn.live/preview/${streamId}`);
       submittedStreamId = streamId;
     } else {
+      // Only reachable against a target that predates the checkboxes.
       await page.getByLabel("Person roles").fill("Test profile");
     }
 

--- a/docs/backend/private-seed-operations.md
+++ b/docs/backend/private-seed-operations.md
@@ -397,16 +397,22 @@ pnpm ops:seed-publish -- `
   `--apply` run sends the identifiers alone. `--rederive-values` also carries
   the display name and aliases, because those are what the suppression recheck
   reads and a re-derivation is the only mode that moves them. It is the one
-  part of the call that grows with
-  the batch rather than the page, so it is capped; a batch with more distinct
-  published profiles than the cap prints a warning saying the totals are
-  approximate, rather than quietly drifting from what the write will do.
-  `--limit` is not the lever, and the warning says so: the carry holds every
-  distinct profile seen so far rather than one entry per page, and the mutation
-  clamps the page size anyway. What degrades past the cap is the reporting, not
-  the migration -- an applied run reads back what it wrote, so the writes are
-  the same either way. Raising the cap is a code change, and the batch this
-  exists for is well under it.
+  part of the call that grows with the batch rather than the page, and it
+  reaches the Convex CLI as one process argument -- so the ceiling is the
+  command line, not anything Convex enforces. On Windows that is 32,767
+  characters, and crossing it fails the spawn before the process starts: no
+  Convex error, no stderr, just a failed call with nothing to inspect. A run
+  against the 405-profile batch hit exactly that at 244 profiles.
+- The driver now fits the carry into a byte budget, shedding in the order that
+  keeps the promise worth most. Which profiles have been counted is what keeps
+  the totals honest and costs an identifier, so the visibility maps and names go
+  first; entries are dropped outright only if the identifiers alone still will
+  not fit. Anything shed prints a warning and marks the totals approximate,
+  rather than quietly drifting from what the write will do. `--limit` is not the
+  lever, and the warning says so: the carry holds every distinct profile seen so
+  far rather than one entry per page, and the mutation clamps the page size
+  anyway. What degrades is the reporting, not the migration -- an applied run
+  reads back what it wrote, so the writes are the same either way.
 - `--field-keys` is optional; omitting it targets every accepted field. It scopes
   the whole run, not just the visibility change: with `--rederive-values`, only
   the named fields are replayed, so a run repairing links cannot overwrite live

--- a/scripts/convex-target.ts
+++ b/scripts/convex-target.ts
@@ -73,6 +73,23 @@ export type ConvexTargetName = keyof typeof CONVEX_TARGETS;
 export const CONVEX_TARGET_NAMES = Object.keys(CONVEX_TARGETS);
 
 /**
+ * How much serialized argument any operator script may hand the Convex CLI.
+ *
+ * Arguments reach the CLI as one process argument, so the ceiling is the
+ * platform's command line rather than anything Convex enforces: Windows
+ * `CreateProcess` caps at 32,767 characters and fails the spawn outright. That
+ * failure is silent in the worst way -- the process never starts, so there is no
+ * Convex error, no stderr, and a caller that only checks the exit status reports
+ * a failed call with nothing to inspect.
+ *
+ * 20,000 leaves room for the rest of the command line and for a payload that
+ * measures larger once escaped. Lives here rather than in one script because
+ * every script that talks to the CLI answers to the same ceiling, and the one
+ * that learned it first had already paid for it.
+ */
+export const MAX_CONVEX_ARGS_BYTES = 20_000;
+
+/**
  * Every Convex CLI flag that can point a command at a different deployment, or
  * supply different credentials. Four rounds of review each found one more entry
  * for this list, so it is no longer written from memory: `--prod`,

--- a/scripts/import-seed-json.mjs
+++ b/scripts/import-seed-json.mjs
@@ -7,6 +7,7 @@ import {
   CONVEX_TARGET_NAMES,
   convexCliPath,
   convexTargetEnv,
+  MAX_CONVEX_ARGS_BYTES,
   SEED_SCRIPT_TARGET_HELP,
   resolveTargetName,
   targetSelectorFlagError,
@@ -17,7 +18,12 @@ const scriptDir = path.dirname(scriptPath);
 const repoRoot = path.resolve(scriptDir, "..");
 const args = process.argv.slice(2);
 
-export const MAX_CONVEX_IMPORT_ARGS_BYTES = 20_000;
+/**
+ * Kept under the name this script and its tests already use. The ceiling is the
+ * command line every operator script shares rather than anything about
+ * importing, which is why the value now lives beside the CLI wrapper.
+ */
+export const MAX_CONVEX_IMPORT_ARGS_BYTES = MAX_CONVEX_ARGS_BYTES;
 
 function option(name) {
   const index = args.indexOf(name);

--- a/scripts/publish-seed-batch.mjs
+++ b/scripts/publish-seed-batch.mjs
@@ -6,6 +6,7 @@ import {
   CONVEX_TARGET_NAMES,
   convexCliPath,
   convexTargetEnv,
+  MAX_CONVEX_ARGS_BYTES,
   SEED_SCRIPT_TARGET_HELP,
   resolveTargetName,
   targetSelectorFlagError,
@@ -205,6 +206,57 @@ export function misplacedPublishFlag(visibility, supplied) {
   return Object.keys(supplied).find((name) => supplied[name]);
 }
 
+/**
+ * Fit the state a page carries forward inside the argument budget.
+ *
+ * This state is the one part of the call that grows with the batch rather than
+ * the page, and it reaches the Convex CLI as a process argument -- so the
+ * ceiling is the command line, not anything Convex enforces. A run against the
+ * 405-profile batch died at 244 profiles because the serialized state crossed
+ * Windows' 32,767-character limit and `spawnSync` never launched the process:
+ * no Convex error, no stderr, just a non-zero status with nothing to inspect.
+ *
+ * The mutation already caps how many profiles it hands back, but a count of
+ * entries is the wrong dimension. What matters is bytes, and a profile carrying
+ * a visibility map and a display name costs several times one carrying an id.
+ *
+ * Degraded in the order that keeps the promise worth most. Membership -- which
+ * profiles the run has already counted -- is what keeps the totals honest, and
+ * it costs an id. The visibility and names only change an answer for a profile
+ * some later candidate touches again, so they go first. Only if the ids alone
+ * still do not fit does anything get dropped outright.
+ *
+ * `complete` is false the moment anything is shed, because past that point the
+ * dry run can count a merged profile twice or predict a suppression skip the
+ * apply would not hit, and a total the runbook promises will match the write has
+ * to say when it stopped promising that.
+ */
+export function fitCarriedProfiles(entries, maxBytes = MAX_CONVEX_ARGS_BYTES) {
+  const size = (value) => Buffer.byteLength(JSON.stringify(value), "utf8");
+
+  if (entries.length === 0 || size(entries) <= maxBytes) {
+    return { carried: entries, complete: true };
+  }
+
+  const idsOnly = entries.map((entry) => ({ profileId: entry.profileId }));
+
+  if (size(idsOnly) <= maxBytes) {
+    return { carried: idsOnly, complete: false };
+  }
+
+  // Estimated from the whole array rather than one entry, so the array's own
+  // punctuation is counted, then walked down. Ids are a fixed width, so this
+  // lands on the answer or one step above it.
+  const perEntry = Math.max(1, Math.ceil(size(idsOnly) / idsOnly.length));
+  let kept = Math.max(0, Math.min(idsOnly.length, Math.floor(maxBytes / perEntry)));
+
+  while (kept > 0 && size(idsOnly.slice(0, kept)) > maxBytes) {
+    kept -= 1;
+  }
+
+  return { carried: idsOnly.slice(0, kept), complete: false };
+}
+
 export function readOption(argv, name) {
   const index = argv.indexOf(name);
 
@@ -396,6 +448,13 @@ function setFieldVisibility({ batchId, visibility, reason, reviewer, limit }) {
   console.log("");
 
   for (;;) {
+    // Trimmed on the way out rather than on the way in, because the ceiling
+    // belongs to this call: the state is fine in the response and fine in the
+    // mutation, and only becomes too large when it has to fit on a command line.
+    const { carried, complete } = fitCarriedProfiles(simulatedProfiles);
+
+    simulationComplete = simulationComplete && complete;
+
     const page = runConvex("seedImports:bulkSetFieldVisibility", {
       externalBatchId: batchId,
       visibility,
@@ -406,7 +465,7 @@ function setFieldVisibility({ batchId, visibility, reason, reviewer, limit }) {
       rederiveValues: flag("--rederive-values"),
       ...(fieldKeys === undefined ? {} : { fieldKeys }),
       ...(cursor === undefined || cursor === null ? {} : { cursor }),
-      ...(simulatedProfiles.length === 0 ? {} : { simulatedProfiles }),
+      ...(carried.length === 0 ? {} : { simulatedProfiles: carried }),
     });
 
     // Carried into the next page so one merged profile is not counted once per
@@ -466,15 +525,17 @@ function setFieldVisibility({ batchId, visibility, reason, reviewer, limit }) {
   // total that quietly drifted from what the write will do.
   if (!simulationComplete) {
     console.log(
-      "\nWarning: this batch has more distinct published profiles than the run carries\n" +
-        "between pages, so the totals above are approximate. Past that point a profile\n" +
-        "two candidates share can be counted twice, and a suppression skip can be\n" +
-        "reported that the apply would not hit.\n" +
+      "\nWarning: this batch carries more state between pages than one Convex CLI call\n" +
+        "can take, so some of it was shed and the totals above are approximate. Past\n" +
+        "that point a profile two candidates share can be counted twice, and a\n" +
+        "suppression skip can be reported that the apply would not hit.\n" +
         "\n" +
-        "--limit does not help: the carry holds every distinct profile seen so far, not\n" +
-        "one entry per page, and the mutation clamps the page size regardless. What the\n" +
-        "numbers say about the writes is unchanged -- an applied run reads back what it\n" +
-        "wrote, so it is the reporting that degrades here and not the migration.",
+        "The detail goes before the membership, so the counts are the last thing to\n" +
+        "suffer and usually survive intact. --limit does not help either way: the carry\n" +
+        "holds every distinct profile seen so far rather than one entry per page, and\n" +
+        "the mutation clamps the page size regardless. What the numbers say about the\n" +
+        "writes is unchanged -- an applied run reads back what it wrote, so it is the\n" +
+        "reporting that degrades here and not the migration.",
     );
   }
 

--- a/tests/backend/seed-imports.test.ts
+++ b/tests/backend/seed-imports.test.ts
@@ -22,6 +22,7 @@ import {
   type SeedImportFixture,
 } from "../../convex/_seedImports";
 import {
+  fitCarriedProfiles,
   misplacedMigrationFlag,
   misplacedPublishFlag,
   readOption,
@@ -942,6 +943,54 @@ describe("seed publish option safety", () => {
       unknownOption(["--reason", "--apply", "--apply"]),
       { name: "--apply", reason: "repeated" },
     );
+  });
+
+  describe("carried simulation state", () => {
+    // The shape the real batch carries: a Convex id and the two field keys the
+    // NWinn import actually holds.
+    const entry = (index: number) => ({
+      profileId: `m57${String(index).padStart(29, "0")}`,
+      fieldVisibility: { outboundLinks: "public", personRoleTags: "public" },
+    });
+    const entries = (count: number) =>
+      Array.from({ length: count }, (_unused, index) => entry(index));
+    const bytes = (value: unknown) => Buffer.byteLength(JSON.stringify(value), "utf8");
+
+    it("passes a payload that already fits through untouched", () => {
+      const carried = entries(10);
+      const result = fitCarriedProfiles(carried, 20_000);
+
+      assert.deepEqual(result.carried, carried);
+      assert.equal(result.complete, true);
+    });
+
+    it("sheds the detail before the membership", () => {
+      // 405 profiles at roughly 119 bytes each is about 48KB, over the budget and
+      // over the Windows command line that budget exists for. The run that found
+      // this died at 244 profiles with no error to inspect, because the spawn
+      // never happened.
+      const result = fitCarriedProfiles(entries(405), 20_000);
+
+      // Every profile still counted, which is what keeps the totals right.
+      assert.equal(result.carried.length, 405);
+      assert.ok(bytes(result.carried) <= 20_000);
+      // Detail gone, and said so.
+      assert.deepEqual(Object.keys(result.carried[0] ?? {}), ["profileId"]);
+      assert.equal(result.complete, false);
+    });
+
+    it("drops entries only when the identifiers alone will not fit", () => {
+      const result = fitCarriedProfiles(entries(4_000), 20_000);
+
+      assert.ok(result.carried.length > 0);
+      assert.ok(result.carried.length < 4_000);
+      assert.ok(bytes(result.carried) <= 20_000);
+      assert.equal(result.complete, false);
+    });
+
+    it("keeps an empty carry empty and complete", () => {
+      assert.deepEqual(fitCarriedProfiles([], 20_000), { carried: [], complete: true });
+    });
   });
 
   it("refuses publication-only flags inside the visibility migration", () => {


### PR DESCRIPTION
Found by pointing `ops:seed-publish` at the real NWinn batch for the first
time. The dry run died at 244 of 405 profiles, reproducibly, with nothing to
inspect.

## What happened

The state a page carries forward reaches the Convex CLI as **one process
argument**, so the ceiling is the command line, not anything Convex enforces.
Each carried profile costs 119 bytes:

```json
{"fieldVisibility":{"outboundLinks":"public","personRoleTags":"public"},"profileId":"m573pmsfews2hfst8g0rh3fhz58bshjx"}
```

At 244 profiles that is 29,036 bytes. The next page crossed Windows'
32,767-character `CreateProcess` limit and `spawnSync` failed **before starting
a process** — so there was no Convex error and no stderr, and the driver's
`result.status !== 0` check reported a failed call with nothing attached. That
silence is what made it hard to read.

`SIMULATION_CARRY_LIMIT` was meant to prevent exactly this, but it counts
entries and sits at 1,000 — about four times past where the real ceiling bites.
Bytes were always the operative dimension.

## Why review did not catch it

Every test of this path uses the two-profile fixture. The ceiling only exists at
scale, so a dozen review rounds went over the bound without it ever being
reachable. Worth noting as a class: a cap expressed in the wrong unit reads as
correct in every small test.

## The fix

`fitCarriedProfiles` fits the carry to a byte budget, shedding in the order that
keeps the promise worth most:

1. **Detail first.** Visibility maps and names only change an answer for a
   profile some later candidate touches again.
2. **Membership last.** Which profiles have been counted is what keeps the
   totals honest, and it costs an identifier.
3. **Entries dropped** only if the identifiers alone still will not fit.

Anything shed still sets `simulationComplete: false`, because past that point a
dry run can double-count a merged profile or predict a suppression skip the
apply would not hit. The counts survive to the end in practice — on this batch
they came out exact.

The budget moves to `convex-target.ts` beside the CLI wrapper, since the ceiling
belongs to every script that talks to the CLI rather than to importing.
`import-seed-json.mjs` had already paid for this lesson and had the constant;
it keeps its own export name so its tests and callers are untouched.

## Verification

Against the batch that found it, `nwinn_2026_07_16_ad79dca17a`:

```
Would set 824 accepted fields to public across 414 candidates,
updating 405 published profiles (visibility only).
Links: 232 would collapse onto an existing link, 5 could not be normalized.
```

405 profiles matches `previewBatchPublication`'s `alreadyPublishedCount`, and
824 fields is consistent with the sampled 2-fields-per-candidate rate. The run
completes all 414 candidates where it previously stopped at 244.

Four unit tests cover the ladder: a payload that fits passes through untouched,
405 profiles shed detail but keep every identifier, 4,000 drop entries as well,
and an empty carry stays empty and complete.

## Not changed

`SIMULATION_CARRY_LIMIT` stays as the server-side backstop on response size.
The driver-side budget is the binding one, and it is the only side that knows
what platform it is spawning on.
