### PR TITLE
Add dynamic profile share cards

### DIFF
--- a/apps/web/e2e/public-routes.smoke.spec.ts
+++ b/apps/web/e2e/public-routes.smoke.spec.ts
@@ -83,6 +83,39 @@ test("OpenAPI YAML document is served", async ({ page }) => {
   expect(body).toContain("/api/v0/openapi.yaml:");
 });
 
+test("profile links expose Discord-ready metadata and a generated image", async ({ page }, testInfo) => {
+  test.skip(isHostedRun, "The deterministic profile metadata fixture is local-only.");
+
+  await page.goto("/playwright-dj-aurora");
+
+  await expect(page).toHaveTitle("DJ Aurora | VRDex");
+  await expect(page.locator('meta[property="og:title"]')).toHaveAttribute(
+    "content",
+    "DJ Aurora | VRDex",
+  );
+  await expect(page.locator('meta[property="og:description"]')).toHaveAttribute(
+    "content",
+    "Melodic house sets for late-night VRChat floors.",
+  );
+  await expect(page.locator('meta[property="og:url"]')).toHaveAttribute(
+    "content",
+    /\/playwright-dj-aurora$/,
+  );
+
+  const imageUrl = await page.locator('meta[property="og:image"]').getAttribute("content");
+  expect(imageUrl).not.toBeNull();
+
+  const imageResponse = await page.request.get(imageUrl!);
+  expect(imageResponse.ok()).toBe(true);
+  expect(imageResponse.headers()["content-type"]).toContain("image/png");
+  const imageBody = await imageResponse.body();
+  expect(imageBody.byteLength).toBeGreaterThan(1_000);
+  await testInfo.attach("profile-open-graph-image", {
+    body: imageBody,
+    contentType: "image/png",
+  });
+});
+
 test("public API supports browser CORS and preflight", async ({ page }) => {
   const origin = "https://developer.example.test";
   const response = await page.request.get("/api/v0/openapi.json", {

--- a/apps/web/src/app/[slug]/opengraph-image.tsx
+++ b/apps/web/src/app/[slug]/opengraph-image.tsx
@@ -1,0 +1,61 @@
+import { ImageResponse } from "next/og";
+
+import type { PublicProfileShareCard } from "../../../../../convex/_profileShareCard";
+import { EntityShareCardImage, entityShareImageSize } from "../_components/entity-share-card-image";
+import { fetchPublicProfileShareCardBySlug } from "@/convex/server";
+import { absolutePublicUrl, publicSiteUrl } from "@/lib/public-site-url";
+
+export const alt = "VRDex profile";
+export const size = entityShareImageSize;
+export const contentType = "image/png";
+
+type EntityShareImageProps = {
+  params: Promise<{ slug: string }>;
+};
+
+const supportedImageTypes = new Set(["image/jpeg", "image/png", "image/svg+xml", "image/webp"]);
+
+async function inlineManagedImage(imageUrl: string | undefined): Promise<string | undefined> {
+  if (!imageUrl) return undefined;
+
+  const absoluteUrl = absolutePublicUrl(imageUrl);
+  if (new URL(absoluteUrl).origin !== new URL(publicSiteUrl()).origin) return undefined;
+
+  try {
+    const response = await fetch(absoluteUrl, { cache: "force-cache" });
+    const contentType = response.headers.get("content-type")?.split(";", 1)[0];
+    if (!response.ok || !contentType || !supportedImageTypes.has(contentType)) return undefined;
+
+    const body = await response.arrayBuffer();
+    if (body.byteLength > 5_000_000) return undefined;
+
+    return `data:${contentType};base64,${Buffer.from(body).toString("base64")}`;
+  } catch {
+    return undefined;
+  }
+}
+
+async function withInlineManagedImages(
+  profile: PublicProfileShareCard | null,
+): Promise<PublicProfileShareCard | null> {
+  if (!profile) return null;
+
+  const [avatarImageUrl, bannerImageUrl] = await Promise.all([
+    inlineManagedImage(profile.avatarImageUrl),
+    inlineManagedImage(profile.bannerImageUrl),
+  ]);
+
+  return {
+    ...profile,
+    avatarImageUrl,
+    bannerImageUrl,
+  };
+}
+
+export default async function EntityShareImage({ params }: EntityShareImageProps) {
+  const { slug } = await params;
+  const result = await fetchPublicProfileShareCardBySlug(slug);
+  const profile = await withInlineManagedImages(result.kind === "live" ? result.profile : null);
+
+  return new ImageResponse(<EntityShareCardImage profile={profile} />, size);
+}

--- a/apps/web/src/app/[slug]/page.tsx
+++ b/apps/web/src/app/[slug]/page.tsx
@@ -1,3 +1,4 @@
+import type { Metadata } from "next";
 import { notFound } from "next/navigation";
 
 import { validateSlugFormat } from "../../../../../convex/_globalSlugs";
@@ -5,7 +6,8 @@ import { EntityBackendNotice } from "./entity-backend-notice";
 import { EventPublicPage } from "../_components/event-public-page";
 import { ProfilePublicPage } from "../_components/profile-public-page";
 import { WorldPublicPage } from "../_components/world-public-page";
-import { fetchPublicEntityBySlug } from "@/convex/server";
+import { fetchPublicEntityBySlug, fetchPublicProfileShareCardBySlug } from "@/convex/server";
+import { profileShareMetadata } from "@/lib/profile-share-card";
 
 export const dynamic = "force-dynamic";
 
@@ -14,6 +16,20 @@ type EntityPageProps = {
     slug: string;
   }>;
 };
+
+export async function generateMetadata({ params }: EntityPageProps): Promise<Metadata> {
+  const { slug } = await params;
+
+  if (!validateSlugFormat(slug).ok) {
+    return {};
+  }
+
+  const result = await fetchPublicProfileShareCardBySlug(slug);
+
+  return result.kind === "live" && result.profile !== null
+    ? profileShareMetadata(result.profile)
+    : {};
+}
 
 // Profiles, worlds, and events are all first-class root links -- vrdex.net/basicbit --
 // so they share one slug namespace and one route. Static segments win over this

--- a/apps/web/src/app/_components/entity-share-card-image.tsx
+++ b/apps/web/src/app/_components/entity-share-card-image.tsx
@@ -1,0 +1,155 @@
+import type { PublicProfileShareCard } from "../../../../../convex/_profileShareCard";
+import { absolutePublicUrl } from "@/lib/public-site-url";
+import { profileInitials, profileShareDescription } from "@/lib/profile-share-card";
+
+export const entityShareImageSize = { width: 1200, height: 630 } as const;
+
+function profileNameFontSize(displayName: string): number {
+  if (displayName.length > 34) return 56;
+  if (displayName.length > 22) return 66;
+  return 76;
+}
+
+export function EntityShareCardImage({ profile }: { profile: PublicProfileShareCard | null }) {
+  const displayName = profile?.displayName ?? "VRDex";
+  const summary = profile ? profileShareDescription(profile) : undefined;
+  const avatarImageUrl = profile?.avatarImageUrl
+    ? absolutePublicUrl(profile.avatarImageUrl)
+    : undefined;
+  const bannerImageUrl = profile?.bannerImageUrl
+    ? absolutePublicUrl(profile.bannerImageUrl)
+    : undefined;
+  const avatarObjectFit = profile?.avatarImageKind === "logo" ? "contain" : "cover";
+
+  return (
+    <div
+      style={{
+        alignItems: "stretch",
+        background: "#08090d",
+        color: "#f5f7fb",
+        display: "flex",
+        height: "100%",
+        overflow: "hidden",
+        position: "relative",
+        width: "100%",
+      }}
+    >
+      {bannerImageUrl ? (
+        // `next/image` is not available inside a generated `ImageResponse` tree.
+        // eslint-disable-next-line @next/next/no-img-element
+        <img
+          alt=""
+          height={630}
+          src={bannerImageUrl}
+          style={{ height: "100%", objectFit: "cover", opacity: 0.36, position: "absolute", width: "100%" }}
+          width={1200}
+        />
+      ) : null}
+      <div
+        style={{
+          background: bannerImageUrl
+            ? "linear-gradient(90deg, rgba(8,9,13,0.98) 0%, rgba(8,9,13,0.88) 48%, rgba(8,9,13,0.42) 100%)"
+            : "radial-gradient(circle at 82% 18%, rgba(142,216,255,0.19), transparent 34%), linear-gradient(145deg, #08090d 0%, #0f1722 100%)",
+          display: "flex",
+          height: "100%",
+          position: "absolute",
+          width: "100%",
+        }}
+      />
+      <div
+        style={{
+          alignItems: "stretch",
+          display: "flex",
+          flexDirection: "column",
+          justifyContent: "space-between",
+          padding: "60px 68px 64px",
+          position: "relative",
+          width: "100%",
+        }}
+      >
+        <div style={{ alignItems: "center", display: "flex", fontSize: 25, fontWeight: 700, letterSpacing: "0.18em" }}>
+          <span style={{ color: "#8ed8ff", display: "flex" }}>VR</span>
+          <span style={{ display: "flex" }}>DEX</span>
+        </div>
+        <div style={{ alignItems: "center", display: "flex", gap: 42, maxWidth: 1030 }}>
+          {avatarImageUrl ? (
+            <div
+              style={{
+                alignItems: "center",
+                background: profile?.avatarImageKind === "logo" ? "rgba(245,247,251,0.06)" : "#151b24",
+                border: "2px solid rgba(245,247,251,0.24)",
+                borderRadius: 28,
+                display: "flex",
+                flex: "0 0 184px",
+                height: 184,
+                justifyContent: "center",
+                overflow: "hidden",
+                padding: profile?.avatarImageKind === "logo" ? 18 : 0,
+                width: 184,
+              }}
+            >
+              {/* `next/image` is not available inside a generated `ImageResponse` tree. */}
+              {/* eslint-disable-next-line @next/next/no-img-element */}
+              <img
+                alt=""
+                height={184}
+                src={avatarImageUrl}
+                style={{ height: "100%", objectFit: avatarObjectFit, width: "100%" }}
+                width={184}
+              />
+            </div>
+          ) : (
+            <div
+              style={{
+                alignItems: "center",
+                background: "rgba(142,216,255,0.12)",
+                border: "2px solid rgba(142,216,255,0.32)",
+                borderRadius: 28,
+                color: "#c7ecff",
+                display: "flex",
+                flex: "0 0 184px",
+                fontSize: 58,
+                fontWeight: 700,
+                height: 184,
+                justifyContent: "center",
+                letterSpacing: "-0.04em",
+                width: 184,
+              }}
+            >
+              {profileInitials(displayName)}
+            </div>
+          )}
+          <div style={{ alignItems: "flex-start", display: "flex", flexDirection: "column", minWidth: 0 }}>
+            <div
+              style={{
+                display: "flex",
+                fontSize: profileNameFontSize(displayName),
+                fontWeight: 650,
+                letterSpacing: "-0.045em",
+                lineHeight: 1.02,
+                maxWidth: 780,
+              }}
+            >
+              {displayName}
+            </div>
+            {summary ? (
+              <div
+                style={{
+                  color: "#b9c2cf",
+                  display: "flex",
+                  fontSize: 28,
+                  lineHeight: 1.32,
+                  marginTop: 22,
+                  maxWidth: 760,
+                }}
+              >
+                {summary}
+              </div>
+            ) : null}
+          </div>
+        </div>
+        <div style={{ background: "#8ed8ff", display: "flex", height: 4, width: 76 }} />
+      </div>
+    </div>
+  );
+}

--- a/apps/web/src/app/_components/entity-share-card-image.tsx
+++ b/apps/web/src/app/_components/entity-share-card-image.tsx
@@ -49,7 +49,7 @@ export function EntityShareCardImage({ profile }: { profile: PublicProfileShareC
         style={{
           background: bannerImageUrl
             ? "linear-gradient(90deg, rgba(8,9,13,0.98) 0%, rgba(8,9,13,0.88) 48%, rgba(8,9,13,0.42) 100%)"
-            : "radial-gradient(circle at 82% 18%, rgba(142,216,255,0.19), transparent 34%), linear-gradient(145deg, #08090d 0%, #0f1722 100%)",
+            : "#08090d",
           display: "flex",
           height: "100%",
           position: "absolute",

--- a/apps/web/src/app/layout.tsx
+++ b/apps/web/src/app/layout.tsx
@@ -4,6 +4,7 @@ import { IBM_Plex_Mono, Space_Grotesk } from "next/font/google";
 import { ConvexClientProvider } from "./ConvexClientProvider";
 import { PostHogProvider } from "./PostHogProvider";
 import { SiteFooter } from "@/components/ui/site-footer";
+import { publicSiteUrl } from "@/lib/public-site-url";
 import "./globals.css";
 
 const spaceGrotesk = Space_Grotesk({
@@ -18,6 +19,7 @@ const ibmPlexMono = IBM_Plex_Mono({
 });
 
 export const metadata: Metadata = {
+  metadataBase: publicSiteUrl(),
   title: "VRDex",
   description: "A VRChat-first identity, profile, and events platform.",
 };

--- a/apps/web/src/convex/server.ts
+++ b/apps/web/src/convex/server.ts
@@ -18,6 +18,7 @@ import {
   searchPlaywrightDiscoveryFixture,
 } from "./playwright-fixtures";
 import { profileClaimPath } from "@/lib/profile-claim";
+import type { PublicProfileShareCard } from "../../../../convex/_profileShareCard";
 
 const seedAccessApi = (api as unknown as {
   seedAccess: {
@@ -85,6 +86,61 @@ export async function fetchPublicProfileBySlug(slug: string, profileType?: Publi
     return {
       kind: "error" as const,
     };
+  }
+}
+
+function fixtureProfileShareCard(slug: string): PublicProfileShareCard | null {
+  const profile =
+    getPlaywrightPublicProfileFixture(slug, "person") ??
+    getPlaywrightPublicProfileFixture(slug, "community");
+
+  if (profile === null) {
+    return null;
+  }
+
+  const profileImage = profile.mediaKit?.profileImage;
+  const logoImage = profile.mediaKit?.primaryLogo;
+  const prefersLogo = profile.mediaKit?.compactDisplay === "logo";
+  const avatarImageUrl = prefersLogo
+    ? logoImage?.imageUrl ?? profileImage?.imageUrl ?? profile.avatarImageUrl
+    : profileImage?.imageUrl ?? profile.avatarImageUrl ?? logoImage?.imageUrl;
+  const avatarImageKind = avatarImageUrl === undefined
+    ? undefined
+    : avatarImageUrl === logoImage?.imageUrl && logoImage?.imageUrl !== profileImage?.imageUrl
+      ? "logo" as const
+      : "profile" as const;
+
+  return {
+    profileType: profile.profileType,
+    slug: profile.slug,
+    displayName: profile.displayName,
+    ...((profile.headline ?? profile.bio) ? { summary: profile.headline ?? profile.bio } : {}),
+    ...(avatarImageUrl ? { avatarImageUrl } : {}),
+    ...(avatarImageKind ? { avatarImageKind } : {}),
+    ...(profile.mediaKit?.banner?.imageUrl || profile.bannerImageUrl
+      ? { bannerImageUrl: profile.mediaKit?.banner?.imageUrl ?? profile.bannerImageUrl }
+      : {}),
+  };
+}
+
+export async function fetchPublicProfileShareCardBySlug(slug: string) {
+  const fixtureProfile = fixtureProfileShareCard(slug);
+
+  if (fixtureProfile !== null) {
+    return { kind: "live" as const, profile: fixtureProfile };
+  }
+
+  if (!process.env.NEXT_PUBLIC_CONVEX_URL) {
+    return { kind: "missing-url" as const, profile: null };
+  }
+
+  try {
+    const profile = await fetchQuery(api.profiles.getPublicShareCardBySlug, { slug });
+    return { kind: "live" as const, profile };
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    console.error(`Server-side Convex profile share-card fetch failed: ${message}`);
+    return { kind: "error" as const, profile: null };
   }
 }
 

--- a/apps/web/src/lib/profile-share-card.ts
+++ b/apps/web/src/lib/profile-share-card.ts
@@ -1,0 +1,59 @@
+import type { Metadata } from "next";
+
+import type { PublicProfileShareCard } from "../../../../convex/_profileShareCard";
+
+export const DEFAULT_SHARE_DESCRIPTION = "A VRChat-first identity, profile, and events platform.";
+
+function compactText(value: string | undefined, maximumLength: number): string | undefined {
+  const compact = value?.trim().replace(/\s+/g, " ");
+
+  if (!compact) {
+    return undefined;
+  }
+
+  if (compact.length <= maximumLength) {
+    return compact;
+  }
+
+  return `${compact.slice(0, maximumLength - 1).trimEnd()}…`;
+}
+
+export function profileShareDescription(card: Pick<PublicProfileShareCard, "summary">): string {
+  return compactText(card.summary, 200) ?? DEFAULT_SHARE_DESCRIPTION;
+}
+
+export function profileShareMetadata(card: PublicProfileShareCard): Metadata {
+  const title = `${card.displayName} | VRDex`;
+  const description = profileShareDescription(card);
+  const path = `/${encodeURIComponent(card.slug)}`;
+
+  return {
+    title,
+    description,
+    alternates: { canonical: path },
+    openGraph: {
+      type: "website",
+      siteName: "VRDex",
+      url: path,
+      title,
+      description,
+    },
+    twitter: {
+      card: "summary_large_image",
+      title,
+      description,
+    },
+  };
+}
+
+export function profileInitials(displayName: string): string {
+  const initials = displayName
+    .trim()
+    .split(/\s+/)
+    .filter(Boolean)
+    .slice(0, 2)
+    .map((part) => part[0]?.toUpperCase())
+    .join("");
+
+  return initials || "VR";
+}

--- a/apps/web/src/lib/public-site-url.ts
+++ b/apps/web/src/lib/public-site-url.ts
@@ -1,0 +1,41 @@
+const PRODUCTION_SITE_URL = "https://vrdex.net";
+const LOCAL_SITE_URL = "http://127.0.0.1:3000";
+
+function parsedHttpUrl(value: string | undefined): URL | null {
+  if (!value?.trim()) {
+    return null;
+  }
+
+  try {
+    const url = new URL(value);
+    return url.protocol === "http:" || url.protocol === "https:" ? url : null;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Absolute metadata URLs must follow the deployment being previewed. Production
+ * stays on the canonical host; Vercel previews and local Playwright runs keep
+ * their generated share image on the same deployment as the page data.
+ */
+export function publicSiteUrl(): URL {
+  if (process.env.VERCEL_ENV === "production") {
+    return new URL(PRODUCTION_SITE_URL);
+  }
+
+  const vercelUrl = process.env.VERCEL_URL?.trim();
+  if (vercelUrl) {
+    return new URL(`https://${vercelUrl.replace(/^https?:\/\//, "")}`);
+  }
+
+  return (
+    parsedHttpUrl(process.env.PLAYWRIGHT_BASE_URL) ??
+    parsedHttpUrl(process.env.SITE_URL) ??
+    new URL(LOCAL_SITE_URL)
+  );
+}
+
+export function absolutePublicUrl(pathOrUrl: string): string {
+  return new URL(pathOrUrl, publicSiteUrl()).href;
+}

--- a/convex/_generated/api.d.ts
+++ b/convex/_generated/api.d.ts
@@ -51,6 +51,7 @@ import type * as _profileOwnership from "../_profileOwnership.js";
 import type * as _profilePermissions from "../_profilePermissions.js";
 import type * as _profilePrivacy from "../_profilePrivacy.js";
 import type * as _profilePublic from "../_profilePublic.js";
+import type * as _profileShareCard from "../_profileShareCard.js";
 import type * as _profileSlugs from "../_profileSlugs.js";
 import type * as _profileStates from "../_profileStates.js";
 import type * as _profileSubmissions from "../_profileSubmissions.js";
@@ -168,6 +169,7 @@ declare const fullApi: ApiFromModules<{
   _profilePermissions: typeof _profilePermissions;
   _profilePrivacy: typeof _profilePrivacy;
   _profilePublic: typeof _profilePublic;
+  _profileShareCard: typeof _profileShareCard;
   _profileSlugs: typeof _profileSlugs;
   _profileStates: typeof _profileStates;
   _profileSubmissions: typeof _profileSubmissions;

--- a/convex/_profileShareCard.ts
+++ b/convex/_profileShareCard.ts
@@ -1,0 +1,70 @@
+import type { Doc } from "./_generated/dataModel";
+import type { PublicProfileMediaKit } from "./_profileAssets";
+import { visibleProfileField } from "./_profileFieldVisibility";
+import { safeHttpsUrl } from "./_publicFields";
+
+export type PublicProfileShareCard = {
+  profileType: "person" | "community";
+  slug: string;
+  displayName: string;
+  summary?: string;
+  avatarImageUrl?: string;
+  avatarImageKind?: "profile" | "logo";
+  bannerImageUrl?: string;
+};
+
+function visibleLegacyImage(
+  profile: Doc<"profiles">,
+  key: "avatarImageUrl" | "bannerImageUrl",
+): string | undefined {
+  return safeHttpsUrl(visibleProfileField(profile, key, profile[key], "discovery"));
+}
+
+/**
+ * The intentionally small projection used outside the profile page itself.
+ *
+ * A Discord unfurl is a public card, not the direct profile page. `unlisted`
+ * fields therefore stay out just as they do in search and discovery, while the
+ * globally public identity fields remain available. Managed media placements
+ * follow the same avatar/banner visibility controls as their legacy URL
+ * counterparts.
+ */
+export function toPublicProfileShareCard(
+  profile: Doc<"profiles">,
+  mediaKit: PublicProfileMediaKit,
+): PublicProfileShareCard {
+  const headline = visibleProfileField(profile, "headline", profile.headline, "discovery");
+  const bio = visibleProfileField(profile, "bio", profile.bio, "discovery");
+  const profileImage = visibleProfileField(
+    profile,
+    "avatarImageUrl",
+    mediaKit.profileImage?.imageUrl ?? visibleLegacyImage(profile, "avatarImageUrl"),
+    "discovery",
+  );
+  const bannerImage = visibleProfileField(
+    profile,
+    "bannerImageUrl",
+    mediaKit.banner?.imageUrl ?? visibleLegacyImage(profile, "bannerImageUrl"),
+    "discovery",
+  );
+  const logoImage = mediaKit.primaryLogo?.imageUrl;
+  const prefersLogo = mediaKit.compactDisplay === "logo";
+  const avatarImageUrl = prefersLogo
+    ? logoImage ?? profileImage
+    : profileImage ?? logoImage;
+  const avatarImageKind = avatarImageUrl === undefined
+    ? undefined
+    : avatarImageUrl === logoImage && logoImage !== profileImage
+      ? "logo" as const
+      : "profile" as const;
+
+  return {
+    profileType: profile.profileType,
+    slug: profile.slug,
+    displayName: profile.displayName,
+    ...((headline ?? bio) ? { summary: headline ?? bio } : {}),
+    ...(avatarImageUrl ? { avatarImageUrl } : {}),
+    ...(avatarImageKind ? { avatarImageKind } : {}),
+    ...(bannerImage ? { bannerImageUrl: bannerImage } : {}),
+  };
+}

--- a/convex/profiles.ts
+++ b/convex/profiles.ts
@@ -38,6 +38,7 @@ import {
 } from "./_profilePermissions";
 import { profileLinkInputValidator } from "./_profileLinks";
 import { toPublicProfile } from "./_profilePublic";
+import { toPublicProfileShareCard } from "./_profileShareCard";
 import {
   createProfileSlugBase,
   findAvailableProfileSlug,
@@ -483,6 +484,30 @@ export const getPublicBySlug = query({
       ...eventContext,
       ...(telemetry ? { telemetry } : {}),
     };
+  },
+});
+
+export const getPublicShareCardBySlug = query({
+  args: {
+    slug: v.string(),
+  },
+  handler: async (ctx, args) => {
+    const validation = validateProfileSlug(args.slug);
+
+    if (!validation.ok) {
+      return null;
+    }
+
+    const profile = await getProfileBySlug(ctx.db, validation.slug);
+
+    if (profile === null || !canReadProfile("public", profile)) {
+      return null;
+    }
+
+    return toPublicProfileShareCard(
+      profile,
+      await getPublicProfileMediaKit(ctx.db, profile),
+    );
   },
 });
 

--- a/docs/backend/profile-schema.md
+++ b/docs/backend/profile-schema.md
@@ -326,6 +326,12 @@ Current recommendation:
 
 `displayName`, `slug`, `profileType`, and trust labels remain public while the profile itself is public.
 
+Profile link previews use a separate card projection at the canonical `/<slug>` route. The projection keeps
+the public display name, prefers the public headline over the public bio, and may use managed profile or
+banner media. Because an unfurl is a card surface rather than the direct profile page, fields marked
+`unlisted` or `private` do not enter its summary or controlled profile/banner image slots. A public primary
+logo may still act as the compact fallback because logo assets do not use the avatar visibility field.
+
 The owner privacy mutation currently accepts these field keys: `aliases`, `tags`, `genres`, `headline`, `bio`, `about`, `avatarImageUrl`, `bannerImageUrl`, `outboundLinks`, `region`, `timezone`, `personPronouns`, `personRoleTags`, `communitySubtype`, and `communityCategoryTags`.
 
 ## Mutation Contracts

--- a/tests/backend/profile-foundation.test.ts
+++ b/tests/backend/profile-foundation.test.ts
@@ -43,6 +43,7 @@ import {
 } from "../../convex/_profileSlugs";
 import { canEditProfileField, canReadProfile } from "../../convex/_profilePermissions";
 import { toPublicProfile } from "../../convex/_profilePublic";
+import { toPublicProfileShareCard } from "../../convex/_profileShareCard";
 import {
   createProfileSortName,
   PROFILE_ALIAS_MAX_COUNT,
@@ -1802,6 +1803,107 @@ describe("API profile update helpers", () => {
 });
 
 describe("public profile projection", () => {
+  it("uses only discovery-visible profile fields in share cards", () => {
+    const profile = {
+      profileType: "person",
+      slug: "dj-card",
+      displayName: "DJ Card",
+      sortName: "dj card",
+      aliases: [],
+      tags: [],
+      headline: "Unlisted headline",
+      bio: "Public bio",
+      avatarImageUrl: "https://legacy.example.invalid/avatar.png",
+      bannerImageUrl: "https://legacy.example.invalid/banner.png",
+      outboundLinks: [],
+      claimState: "claimed_unverified",
+      publicationState: "published",
+      publicSurfacingState: "public",
+      creationSource: "self",
+      publishedAt: 1,
+      updatedAt: 1,
+      fieldVisibility: {
+        headline: "unlisted",
+        avatarImageUrl: "private",
+        bannerImageUrl: "unlisted",
+      },
+      person: { roleTags: [] },
+    } as Doc<"profiles">;
+    const mediaKit = {
+      profileImage: { imageUrl: "/api/profile-image" },
+      banner: { imageUrl: "/api/banner-image" },
+      primaryLogo: { imageUrl: "/api/primary-logo" },
+      additionalLogos: [],
+      logos: [],
+      assets: [],
+      galleryAssets: [],
+      compactDisplay: "profile_image",
+      avatarAppearance: {
+        borderEnabled: true,
+        borderColor: "#ffffff",
+        borderWidthPx: 3,
+        borderSoftnessPx: 0,
+        radiusPercent: 18,
+      },
+    } as unknown as Awaited<ReturnType<typeof getPublicProfileMediaKit>>;
+
+    assert.deepEqual(toPublicProfileShareCard(profile, mediaKit), {
+      profileType: "person",
+      slug: "dj-card",
+      displayName: "DJ Card",
+      summary: "Public bio",
+      avatarImageUrl: "/api/primary-logo",
+      avatarImageKind: "logo",
+    });
+  });
+
+  it("prefers public managed profile media and headline in share cards", () => {
+    const profile = {
+      profileType: "community",
+      slug: "night-shift",
+      displayName: "Night Shift",
+      sortName: "night shift",
+      aliases: [],
+      tags: [],
+      headline: "Late-night VRChat events.",
+      bio: "Longer profile biography.",
+      outboundLinks: [],
+      claimState: "claimed_verified",
+      publicationState: "published",
+      publicSurfacingState: "public",
+      creationSource: "self",
+      publishedAt: 1,
+      updatedAt: 1,
+      community: { categoryTags: [] },
+    } as Doc<"profiles">;
+    const mediaKit = {
+      profileImage: { imageUrl: "/api/profile-image" },
+      banner: { imageUrl: "/api/banner-image" },
+      additionalLogos: [],
+      logos: [],
+      assets: [],
+      galleryAssets: [],
+      compactDisplay: "profile_image",
+      avatarAppearance: {
+        borderEnabled: true,
+        borderColor: "#ffffff",
+        borderWidthPx: 3,
+        borderSoftnessPx: 0,
+        radiusPercent: 18,
+      },
+    } as unknown as Awaited<ReturnType<typeof getPublicProfileMediaKit>>;
+
+    assert.deepEqual(toPublicProfileShareCard(profile, mediaKit), {
+      profileType: "community",
+      slug: "night-shift",
+      displayName: "Night Shift",
+      summary: "Late-night VRChat events.",
+      avatarImageUrl: "/api/profile-image",
+      avatarImageKind: "profile",
+      bannerImageUrl: "/api/banner-image",
+    });
+  });
+
   it("omits source attribution identifiers from public profile results", () => {
     const profile = {
       profileType: "person",

--- a/tests/web/profile-share-card.test.ts
+++ b/tests/web/profile-share-card.test.ts
@@ -1,0 +1,42 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+
+import {
+  DEFAULT_SHARE_DESCRIPTION,
+  profileInitials,
+  profileShareDescription,
+  profileShareMetadata,
+} from "../../apps/web/src/lib/profile-share-card";
+
+describe("profile share metadata", () => {
+  it("uses the canonical root slug and approved profile title format", () => {
+    const metadata = profileShareMetadata({
+      profileType: "person",
+      slug: "dj-aurora",
+      displayName: "DJ Aurora",
+      summary: "Melodic house sets for late-night VRChat floors.",
+    });
+
+    assert.equal(metadata.title, "DJ Aurora | VRDex");
+    assert.equal(metadata.description, "Melodic house sets for late-night VRChat floors.");
+    assert.equal(metadata.alternates?.canonical, "/dj-aurora");
+    assert.equal(metadata.openGraph?.url, "/dj-aurora");
+    assert.equal(metadata.openGraph?.title, "DJ Aurora | VRDex");
+    assert.equal(metadata.twitter?.card, "summary_large_image");
+  });
+
+  it("falls back to existing VRDex copy and bounds long summaries", () => {
+    assert.equal(profileShareDescription({}), DEFAULT_SHARE_DESCRIPTION);
+
+    const description = profileShareDescription({ summary: `  ${"word ".repeat(60)}  ` });
+    assert.equal(description.length, 200);
+    assert.equal(description.endsWith("…"), true);
+    assert.equal(description.includes("  "), false);
+  });
+
+  it("builds restrained initials when no public image is available", () => {
+    assert.equal(profileInitials("DJ Aurora"), "DA");
+    assert.equal(profileInitials("BASICBIT"), "B");
+    assert.equal(profileInitials("   "), "VR");
+  });
+});


### PR DESCRIPTION
[AGENT] Adds privacy-aware Open Graph and Twitter metadata plus generated 1200x630 share art for canonical /{slug} profile pages. Unlisted and private fields stay out of previews, while supported managed public media is rendered into the card. Includes projection, unit, end-to-end coverage, and profile schema documentation.