### PR TITLE
Probe the stream VRCDN actually serves

### DIFF
--- a/apps/web/src/lib/server/vrcdn-live.ts
+++ b/apps/web/src/lib/server/vrcdn-live.ts
@@ -26,11 +26,16 @@ const getCachedVrcdnLiveState = unstable_cache(
       return { observedAt: Date.now(), state: "unavailable" };
     }
 
-    const response = await fetch(stream.hlsUrl, { signal: AbortSignal.timeout(probeTimeoutMs) });
+    // The transport stream, not the HLS manifest. The manifest answers `404`
+    // for a stream that is actively publishing, so probing it could never
+    // report anyone live.
+    const response = await fetch(stream.questUrl, { signal: AbortSignal.timeout(probeTimeoutMs) });
 
-    // The status carries the whole answer, so the body is dropped rather than
-    // read. Nothing here pulls a media segment, which is the part that would
-    // plausibly spend one of the operator's paid viewer slots.
+    // Dropped before a frame is read. This endpoint serves media and ignores
+    // `Range`, so it starts pushing MPEG-TS the moment it answers; cancelling
+    // here is what keeps the probe to a connection rather than a download.
+    // Whether VRCDN counts that against the operator's viewer cap cannot be
+    // determined from outside their account.
     await response.body?.cancel();
 
     const state = vrcdnLiveStateFromStatus(response.status);

--- a/apps/web/src/lib/vrcdn-live.ts
+++ b/apps/web/src/lib/vrcdn-live.ts
@@ -1,15 +1,27 @@
 import { parseVrcdnStreamLinks } from "../../../../convex/_vrcdnLinks";
 
 /**
- * VRCDN publishes no liveness API, so this is read off the HLS manifest.
- * `vrcdn.live` is a Blazor SPA that answers `200` with the app shell for
- * unknown paths, which makes both the page and `/api/live` useless as signals.
+ * VRCDN publishes no liveness API, so this is read off the transport stream at
+ * `stream.vrcdn.live/live/<id>.live.ts` -- the endpoint a Quest client pulls.
  *
- * `offline` is a real `404` from the media server, and it cannot separate "not
- * publishing" from "no such stream" -- which is why a stream id has to come
- * from an owner-confirmed link rather than from the probe. `unavailable` is
- * kept distinct from `offline` because a probe that could not finish is not
- * evidence that anyone stopped streaming.
+ *     GET .live.ts   live -> 200 (video/mp2t)   idle -> 404   unknown id -> 401
+ *     GET .m3u8      live -> 404                idle -> 404   unknown id -> 404
+ *     HEAD .live.ts  live -> 200                idle -> 200   unknown id -> 200
+ *
+ * Measured against a real stream on 2026-08-10, live and then idle. The HLS
+ * manifest was the original mechanism and is inert -- it answers `404` for a
+ * stream that is actively publishing, so it could never report anyone live.
+ * `HEAD` answers `200` for stream ids that do not exist, so it is not a signal
+ * either. `vrcdn.live` itself is a Blazor SPA that answers `200` with the app
+ * shell for unknown paths, which rules out the page and `/api/live` as well.
+ *
+ * `unavailable` is kept distinct from `offline` because a probe that could not
+ * finish is not evidence that anyone stopped streaming.
+ *
+ * Note this endpoint serves media: it ignores `Range` and begins pushing MPEG-TS
+ * as soon as it answers, so the probe drops the body immediately. Whether that
+ * still spends one of the operator's viewer slots is not answerable from
+ * outside their account. See `#217`.
  */
 export type VrcdnLiveState = "live" | "offline" | "unavailable";
 
@@ -25,9 +37,9 @@ export type VrcdnLiveLink = {
  * `community_submitted` is deliberately absent. `submitCommunityProfile`
  * publishes immediately, and a community submission is one signed-in person
  * adding somebody else's profile -- so a stranger could attach a stream id they
- * do not own and make an unclaimed profile announce that person is live. A
- * `404` cannot tell "not publishing" from "not their stream", so the probe
- * cannot catch this; only provenance can.
+ * do not own and make an unclaimed profile announce that person is live. The
+ * probe cannot catch this -- somebody else's stream id is a perfectly valid id
+ * and answers `200` while they are streaming -- so only provenance can.
  *
  * The link still renders. It is the claim about who is streaming that needs a
  * vetted source.
@@ -35,14 +47,18 @@ export type VrcdnLiveLink = {
 const liveClaimLinkSources = new Set(["owner_authored", "partner_provided", "reviewed"]);
 
 export function vrcdnLiveStateFromStatus(status: number): VrcdnLiveState {
-  if (status === 404) {
+  // `404` is a real stream that is not publishing. `401` is an id the media
+  // server does not know, which the badge treats the same way -- nobody is
+  // live either way. They are worth keeping apart in the probe because this
+  // endpoint, unlike the manifest, actually does distinguish them: a typo in an
+  // owner's own link reads `401` forever, where an idle stream reads `404`.
+  if (status === 404 || status === 401) {
     return "offline";
   }
 
-  // `200` exactly, not 2xx. The verified contract is a manifest served behind a
-  // `200`; a bodyless success from an intermediary -- a `204`, a cache layer's
-  // `205` -- is that intermediary answering, not VRCDN saying someone is
-  // publishing, and it should not light up `Live now`.
+  // `200` exactly, not 2xx. A bodyless success from an intermediary -- a `204`,
+  // a cache layer's `205` -- is that intermediary answering, not VRCDN handing
+  // over a transport stream, and it should not light up `Live now`.
   return status === 200 ? "live" : "unavailable";
 }
 

--- a/docs/backend/profile-schema.md
+++ b/docs/backend/profile-schema.md
@@ -60,13 +60,23 @@ Core presentation fields:
 
 Provider liveness is read when the profile is requested and is not stored on the profile. Twitch comes from `apps/web/src/lib/server/twitch-live.ts`, VRCDN from `apps/web/src/lib/server/vrcdn-live.ts`; both cache for sixty seconds and render as a `Live now` badge in the `Watch` surface.
 
-- VRCDN publishes no liveness API. `GET https://stream.vrcdn.live/live/<streamId>.m3u8` answers `200` when the origin is publishing and `404` when it is not, and that is the whole signal. `vrcdn.live` is a Blazor SPA that answers `200` with its app shell for unknown paths, so neither the page nor `/api/live` distinguishes anything.
-- Only `200` counts as live. A bodyless `2xx` is an intermediary answering, not VRCDN reporting a stream.
-- A `404` cannot separate "not publishing" from "no such stream", which is why a stream id has to come from an owner-confirmed link rather than from the probe.
+- VRCDN publishes no liveness API. The signal is `GET https://stream.vrcdn.live/live/<streamId>.live.ts`, the transport stream a Quest client pulls. Measured against a real stream on 2026-08-10, live and then idle:
+
+  | Request | Live | Idle | Unknown id |
+  | --- | --- | --- | --- |
+  | `GET .live.ts` | `200` (`video/mp2t`) | `404` | `401` |
+  | `GET .m3u8` | `404` | `404` | `404` |
+  | `HEAD .live.ts` | `200` | `200` | `200` |
+
+- The HLS manifest is **not** a liveness signal, despite being the original mechanism in `#217`. It answers `404` for a stream that is actively publishing, so probing it reported nobody live, ever. That issue's "verified" note covered only the negative leg — an idle stream and a bad id, both `404` for the wrong reason. `HEAD` is not a signal either, since it answers `200` for ids that do not exist. `vrcdn.live` itself is a Blazor SPA that answers `200` with its app shell for unknown paths, so the page and `/api/live` are out too.
+- Only `200` counts as live. A bodyless `2xx` is an intermediary answering, not VRCDN handing over a stream.
+- `401` (unknown id) and `404` (idle) both render as no badge. They are worth keeping apart because this endpoint distinguishes them: a typo in an owner's own link reads `401` forever, where an idle stream reads `404`.
+- The probe cannot tell whose stream an id belongs to — somebody else's id answers `200` while they are streaming — which is why provenance rather than the probe decides whether a claim may be made.
 - Only `owner_authored`, `reviewed`, and `partner_provided` links are probed. `submitCommunityProfile` publishes immediately and a community submission is one signed-in person adding somebody else's profile, so a `community_submitted` stream id could belong to anyone; the link still renders, but it carries no live claim.
 - Three states, not two: `offline` is a real `404`, `unavailable` is a probe that could not finish. A failed probe renders no badge rather than an idle stream.
 - Observations expire after five minutes. The cache serves a stale entry while it refreshes, and a refresh that keeps throwing would otherwise leave a `Live now` claim standing for the length of a provider outage.
-- Nothing sweeps on a schedule. A stream nobody opens is never probed, and the probe cancels the response body without pulling a media segment. VRCDN plans are viewer-capped and whether a manifest request spends a slot is not answerable from outside the operator's account, so the recurring sweep that a `Live now` discovery surface would need should not ship until VRCDN answers that. See `#217`.
+- Nothing sweeps on a schedule. A stream nobody opens is never probed, and an opened one is probed at most once a minute.
+- The probe touches a media endpoint, and this is the known cost of the mechanism. `.live.ts` ignores `Range` and starts pushing MPEG-TS as soon as it answers, so the probe cancels the body before reading a frame — a connection rather than a download. VRCDN plans are viewer-capped and whether that connection spends a slot cannot be determined from outside the operator's account. Shipping it was an explicit owner decision on `#217` with that question still open, not a resolved one. A recurring sweep, which a `Live now` discovery surface would need, multiplies the same unknown across every stream on a timer and still should not ship until VRCDN answers.
 
 State fields:
 

--- a/tests/web/vrcdn-live.test.ts
+++ b/tests/web/vrcdn-live.test.ts
@@ -9,6 +9,8 @@ import {
 } from "../../apps/web/src/lib/vrcdn-live";
 
 describe("VRCDN liveness", () => {
+  // Measured against a real stream on 2026-08-10, live and then idle:
+  //   .live.ts   live -> 200   idle -> 404   unknown id -> 401
   it("reads the media server's answer, and refuses to guess at anything else", () => {
     assert.equal(vrcdnLiveStateFromStatus(200), "live");
     // Not `offline`. The stream is publishing or it is not; a CDN failure is
@@ -17,9 +19,16 @@ describe("VRCDN liveness", () => {
     assert.equal(vrcdnLiveStateFromStatus(404), "offline");
   });
 
+  it("treats an id the media server does not know as nobody streaming", () => {
+    // `401` is what a bogus stream id answers -- a typo in an owner's own link,
+    // say. Distinct from the idle `404` at the endpoint, identical to the
+    // reader: no badge either way.
+    assert.equal(vrcdnLiveStateFromStatus(401), "offline");
+  });
+
   it("does not read a bodyless success as a stream", () => {
-    // A `204` carries no manifest, so it is some intermediary answering rather
-    // than VRCDN reporting that anyone is publishing.
+    // A `204` carries no transport stream, so it is some intermediary answering
+    // rather than VRCDN reporting that anyone is publishing.
     assert.equal(vrcdnLiveStateFromStatus(204), "unavailable");
   });
 


### PR DESCRIPTION
#257 shipped a detector that could never fire. It probed the HLS manifest, which answers `404` for a stream that is actively publishing.

Caught by the owner testing it against their own live stream and reporting no badge.

## What the endpoints actually do

Measured against a real stream on 2026-08-10, live and then idle:

| Request | Live | Idle | Unknown id |
| --- | --- | --- | --- |
| `GET .live.ts` | `200` (`video/mp2t`) | `404` | `401` |
| `GET .m3u8` | `404` | `404` | `404` |
| `HEAD .live.ts` | `200` | `200` | `200` |

## Why the wrong one was verified

`#217` recorded the manifest mechanism as verified on 2026-07-30, against "a known-offline stream and a nonexistent id". Both of those return `404` — so the check confirmed the negative leg twice and never established that anything returns `200`. The positive leg stayed unverified through review and merge; I flagged it as resting on that note rather than on a live test, and shipped anyway. It does not hold.

`HEAD` is not a cheaper substitute: it answers `200` for stream ids that do not exist.

## The change

The probe moves to `.live.ts`. `401` joins `404` as not-live, since both mean nobody is streaming to the reader. They stay separate in the probe because this endpoint distinguishes them where the manifest could not — a typo in an owner's own link reads `401` forever, an idle stream reads `404`.

One claim in the previous docs is now corrected rather than carried: "a `404` cannot separate 'not publishing' from 'no such stream'" was an artifact of testing the wrong endpoint. `.live.ts` separates them.

The provenance filter is unchanged and still necessary — the probe cannot tell *whose* stream an id is, since somebody else's answers `200` while they stream.

## The cost, stated plainly

`.live.ts` is a media endpoint. It ignores `Range` and begins pushing MPEG-TS as soon as it answers, so the probe cancels the body before reading a frame — a connection rather than a download.

The previous design's main defence was that a manifest request plausibly costs nothing. That defence is gone. Whether a brief connection spends one of the operator's viewer slots cannot be determined from outside their account, and VRCDN plans are viewer-capped. Shipping with that open is an explicit owner decision, taken with the tradeoff described; the docs now record it as an open question rather than implying it was settled.

The recurring sweep a `Live now` index would need multiplies the same unknown across every stream on a timer, and still should not ship until VRCDN answers.

## Checks

`pnpm lint:web`, `pnpm typecheck:web`, `pnpm lint:markdown`, and the liveness unit tests (7 passing).

The fixture profile pins `vrcdnLive` directly, so e2e and the visual baselines exercise the badge without touching the network and are unaffected.

Refs #217

🤖 Generated with [Claude Code](https://claude.com/claude-code)
